### PR TITLE
Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ This will build and copy `libMangoHud.so` & `libMangoHud32.so` to `$HOME/.local/
 
 If you are running an Ubuntu-like distrobution, Fedora, or Arch, the build script will automatically detect and prompt you to install missing build dependencies. If you run in to any issues with this please report them!
 
+## Packaging status
+
+[Fedora](https://src.fedoraproject.org/rpms/mangohud): `sudo dnf install mangohud`
+
 # Normal usage
 
 To enable the MangoHud Vulkan overlay layer, run :


### PR DESCRIPTION
_MangoHud_ packaged for Fedora and available in official repos now. Please add installation instructions into Readme file.

Also please hold a little bit this PR until status in Bodhi will been changed from `Pending -> Stable` to `Stable`.

Thank you for such awesome app/tool.