### PR TITLE
Use dpkg-query -s to query for packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ dependencies() {
                 DEPS="{glibc-devel.i686,libstdc++-devel.i686,libX11-devel.i686}"
                 install
             ;;
-            *"buntu"|"Linux Mint"|"Debian")
+            *"buntu"|"Linux Mint"|"Debian"|"Zorin OS")
                 MANAGER_QUERY="dpkg-query -s"
                 MANAGER_INSTALL="apt install"
                 DEPS="{gcc,g++,gcc-multilib,g++-multilib,ninja-build,python3-pip,python3-setuptools,python3-wheel,pkg-config,mesa-common-dev,libx11-dev:i386}"

--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ dependencies() {
                 install
             ;;
             *"buntu"|"Linux Mint"|"Debian")
-                MANAGER_QUERY="dpkg-query -l"
+                MANAGER_QUERY="dpkg-query -s"
                 MANAGER_INSTALL="apt install"
                 DEPS="{gcc,g++,gcc-multilib,g++-multilib,ninja-build,python3-pip,python3-setuptools,python3-wheel,pkg-config,mesa-common-dev,libx11-dev:i386}"
                 install


### PR DESCRIPTION
By own experience, `dpkg-query -l` doesn't always return 1 if a package isn't installed.

`dpkg-query -s` seems more reliable. Source:

https://github.com/bitrise-io/bitrise/issues/433