### PR TITLE
build.sh: Show usage help when no arguments are passed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -181,7 +181,7 @@ usage() {
     if test -z $1; then
         echo "Unrecognized command argument: $a"
     else
-        echo "$0 requires at least one argument"
+        echo "$0 requires one argument"
     fi
     echo 'Accepted arguments: "pull", "configure", "build", "package", "install", "clean", "uninstall".'
 }
@@ -202,7 +202,7 @@ for a in $@; do
     esac
 done
 
-if test -z $@; then
+if [[ -z $@ ]]; then
     usage no-args
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -177,6 +177,15 @@ uninstall() {
     rm -fv "/usr/bin/mangohud.x86"
 }
 
+usage() {
+    if test -z $1; then
+        echo "Unrecognized command argument: $a"
+    else
+        echo "$0 requires at least one argument"
+    fi
+    echo 'Accepted arguments: "pull", "configure", "build", "package", "install", "clean", "uninstall".'
+}
+
 for a in $@; do
     case $a in
         "") build;;
@@ -189,7 +198,11 @@ for a in $@; do
         "uninstall") uninstall;;
         "release") release;;
         *)
-            echo "Unrecognized command argument: $a"
-            echo 'Accepted arguments: "pull", "configure", "build", "package", "install", "clean", "uninstall".'
+            usage
     esac
 done
+
+if test -z $@; then
+    usage no-args
+fi
+


### PR DESCRIPTION
Previously build.sh would do nothing if no arguments were passed. This patch changes this behaviour to instead make it show the usage help that is printed if an invalid argument is passed, along with a modified reason message. 