### PR TITLE
Add missing parameters to MangoHud.conf

### DIFF
--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -23,6 +23,11 @@ cpu_stats
 ### Display the current GPU information
 gpu_stats
 # gpu_temp
+# gpu_core_clock
+# gpu_mem_clock
+
+### Display loaded MangoHud architecture
+# arch
 
 ### Display the frametime line graph
 frame_timing
@@ -44,6 +49,10 @@ position=top-left
 ### Display the current CPU load & frequency for each core
 # core_load
 
+### IO read and write for the app (not system)
+# io_read
+# io_write
+
 ### Display system ram / vram usage
 # ram
 # vram
@@ -61,6 +70,21 @@ position=top-left
 
 ### Hud transparency / alpha
 background_alpha=0.5
+# alpha=
+
+### Color customization
+# text_color=FFFFFF
+# gpu_color=2E9762
+# cpu_color=2E97CB
+# vram_color=AD64C1
+# ram_color=C26693
+# engine_color=EB5B5B
+# io_color=A491D3
+# frametime_color=00FF00
+# background_color=020202
+
+### Change default font (set location to .TTF/.OTF file )
+# font_file
 
 ### Crosshair overlay (default size is 30)
 # crosshair
@@ -72,3 +96,11 @@ background_alpha=0.5
 ### Change toggle keybinds for the hud & logging
 toggle_hud=F12
 toggle_logging=F2
+reload_cfg=F4
+
+################## LOG #################
+
+### Set amount of time in second that the logging will run for
+# log_duration
+### Define name and location of the output file (Required for logging)
+# output_file


### PR DESCRIPTION
Adds missing parameters from #95 as well as `arch` parameter in develop branch