### PR TITLE
Improve os-release parsing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ dependencies() {
                 DEPS="{glibc-devel.i686,libstdc++-devel.i686,libX11-devel.i686}"
                 install
             ;;
-            *"buntu"|"Linux Mint"|"Debian"|"Zorin OS"|"Pop!_OS"|"elementary OS")
+            *"buntu"|"Linux Mint"|"Debian GNU/Linux"|"Zorin OS"|"Pop!_OS"|"elementary OS")
                 MANAGER_QUERY="dpkg-query -s"
                 MANAGER_INSTALL="apt install"
                 DEPS="{gcc,g++,gcc-multilib,g++-multilib,ninja-build,python3-pip,python3-setuptools,python3-wheel,pkg-config,mesa-common-dev,libx11-dev:i386}"

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ for os_release in ${OS_RELEASE_FILES[@]} ; do
     if [[ ! -e "${os_release}" ]]; then
         continue
     fi
-    DISTRO=$(sed 1q ${os_release} | sed 's/NAME=//g' | sed 's/"//g')
+    DISTRO=$(sed -rn 's/^NAME="(.+)"/\1/p' ${os_release})
 done
 
 dependencies() {


### PR DESCRIPTION
My Debian `/etc/os-release` looks like this:

```sh
PRETTY_NAME="Debian GNU/Linux bullseye/sid"
NAME="Debian GNU/Linux"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
The `build.sh` script assumes that the `NAME` property appears on the first line, which is apparently not always the case. I've fixed this by using a regular expression to extract the name inside the quotes. Additionally, the correct name for Debian seems to be `Debian GNU/Linux`.