### PR TITLE
Blacklist Additions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -202,6 +202,12 @@ install() {
     echo "MangoHud Installed"
 }
 
+reinstall() {
+    build
+    package
+    install
+}
+
 clean() {
     rm -rf "build"
 }
@@ -244,6 +250,7 @@ for a in $@; do
         "build") build;;
         "package") package;;
         "install") install;;
+        "reinstall") reinstall;;
         "clean") clean;;
         "uninstall") uninstall;;
         "release") release;;

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -39,7 +39,7 @@ static bool check_blacklisted() {
         "ffxivlauncher.exe",
         "ffxivlauncher64.exe",
         "LeagueClient.exe",
-        "wine-LeagueClientUxRender",
+        "LeagueClientUxRender.exe",
         "lutris"
     };
 

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -38,6 +38,7 @@ static bool check_blacklisted() {
         "Steam.exe",
         "ffxivlauncher.exe",
         "ffxivlauncher64.exe",
+        "lutris"
     };
 
     std::string proc_name = get_proc_name();

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -44,7 +44,7 @@ static bool check_blacklisted() {
 
     std::string proc_name = get_proc_name();
     bool blacklisted = std::find(blacklist.begin(), blacklist.end(), proc_name) != blacklist.end();
-    fprintf(stderr, "INFO: process %s is blacklisted in MangoHud %d\n", proc_name.c_str());
+    fprintf(stderr, "INFO: process %s is blacklisted in MangoHud\n", proc_name.c_str());
     return blacklisted;
 }
 

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -39,6 +39,7 @@ static bool check_blacklisted() {
         "ffxivlauncher.exe",
         "ffxivlauncher64.exe",
         "LeagueClient.exe",
+        "wine-LeagueClientUxRender",
         "lutris"
     };
 

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -44,9 +44,7 @@ static bool check_blacklisted() {
 
     std::string proc_name = get_proc_name();
     bool blacklisted = std::find(blacklist.begin(), blacklist.end(), proc_name) != blacklist.end();
-#ifndef NDEBUG
-    fprintf(stderr, "MANGOHUD: process %s is blacklisted: %d\n", proc_name.c_str(), blacklisted);
-#endif
+    fprintf(stderr, "INFO: process %s is blacklisted in MangoHud %d\n", proc_name.c_str());
     return blacklisted;
 }
 

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -39,8 +39,7 @@ static bool check_blacklisted() {
         "ffxivlauncher.exe",
         "ffxivlauncher64.exe",
         "LeagueClient.exe",
-        "LeagueClientUxRender.exe",
-        "lutris"
+        "LeagueClientUxRender.exe"
     };
 
     std::string proc_name = get_proc_name();

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -45,7 +45,11 @@ static bool check_blacklisted() {
 
     std::string proc_name = get_proc_name();
     bool blacklisted = std::find(blacklist.begin(), blacklist.end(), proc_name) != blacklist.end();
-    fprintf(stderr, "INFO: process %s is blacklisted in MangoHud\n", proc_name.c_str());
+
+    if(blacklisted) {
+        fprintf(stderr, "INFO: process %s is blacklisted in MangoHud\n", proc_name.c_str());
+    }
+
     return blacklisted;
 }
 

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -38,6 +38,7 @@ static bool check_blacklisted() {
         "Steam.exe",
         "ffxivlauncher.exe",
         "ffxivlauncher64.exe",
+        "LeagueClient.exe",
         "lutris"
     };
 


### PR DESCRIPTION
This PR:
- Blacklists `LeagueClient` and `LeagueClientUxRender` which would crash with `MANGOHUD=1` 
- Replaces debug stream write which now always displays blacklisted processes when detected
- Introduces `reinstall` command to `build.sh` which bundles `build, package, install`

League of Legends now works with this PR - [benchmark](https://flightlessmango.com/games/2829/logs/252).
