### PR TITLE
Change flatpak ID in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you are using Flatpaks, you will have to add the [Flathub repository](https:/
 
 ##### For Steam flatpak
 ```
-flatpak install com.valvesoftware.Steam.VulkanLayer.MangoHud
+flatpak install com.valvesoftware.Steam.Utility.MangoHud
 ```
 To enable MangoHud for all Steam games:
 ```


### PR DESCRIPTION
Extension point of Steam flatpak, where MangoHud extension is attached, was changed in order to better fit MangoHud's new OpenGL support.