### PR TITLE
Better names for source tarballs

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-VERSION=$(git describe --long --tags --always | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//')
+VERSION=$(git describe --tags)
 
 EXCLUDE_PATTERN="--exclude-vcs --exclude-vcs-ignores"
 
-tar -cf v$VERSION.tar.gz $EXCLUDE_PATTERN .
-tar -cf v$VERSION-DFSG.tar.gz $EXCLUDE_PATTERN --exclude=include/nvml.h .
+tar -cf MangoHud-$VERSION-Source.tar.gz $EXCLUDE_PATTERN .
+tar -cf MangoHud-$VERSION-Source-DFSG.tar.gz $EXCLUDE_PATTERN --exclude=include/nvml.h .


### PR DESCRIPTION
A bit more descriptive tarball names by adding "-Source" and fixing the version fetching (it now stopss adding the commit id when on the tag).