### PR TITLE
Write log in a memory buffer and periodically write it in disk

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -60,8 +60,8 @@ void *logging(void *params_void){
 
     if ((elapsedLog) >= params->log_duration * 1000000 && params->log_duration)
       loggingOn = false;
-
-    this_thread::sleep_for(chrono::milliseconds(log_period));
+    else
+      this_thread::sleep_for(chrono::milliseconds(log_period));
   }
 
   writeFile(params->output_file + date);

--- a/src/logging.h
+++ b/src/logging.h
@@ -41,16 +41,21 @@ void *logging(void *params_void){
   overlay_params *params = reinterpret_cast<overlay_params *>(params_void);
   time_t now_log = time(0);
   tm *log_time = localtime(&now_log);
-	string date = to_string(log_time->tm_year + 1900) + "-" + to_string(1 + log_time->tm_mon) + "-" + to_string(log_time->tm_mday) + "_" + to_string(1 + log_time->tm_hour) + "-" + to_string(1 + log_time->tm_min) + "-" + to_string(1 + log_time->tm_sec);
+  string date = to_string(log_time->tm_year + 1900) + "-" +
+                to_string(1 + log_time->tm_mon) + "-" +
+                to_string(log_time->tm_mday) + "_" +
+                to_string(1 + log_time->tm_hour) + "-" +
+                to_string(1 + log_time->tm_min) + "-" +
+                to_string(1 + log_time->tm_sec);
   log_start = os_time_get();
   out.open(params->output_file + date, ios::out | ios::app);
   out << "os," << "cpu," << "gpu," << "ram," << "kernel," << "driver" << endl;
   out << os << "," << cpu << "," << gpu << "," << ram << "," << kernel << "," << driver << endl;
-	while (loggingOn){
+  while (loggingOn){
     uint64_t now = os_time_get();
     elapsedLog = (double)(now - log_start);
     out << fps << "," << cpuLoadLog << "," << gpuLoadLog << "," <<  now - log_start << endl;
-		// logArray.push_back({fps, cpuLoadLog, gpuLoadLog, 0.0f});
+    // logArray.push_back({fps, cpuLoadLog, gpuLoadLog, 0.0f});
 
     if ((elapsedLog) >= params->log_duration * 1000000 && params->log_duration)
       loggingOn = false;

--- a/src/logging.h
+++ b/src/logging.h
@@ -58,7 +58,7 @@ void *logging(void *params_void){
     elapsedLog = now - log_start;
     logArray.push_back({fps, cpuLoadLog, gpuLoadLog, elapsedLog});
 
-    if ((elapsedLog) >= params->log_duration * 1000000 && params->log_duration)
+    if (params->log_duration && (elapsedLog) >= params->log_duration * 1000000)
       loggingOn = false;
     else
       this_thread::sleep_for(chrono::milliseconds(log_period));


### PR DESCRIPTION
Hello,

This PR improves the performance of logging by writing data in a memory buffer and periodically writing it to disk, to avoid losing data in case of interruption. The time interval of writes can be set using the environment variable `LOG_WRITE_INTERVAL` and it is set as 1 second by default. Writing to the file for each line can hurt performance since it will trigger a disk write and this action can be blocked.

To test this, I have setup the following environment:  
- `LOG_WRITE_INTERVAL = 1 sec`
- `LOG_PERIOD = 10`
- `output_file`: a file in a USB flash drive
- Used the benchmark tool from "Metro: Last Light Redux". Owners of this game can find this tool in `.local/share/Steam/steamapps/common/Metro Last Light Redux/benchmark.sh`.

This was the result:

![buffer_disk](https://user-images.githubusercontent.com/11445613/78820343-0007c100-79ae-11ea-8c01-40b2cb125f9e.png)

I started the logging at the same time, and it should have the same duration. However, as can be seen, the "Write on disk" test took long to run, since a lag was added between the frame draws, making the a horizontal scaling (like when you multiply _x_ by a constant).

It also improves the indentation and don't call sleep if the log duration is over.

Thanks!