### PR TITLE
Blacklist: Add OpenGL and fix `mangohud steam`

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('with_xnvctrl', type : 'feature', value : 'enabled', description: 'Enable
 option('with_x11', type : 'feature', value : 'enabled')
 option('with_wayland', type : 'feature', value : 'disabled')
 option('with_dbus', type : 'feature', value : 'enabled')
+option('with_dlsym', type : 'feature', value : 'disabled')

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -1,0 +1,59 @@
+#include <vector>
+#include <string>
+#include <algorithm>
+
+#include "blacklist.h"
+#include "string_utils.h"
+#include "file_utils.h"
+
+static std::string get_proc_name() {
+#ifdef _GNU_SOURCE_OFF
+   std::string p(program_invocation_name);
+   std::string proc_name = p.substr(p.find_last_of("/\\") + 1);
+#else
+   std::string p = get_exe_path();
+   std::string proc_name;
+   if (ends_with(p, "wine-preloader") || ends_with(p, "wine64-preloader")) {
+      get_wine_exe_name(proc_name, true);
+   } else {
+      proc_name = p.substr(p.find_last_of("/\\") + 1);
+   }
+#endif
+    return proc_name;
+}
+
+static bool check_blacklisted() {
+    std::vector<std::string> blacklist {
+        "Battle.net.exe",
+        "BethesdaNetLauncher.exe",
+        "EpicGamesLauncher.exe",
+        "IGOProxy.exe",
+        "IGOProxy64.exe",
+        "Origin.exe",
+        "OriginThinSetupInternal.exe",
+        "steam",
+        "steamwebhelper",
+        "gldriverquery",
+        "vulkandriverquery",
+        "Steam.exe",
+    };
+
+    std::string proc_name = get_proc_name();
+    bool blacklisted = std::find(blacklist.begin(), blacklist.end(), proc_name) != blacklist.end();
+#ifndef NDEBUG
+    std::cerr << "MANGOHUD: process " << proc_name << " is blacklisted: " << blacklisted << std::endl;
+#endif
+    return blacklisted;
+}
+
+bool& is_blacklisted() {
+    static bool checked     = false;
+    static bool blacklisted = false;
+
+    if (!checked) {
+        checked = true;
+        blacklisted = check_blacklisted();
+    }
+
+    return blacklisted;
+}

--- a/src/blacklist.h
+++ b/src/blacklist.h
@@ -1,0 +1,3 @@
+#pragma once
+
+bool& is_blacklisted();

--- a/src/meson.build
+++ b/src/meson.build
@@ -63,7 +63,9 @@ opengl_files = files(
   'gl/inject_egl.cpp',
 )
 
-pre_args += '-DHOOK_DLSYM'
+if get_option('with_dlsym').enabled()
+    pre_args += '-DHOOK_DLSYM'
+endif
 
 if get_option('with_xnvctrl').enabled()
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -42,6 +42,7 @@ vklayer_files = files(
   'overlay.cpp',
   'overlay_params.cpp',
   'font_unispace.c',
+  'blacklist.cpp',
   'cpu.cpp',
   'loaders/loader_nvml.cpp',
   'nvml.cpp',

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -817,7 +817,10 @@ void init_gpu_stats(uint32_t& vendorID, overlay_params& params)
 }
 
 void init_system_info(){
-      unsetenv("LD_PRELOAD");
+      const char* ld_preload = getenv("LD_PRELOAD");
+      if (ld_preload)
+         unsetenv("LD_PRELOAD");
+
       ram =  exec("cat /proc/meminfo | grep 'MemTotal' | awk '{print $2}'");
       trim(ram);
       cpu =  exec("cat /proc/cpuinfo | grep 'model name' | tail -n1 | sed 's/^.*: //' | sed 's/([^)]*)/()/g' | tr -d '(/)'");
@@ -833,6 +836,8 @@ void init_system_info(){
       trim(driver);
       //driver = itox(device_data->properties.driverVersion);
 
+      if (ld_preload)
+         setenv("LD_PRELOAD", ld_preload, 1);
 #ifndef NDEBUG
       std::cout << "Ram:" << ram << "\n"
                 << "Cpu:" << cpu << "\n"


### PR DESCRIPTION
This adds the ability to run `mangohud steam` and have it work with all games by default. That requires:
 - adding the blacklist functionality to OpenGL
 - not hooking dlsym as this breaks steamwebhelper and doesn't seem to be required by any games I've tried
 - fixing `LD_PRELOAD` that is currently unset and never reset.