### PR TITLE
Add instructions for using MangoHud with Lutris

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Or
 
 `mangohud.x86 /path/to/app` for 32bit OpenGL
 
+For Lutris games, go to the System options in Lutris (make sure that advanced options are enabled) and add this to the `Command prefix` setting:
+
+`mangohud`
+
 For Steam games, you can add this as a launch option:
 
 `mangohud %command%`


### PR DESCRIPTION
The Lutris bug tracker is currently getting a lot of reports of Lutris not launching when it is started through MangoHud. I guess a lot of people don't know how to use MangoHud with Lutris correctly so they just enable it globally. With this Readme change I hope fewer people will encounter issues with MangoHud and Lutris in the future.