### PR TITLE
Fix gcc-c++-32bit being misspelt as gcc-c++-31bit in OpenSUSE section

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ dependencies() {
             "openSUSE Leap"|"openSUSE Tumbleweed")
                 MANAGER_QUERY="zypper search"
                 MANAGER_INSTALL="zypper install"
-                DEPS="{gcc-c++,gcc-c++-31bit,meson,libpkgconf-devel,python3-Mako,libX11-devel,libX11-devel-32bit,glslang-devel,libglvnd-devel,libglvnd-devel-32bit,glibc-devel,glibc-devel-32bit,libstdc++-devel,libstdc++-devel-32bit,Mesa-libGL-devel}"
+                DEPS="{gcc-c++,gcc-c++-32bit,meson,libpkgconf-devel,python3-Mako,libX11-devel,libX11-devel-32bit,glslang-devel,libglvnd-devel,libglvnd-devel-32bit,glibc-devel,glibc-devel-32bit,libstdc++-devel,libstdc++-devel-32bit,Mesa-libGL-devel}"
                 install
             ;;
             "Solus")


### PR DESCRIPTION
Typo in package name. 

While this might be obvious, should there be any doubt I suggest you see this link: https://software.opensuse.org/search?utf8=%E2%9C%93&baseproject=ALL&q=gcc-c%2B%2B