### PR TITLE
Add builddir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+builddir/
 __pycache__/
 .vscode/
 MangoHud*.tar.gz


### PR DESCRIPTION
Most Meson builds use the `builddir` folder instead of the `build` folder, see also [their example](https://mesonbuild.com/Running-Meson.html).
The vscode addon just doesn't go with that by default, but it can be changed in the settings.