### PR TITLE
build-source.sh: ensure that working tree is clean

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION=$(git describe --tags)
+VERSION=$(git describe --tags --dirty=+)
 
 FILE_PATTERN="--exclude-vcs --exclude-vcs-ignores ."
 


### PR DESCRIPTION
Inspired from https://github.com/flightlessmango/MangoHud/blob/master/meson.build#L14, it adds dirty to the name if there are modified or non-committed files. It's basically a free check that the source tarball is actually what it should include (except ofc the git submodule, sigh).