### PR TITLE
Make used NVML optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
-build/
-builddir/
-__pycache__/
-.vscode/
+build
+builddir
+__pycache__
+.vscode
 MangoHud*.tar.gz
-pkg/*
+pkg
 mangohud*.tar.*
 lib32-mangohud*.tar.*
+v*.tar.gz
 
 # Prerequisites
 *.d

--- a/build-source.sh
+++ b/build-source.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+VERSION=$(git describe --long --tags --always | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//')
+
+EXCLUDE_PATTERN="--exclude-vcs --exclude-vcs-ignores"
+
+tar -cf v$VERSION.tar.gz $EXCLUDE_PATTERN .
+tar -cf v$VERSION-DFSG.tar.gz $EXCLUDE_PATTERN --exclude=include/nvml.h .

--- a/meson.build
+++ b/meson.build
@@ -212,5 +212,11 @@ util_files = files(
   'src/mesa/util/os_time.c',
 )
 
+if get_option('use_system_nvml')
+  cpp_nvml_args = '-DUSE_SYSTEM_NVML'
+else
+  cpp_nvml_args = []
+endif
+
 subdir('modules/ImGui')
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('glibcxx_asserts', type : 'boolean', value : false)
 option('use_system_vulkan', type : 'feature', value : 'disabled', description: 'Use system vulkan headers instead of the provided ones')
+option('use_system_nvml', type : 'boolean', value : false, description : 'Use system nvml headers instead of the provided ones')
 option('mangohud_prefix', type : 'string', value : '', description: 'Add prefix to cross-compiled library, like "lib32-".')
 option('append_libdir_mangohud', type : 'boolean', value : true, description: 'Append "mangohud" to libdir path or not.')
 option('include_doc', type : 'boolean', value : true, description: 'Include the example config')

--- a/src/loaders/loader_nvml.h
+++ b/src/loaders/loader_nvml.h
@@ -4,7 +4,11 @@
 #ifndef LIBRARY_LOADER_NVML_H
 #define LIBRARY_LOADER_NVML_H
 
+#if USE_SYSTEM_NVML
+#include <nvml.h>
+#else
 #include "nvml.h"
+#endif
 #define LIBRARY_LOADER_NVML_H_DLOPEN
 
 #include <string>

--- a/src/meson.build
+++ b/src/meson.build
@@ -82,6 +82,7 @@ vklayer_mesa_overlay = shared_library(
   cpp_args : [
     pre_args,
     cpp_vis_args, 
+    cpp_nvml_args,
     vulkan_wsi_args
     ],
   dependencies : [


### PR DESCRIPTION
Closes #121. Allows users with `nvml.h` on their system to use that file instead, which allows to ship a source tarball that is compliant with the DFSG.
Also adds a script to release a DFSG compliant source tarball, as well as a full source tarball. For this I needed to modify the gitignore to not list dirs with a `/` in the end, else tar doesn't ignore them.