### PR TITLE
Correct Fedora package names

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ dependencies() {
             "Fedora")
                 MANAGER_QUERY="dnf list installed"
                 MANAGER_INSTALL="dnf install"
-                DEPS="{meson,gcc,gcc-g++,libX11-devel,glslang,python3-mako,mesa-libGL-devel}"
+                DEPS="{meson,gcc,gcc-c++,libX11-devel,glslang,python3-mako,mesa-libGL-devel}"
                 install
 
                 unset INSTALL

--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ dependencies() {
             "Fedora")
                 MANAGER_QUERY="dnf list installed"
                 MANAGER_INSTALL="dnf install"
-                DEPS="{meson,gcc,g++,libX11-devel,glslang,python-mako,mesa-libGL-devel}"
+                DEPS="{meson,gcc,gcc-g++,libX11-devel,glslang,python3-mako,mesa-libGL-devel}"
                 install
 
                 unset INSTALL


### PR DESCRIPTION
This patch corrects some package names in Fedora. dnf lets you install gcc-c++ and python3-mako packages via the "aliases" g++ and python-mako, but the packages do not appear with such names in `dnf list installed`. This patch makes them use their proper names so that during dependency checking these packages don't always appear as uninstalled. Tested on Fedora 31.