### PR TITLE
Fix -Wformat-security warning with GCC 10.1

### DIFF
--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -1044,12 +1044,12 @@ void render_benchmark(swapchain_stats& data, struct overlay_params& params, ImVe
    ImGui::Begin("Benchmark", &open, ImGuiWindowFlags_NoDecoration);
    static const char* finished = "Logging Finished";
    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2 )- (ImGui::CalcTextSize(finished).x / 2));
-   ImGui::TextColored(ImVec4(1.0, 1.0, 1.0, alpha / params.background_alpha), finished);
+   ImGui::TextColored(ImVec4(1.0, 1.0, 1.0, alpha / params.background_alpha), "%s", finished);
    ImGui::Dummy(ImVec2(0.0f, 8.0f));
    char duration[20];
    snprintf(duration, sizeof(duration), "Duration: %.1fs", float(log_end - log_start) / 1000000);
    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2 )- (ImGui::CalcTextSize(duration).x / 2));
-   ImGui::TextColored(ImVec4(1.0, 1.0, 1.0, alpha / params.background_alpha), duration);
+   ImGui::TextColored(ImVec4(1.0, 1.0, 1.0, alpha / params.background_alpha), "%s", duration);
    for (auto& data_ : benchmark_data){
       char buffer[20];
       snprintf(buffer, sizeof(buffer), "%s %.1f", data_.first.c_str(), data_.second);


### PR DESCRIPTION
Fixes:
```
[12/40] c++ -Isrc/25a6634@@MangoHud@sha -Isrc -I../src -I../include -I../modules/ImGui/src -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -std=c++14 -Werror=return-type -fno-math-errno -fno-trapping-math -Wno-non-virtual-dtor -Wno-missing-field-initializers -Wno-format-truncation -O2 -g -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables -fPIC -pthread -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS '-DPACKAGE_VERSION="v0.4.0"' -DNDEBUG -D_GNU_SOURCE -DHAVE_PTHREAD -DUSE_GCC_ATOMIC_BUILTINS -DHAVE_TIMESPEC_GET -DHAVE___BUILTIN_BSWAP32 -DHAVE___BUILTIN_BSWAP64 -DHAVE___BUILTIN_CLZ -DHAVE___BUILTIN_CLZLL -DHAVE___BUILTIN_CTZ -DHAVE___BUILTIN_EXPECT -DHAVE___BUILTIN_FFS -DHAVE___BUILTIN_FFSLL -DHAVE___BUILTIN_POPCOUNT -DHAVE___BUILTIN_POPCOUNTLL -DHAVE___BUILTIN_UNREACHABLE '-DMANGOHUD_ARCH="64bit"' -DHAVE_X11 -DHAVE_DBUS -fvisibility=hidden -DVK_USE_PLATFORM_XLIB_KHR -MD -MQ 'src/25a6634@@MangoHud@sha/overlay.cpp.o' -MF 'src/25a6634@@MangoHud@sha/overlay.cpp.o.d' -o 'src/25a6634@@MangoHud@sha/overlay.cpp.o' -c ../src/overlay.cpp
FAILED: src/25a6634@@MangoHud@sha/overlay.cpp.o 
c++ -Isrc/25a6634@@MangoHud@sha -Isrc -I../src -I../include -I../modules/ImGui/src -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -std=c++14 -Werror=return-type -fno-math-errno -fno-trapping-math -Wno-non-virtual-dtor -Wno-missing-field-initializers -Wno-format-truncation -O2 -g -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4 -fasynchronous-unwind-tables -fPIC -pthread -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS '-DPACKAGE_VERSION="v0.4.0"' -DNDEBUG -D_GNU_SOURCE -DHAVE_PTHREAD -DUSE_GCC_ATOMIC_BUILTINS -DHAVE_TIMESPEC_GET -DHAVE___BUILTIN_BSWAP32 -DHAVE___BUILTIN_BSWAP64 -DHAVE___BUILTIN_CLZ -DHAVE___BUILTIN_CLZLL -DHAVE___BUILTIN_CTZ -DHAVE___BUILTIN_EXPECT -DHAVE___BUILTIN_FFS -DHAVE___BUILTIN_FFSLL -DHAVE___BUILTIN_POPCOUNT -DHAVE___BUILTIN_POPCOUNTLL -DHAVE___BUILTIN_UNREACHABLE '-DMANGOHUD_ARCH="64bit"' -DHAVE_X11 -DHAVE_DBUS -fvisibility=hidden -DVK_USE_PLATFORM_XLIB_KHR -MD -MQ 'src/25a6634@@MangoHud@sha/overlay.cpp.o' -MF 'src/25a6634@@MangoHud@sha/overlay.cpp.o.d' -o 'src/25a6634@@MangoHud@sha/overlay.cpp.o' -c ../src/overlay.cpp
../src/overlay.cpp: In function ‘void render_benchmark(swapchain_stats&, overlay_params&, ImVec2&, unsigned int, uint64_t)’:
../src/overlay.cpp:1047:87: error: format not a string literal and no format arguments [-Werror=format-security]
 1047 |    ImGui::TextColored(ImVec4(1.0, 1.0, 1.0, alpha / params.background_alpha), finished);
      |                                                                                       ^
../src/overlay.cpp:1052:79: error: format not a string literal and no format arguments [-Werror=format-security]
 1052 |    ImGui::TextColored(ImVec4(1.0, 1.0, 1.0, alpha / params.background_alpha), duration);
      |                                                                               ^~~~~~~~
```