### PR TITLE
add .csv extension to log file

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -39,13 +39,13 @@ void writeFile(string filename){
   logArray.clear();
 }
 
-string get_current_time(){
+string get_log_suffix(){
   time_t now_log = time(0);
   tm *log_time = localtime(&now_log);
   std::ostringstream buffer;
-  buffer << std::put_time(log_time, "%Y-%m-%d_%H-%M-%S");
-  string date = buffer.str();
-  return date;
+  buffer << std::put_time(log_time, "%Y-%m-%d_%H-%M-%S") << ".csv";
+  string log_name = buffer.str();
+  return log_name;
 }
 
 void logging(void *params_void){
@@ -61,5 +61,5 @@ void logging(void *params_void){
       this_thread::sleep_for(chrono::milliseconds(params->log_interval));
   }
 
-  writeFile(params->output_file + get_current_time());
+  writeFile(params->output_file + get_log_suffix());
 }

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -736,7 +736,7 @@ void check_keybinds(struct overlay_params& params){
          log_start = now;
        }
        if (!params.output_file.empty() && params.log_duration == 0 && params.log_interval == 0 && loggingOn)
-         writeFile(params.output_file + get_current_time());
+         writeFile(params.output_file + get_log_suffix());
        loggingOn = !loggingOn;
 
        if (!params.output_file.empty() && loggingOn && params.log_interval != 0)


### PR DESCRIPTION
This PR adds the .csv extension to the log filename and refactors the function name that generates it to be more clear.

Fixes issue #106