### PR TITLE
Use gzip in build-source.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ MangoHud*.tar.gz
 pkg
 mangohud*.tar.*
 lib32-mangohud*.tar.*
-v*.tar.gz
 
 # Prerequisites
 *.d

--- a/build-source.sh
+++ b/build-source.sh
@@ -2,7 +2,9 @@
 
 VERSION=$(git describe --tags)
 
-EXCLUDE_PATTERN="--exclude-vcs --exclude-vcs-ignores"
+FILE_PATTERN="--exclude-vcs --exclude-vcs-ignores ."
 
-tar -cf MangoHud-$VERSION-Source.tar.gz $EXCLUDE_PATTERN .
-tar -cf MangoHud-$VERSION-Source-DFSG.tar.gz $EXCLUDE_PATTERN --exclude=include/nvml.h .
+# default version
+tar -czf MangoHud-$VERSION-Source.tar.gz $FILE_PATTERN
+# DFSG compliant version, excludes NVML
+tar -czf MangoHud-$VERSION-Source-DFSG.tar.gz --exclude=include/nvml.h $FILE_PATTERN


### PR DESCRIPTION
I just noticed I messed up the script - it didn't use gzip (or any other compression). Debian doesn't accept non-compressed tarballs, which means the uploaded ones are useless to me.
Can you run the tar commands by hand on the v0.3.5 tag (the script on that tag has to be unchanged else there will be diff errors), and publish the tarballs? I'm really sorry for this.

I also removed an old entry in the gitignore I forgot to remove in #148.