### PR TITLE
Implement keybindings with multiple keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ lib32-mangohud*.tar.*
 subprojects/packagecache/
 subprojects/imgui-*/
 subprojects/Vulkan-Headers-*/
+
+#GNU Global Metadata
+**/GPATH
+**/GRTAGS
+**/GTAGS

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A partial list of parameters are below. See the config file for a complete list.
 | `offset_x` `offset_y`              | Hud position offsets                                                                  |
 | `no_display`                       | Hide the hud by default                                                               |
 | `toggle_hud=`<br>`toggle_logging=` | Modifiable toggle hotkeys. Default are F12 and F2, respectively.                      |
-| `reload_cfg=`                      | Change keybind for reloading the config                                               |
+| `reload_cfg=`                      | Change keybind for reloading the config. Default = `Shift_L F4`                       |
 | `time`<br>`time_format=%T`         | Displays local time. See [std::put_time](https://en.cppreference.com/w/cpp/io/manip/put_time) for formatting help. |
 | `gpu_color`<br>`gpu_color`<br>`vram_color`<br>`ram_color`<br>`io_color`<br>`engine_color`<br>`frametime_color`<br>`background_color`<br>`text_color`         | Change default colors: `gpu_color=RRGGBB`|
 | `alpha`                            | Set the opacity of all text and frametime graph `0.0-1.0`                             |

--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -16,7 +16,7 @@ bool keys_are_pressed(std::vector<KeySym>& keys) {
         return false;
 
     char keys_return[32];
-    std::vector<bool> pressed;
+    size_t pressed = 0;
 
     g_x11->XQueryKeymap(get_xdisplay(), keys_return);
 
@@ -27,11 +27,11 @@ bool keys_are_pressed(std::vector<KeySym>& keys) {
 
         if(isPressed)
         {
-            pressed.push_back(true);
+            pressed++;
         }
     }
 
-    if(pressed.size() == keys.size() && pressed.size() > 0)
+    if(pressed > 0 && pressed == keys.size())
     {
         return true;
     }

--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -10,15 +10,32 @@ double elapsedF2, elapsedF12, elapsedReloadCfg;
 uint64_t last_f2_press, last_f12_press, reload_cfg_press;
 
 #ifdef HAVE_X11
-bool key_is_pressed(KeySym ks) {
+bool keys_are_pressed(std::vector<KeySym>& keys) {
 
     if (!init_x11())
         return false;
 
     char keys_return[32];
+    std::vector<bool> pressed;
+
     g_x11->XQueryKeymap(get_xdisplay(), keys_return);
-    KeyCode kc2 = g_x11->XKeysymToKeycode(get_xdisplay(), ks);
-    bool isPressed = !!(keys_return[kc2 >> 3] & (1 << (kc2 & 7)));
-    return isPressed;
+
+    for(int i=0; i < keys.size(); i++){
+        KeyCode kc2 = g_x11->XKeysymToKeycode(get_xdisplay(), keys[i]);
+
+        bool isPressed = !!(keys_return[kc2 >> 3] & (1 << (kc2 & 7)));
+
+        if(isPressed)
+        {
+            pressed.push_back(true);
+        }
+    }
+
+    if(pressed.size() == keys.size() && pressed.size() > 0)
+    {
+        return true;
+    }
+
+    return false;
 }
 #endif

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -876,7 +876,7 @@ void check_keybinds(struct overlay_params& params){
   
   if (elapsedF2 >= 500000 && !params.output_file.empty()){
 #ifdef HAVE_X11
-     pressed = key_is_pressed(params.toggle_logging);
+     pressed = keys_are_pressed(params.toggle_logging);
 #else
      pressed = false;
 #endif
@@ -893,7 +893,7 @@ void check_keybinds(struct overlay_params& params){
 
    if (elapsedF12 >= 500000){
 #ifdef HAVE_X11
-      pressed = key_is_pressed(params.toggle_hud);
+      pressed = keys_are_pressed(params.toggle_hud);
 #else
       pressed = false;
 #endif
@@ -905,7 +905,7 @@ void check_keybinds(struct overlay_params& params){
 
    if (elapsedReloadCfg >= 500000){
 #ifdef HAVE_X11
-      pressed = key_is_pressed(params.reload_cfg);
+      pressed = keys_are_pressed(params.reload_cfg);
 #else
       pressed = false;
 #endif

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -386,9 +386,9 @@ parse_overlay_config(struct overlay_params *params,
    params->text_color = strtol("ffffff", NULL, 16);
 
 #ifdef HAVE_X11
-   params->toggle_hud = std::vector<KeySym>(XK_Shift_L, XK_F12);
+   params->toggle_hud = std::vector<KeySym>(XK_F12);
    params->toggle_logging = std::vector<KeySym>(XK_F2);
-   params->reload_cfg = std::vector<KeySym>(XK_F4);
+   params->reload_cfg = std::vector<KeySym>(XK_Shift_L, XK_F4);
 #endif
 
    // first pass with env var

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -6,8 +6,6 @@
 #include <wordexp.h>
 #include "imgui.h"
 #include <iostream>
-#include <sstream>
-#include <istream>
 #include <string>
 
 #include "overlay_params.h"

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -2,6 +2,7 @@
 #define OVERLAY_PARAMS_H
 
 #include <string>
+#include <vector>
 #include <unordered_map>
 
 #ifdef __cplusplus
@@ -122,9 +123,9 @@ struct overlay_params {
    unsigned tableCols;
    float font_size;
    float background_alpha, alpha;
-   KeySym toggle_hud;
-   KeySym toggle_logging;
-   KeySym reload_cfg;
+   std::vector<KeySym> toggle_hud;
+   std::vector<KeySym> toggle_logging;
+   std::vector<KeySym> reload_cfg;
    std::string time_format, output_file, font_file;
    std::string pci_dev;
 


### PR DESCRIPTION
This PR:
- Implements keybinding configuration to support arrays of keys
- Adds `GNU Global` metadata to `.gitignore`
- Sets default keybind for `reload_cfg` to `LShift+F4`

In theory, should support any number of keys per a binding.
Space as a delimiter would be a good default, I think. 

These are my first contributions for a `C++` project, so I expect I'll have to iterate on it before merging.