### PR TITLE
build-source.sh: only pack required imgui files

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -7,8 +7,8 @@ NAME=MangoHud-$VERSION-Source
 git submodule update --init
 # get everything except submodules
 git archive HEAD --format=tar --prefix=${NAME}/ --output=${NAME}.tar
-# add imgui submodule
-tar -rf ${NAME}.tar --exclude-vcs --transform="s,^modules/ImGui/src,${NAME}/modules/ImGui/src," modules/ImGui/src
+# add imgui files
+tar -rf ${NAME}.tar --transform="s,^modules/ImGui/src,${NAME}/modules/ImGui/src," modules/ImGui/src/imconfig.h modules/ImGui/src/imgui.cpp modules/ImGui/src/imgui.h modules/ImGui/src/imgui_draw.cpp modules/ImGui/src/imgui_internal.h modules/ImGui/src/imgui_widgets.cpp modules/ImGui/src/imstb_rectpack.h modules/ImGui/src/imstb_textedit.h modules/ImGui/src/imstb_truetype.h
 # create DFSG compliant version which excludes NVML
 cp ${NAME}.tar ${NAME}-DFSG.tar
 tar -f ${NAME}-DFSG.tar --delete ${NAME}/include/nvml.h


### PR DESCRIPTION
@jackun @flightlessmango 
This is attempt to reduce the somewhat complicated copyright attribution for MangoHud ([here](https://salsa.debian.org/games-team/mangohud/-/blob/debian/master/debian/copyright) is my review) by removing all unneeded Dear ImGui files.
Just because I think it should be mentioned #153 also helps in this regard since it reduces the diffs between git repo and source tarball (which will be quite big with this commit).
