### PR TITLE
Supporting setting up dependencies in elementary OS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,7 +59,7 @@ dependencies() {
                 DEPS="{glibc-devel.i686,libstdc++-devel.i686,libX11-devel.i686}"
                 install
             ;;
-            *"buntu"|"Linux Mint"|"Debian"|"Zorin OS"|"Pop!_OS")
+            *"buntu"|"Linux Mint"|"Debian"|"Zorin OS"|"Pop!_OS"|"elementary OS")
                 MANAGER_QUERY="dpkg-query -s"
                 MANAGER_INSTALL="apt install"
                 DEPS="{gcc,g++,gcc-multilib,g++-multilib,ninja-build,python3-pip,python3-setuptools,python3-wheel,pkg-config,mesa-common-dev,libx11-dev:i386}"


### PR DESCRIPTION
Add elementary OS to list of Debian-family operating systems. Tested on 5.1 Hera. Fixes https://github.com/flightlessmango/MangoHud/issues/56