### PR TITLE
Fix missing dependency checking on OpenSUSE

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,7 +76,7 @@ dependencies() {
                 fi
             ;;
             "openSUSE Leap"|"openSUSE Tumbleweed")
-                MANAGER_QUERY="zypper search"
+                MANAGER_QUERY="rpm -q"
                 MANAGER_INSTALL="zypper install"
                 DEPS="{gcc-c++,gcc-c++-32bit,meson,libpkgconf-devel,python3-Mako,libX11-devel,libX11-devel-32bit,glslang-devel,libglvnd-devel,libglvnd-devel-32bit,glibc-devel,glibc-devel-32bit,libstdc++-devel,libstdc++-devel-32bit,Mesa-libGL-devel}"
                 install


### PR DESCRIPTION
Use `rpm -q` instead of `zypper seach` as the latter does not use the expected exit codes and searches remote caches. Unfortunately I could not find a way to do this without directly using rpm. Fixes https://github.com/flightlessmango/MangoHud/issues/85