### PR TITLE
Add Flatpak usage notes to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,15 @@ sudo dnf install mangohud
 
 #### Flatpak
 
-If you are using Flatpaks, you will have to add the [FlatHub repository](https://flatpak.org/setup/) for your specific distribution, and then, to install it, execute:
+If you are using Flatpaks, you will have to add the [Flathub repository](https://flatpak.org/setup/) for your specific distribution, and then, to install it, execute:
 
+##### For Steam flatpak
 ```
 flatpak install com.valvesoftware.Steam.VulkanLayer.MangoHud
+```
+To enable MangoHud for all Steam games:
+```
+flatpak override --user --env=MANGOHUD=1 com.valvesoftware.Steam
 ```
 
 # Normal usage


### PR DESCRIPTION
Currently, MangoHud flatpak is available only for Steam flatpak - readme should reflect that.
Also flatpak allows user to set an environment variable per-app, which may be useful in MangoHud's case, so add a note about it.