### PR TITLE
build-source.sh: Add parent directory to source tarballs

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
 VERSION=$(git describe --tags --dirty=+)
+NAME=MangoHud-$VERSION-Source
 
 FILE_PATTERN="--exclude-vcs --exclude-vcs-ignores ."
 
+# Ensure that submodules are present
+git submodule update --init
+
+mkdir -p build
+
 # default version
-tar -czf MangoHud-$VERSION-Source.tar.gz $FILE_PATTERN
+tar -czf build/$NAME.tar.gz $FILE_PATTERN --transform "s,^\.,$NAME,"
 # DFSG compliant version, excludes NVML
-tar -czf MangoHud-$VERSION-Source-DFSG.tar.gz --exclude=include/nvml.h $FILE_PATTERN
+tar -czf build/$NAME-DFSG.tar.gz --exclude=include/nvml.h $FILE_PATTERN --transform "s,^\.,$NAME-DFSG,"


### PR DESCRIPTION
Also ensure that submodules have been initialized.

---

Most source distribution tarballs include a parent folder that matches the tarball's name (without extension), so this change makes this follow the same convention.