### PR TITLE
add 0.1% lows to the brief benchmark overlay

### DIFF
--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -789,6 +789,8 @@ void calculate_benchmark_data(){
       benchmark.total = sorted[i];
    }
    benchmark.oneP = benchmark.total;
+   // 0.1% min
+   benchmark.pointOneP = sorted[sorted.size() * 0.01];
 }
 
 void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID){
@@ -1022,7 +1024,7 @@ void render_benchmark(swapchain_stats& data, struct overlay_params& params, ImVe
    else
       ImGui::SetNextWindowPos(ImVec2(data.main_window_pos.x, data.main_window_pos.y + window_size.y + 5), ImGuiCond_Always);
 
-   vector<pair<string, float>> benchmark_data = {{"97%", benchmark.ninety}, {"AVG", benchmark.avg}, {"1% ", benchmark.oneP}};
+   vector<pair<string, float>> benchmark_data = {{"97% ", benchmark.ninety}, {"AVG ", benchmark.avg}, {"1%  ", benchmark.oneP}, {"0.1%", benchmark.pointOneP}};
    float display_time = float(now - log_end) / 1000000;
    float display_for = 10.0f;
    float alpha;

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -785,12 +785,12 @@ void calculate_benchmark_data(){
    benchmark.avg = benchmark.total / sorted.size();
    // 1% min
    benchmark.total = 0.f;
-   for (size_t i = 0; i < sorted.size() * 0.1; i++){
+   for (size_t i = 0; i < sorted.size() * 0.01; i++){
       benchmark.total = sorted[i];
    }
    benchmark.oneP = benchmark.total;
    // 0.1% min
-   benchmark.pointOneP = sorted[sorted.size() * 0.01];
+   benchmark.pointOneP = sorted[sorted.size() * 0.001];
 }
 
 void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID){
@@ -1017,7 +1017,7 @@ void render_mpris_metadata(swapchain_stats& data, const ImVec4& color, metadata&
 
 void render_benchmark(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, unsigned height, uint64_t now){
    // TODO, FIX LOG_DURATION FOR BENCHMARK
-   int benchHeight = 5 * params.font_size + 10.0f + 58;
+   int benchHeight = 6 * params.font_size + 10.0f + 58;
    ImGui::SetNextWindowSize(ImVec2(window_size.x, benchHeight), ImGuiCond_Always);
    if (height - (window_size.y + data.main_window_pos.y + 5) < benchHeight)
       ImGui::SetNextWindowPos(ImVec2(data.main_window_pos.x, data.main_window_pos.y - benchHeight - 5), ImGuiCond_Always);

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -55,6 +55,7 @@ struct benchmark_stats {
    float ninety;
    float avg;
    float oneP;
+   float pointOneP;
    float total;
    std::vector<float> fps_data;
 };


### PR DESCRIPTION
i believe this would be the last change that issue #195 requested, but whether you close that issue is up to you of course. :)

i'm not sure why the existing code for getting 1% lows in the `calculate_benchmark_data` function uses a for loop to work it out. my solution here only uses one line to do the same thing for 0.1% lows. if there's any particular reason for the existing method being the way it is, i'll be happy to change my solution to be consistent with that. 

example output:
![image](https://user-images.githubusercontent.com/37349466/85022321-0ca55400-b16b-11ea-97e4-092e966e4048.png)