### PR TITLE
Change blacklist type

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -23,7 +23,7 @@ static std::string get_proc_name() {
 }
 
 static bool check_blacklisted() {
-    static const std::array<std::string, 17> blacklist {
+    static const std::vector<std::string> blacklist {
         "Battle.net.exe",
         "BethesdaNetLauncher.exe",
         "EpicGamesLauncher.exe",

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -23,7 +23,7 @@ static std::string get_proc_name() {
 }
 
 static bool check_blacklisted() {
-    static const std::array<const char *, 17> blacklist {
+    static const std::array<std::string, 17> blacklist {
         "Battle.net.exe",
         "BethesdaNetLauncher.exe",
         "EpicGamesLauncher.exe",

--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -1,4 +1,4 @@
-#include <array>
+#include <vector>
 #include <string>
 #include <algorithm>
 


### PR DESCRIPTION
This PR changes blacklist to contain `std::string` instead of `const char*` which fixes segfaults in `lutris` and `vulkaninfo`.

Also changes blacklist to be `std::vector` instead of an array as I think it helps with maintainability.

Discussion: https://github.com/flightlessmango/MangoHud/pull/197