### PR TITLE
Use the std::chrono convenience classes for timing

### DIFF
--- a/src/gl/inject_glx.cpp
+++ b/src/gl/inject_glx.cpp
@@ -127,10 +127,11 @@ EXPORT_C_(void) glXSwapBuffers(void* dpy, void* drawable) {
     do_imgui_swap(dpy, drawable);
     glx.SwapBuffers(dpy, drawable);
 
-    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0){
-        fps_limit_stats.frameStart = os_time_get_nano();
+    using namespace std::chrono_literals;
+    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0s){
+        fps_limit_stats.frameStart = Clock::now();
         FpsLimiter(fps_limit_stats);
-        fps_limit_stats.frameEnd = os_time_get_nano();
+        fps_limit_stats.frameEnd = Clock::now();
     }
 }
 
@@ -141,10 +142,11 @@ EXPORT_C_(int64_t) glXSwapBuffersMscOML(void* dpy, void* drawable, int64_t targe
     do_imgui_swap(dpy, drawable);
     int64_t ret = glx.SwapBuffersMscOML(dpy, drawable, target_msc, divisor, remainder);
 
-    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0){
-        fps_limit_stats.frameStart = os_time_get_nano();
+    using namespace std::chrono_literals;
+    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0s){
+        fps_limit_stats.frameStart = Clock::now();
         FpsLimiter(fps_limit_stats);
-        fps_limit_stats.frameEnd = os_time_get_nano();
+        fps_limit_stats.frameEnd = Clock::now();
     }
     return ret;
 }

--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -6,8 +6,7 @@
 typedef unsigned long KeySym;
 #endif
 
-double elapsedF2, elapsedF12, elapsedReloadCfg, elapsedUpload;
-uint64_t last_f2_press, last_f12_press, reload_cfg_press, last_upload_press;
+Clock::time_point last_f2_press, last_f12_press, reload_cfg_press, last_upload_press;
 
 #ifdef HAVE_X11
 bool keys_are_pressed(const std::vector<KeySym>& keys) {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -6,13 +6,13 @@
 string os, cpu, gpu, ram, kernel, driver;
 bool sysInfoFetched = false;
 int gpuLoadLog = 0, cpuLoadLog = 0;
-uint64_t elapsedLog;
+Clock::duration elapsedLog;
 std::vector<std::string> logFiles;
 double fps;
 std::vector<logData> logArray;
 ofstream out;
 bool loggingOn;
-uint64_t log_start, log_end;
+Clock::time_point log_start, log_end;
 logData currentLogData = {};
 bool logUpdate = false;
 
@@ -74,7 +74,7 @@ void writeFile(string filename){
     out << logArray[i].gpu_mem_clock << ",";
     out << logArray[i].gpu_vram_used << ",";
     out << logArray[i].ram_used << ",";
-    out << logArray[i].previous << "\n";
+    out << std::chrono::duration_cast<std::chrono::microseconds>(logArray[i].previous).count() << "\n";
   }
 
   out.close();
@@ -93,7 +93,7 @@ string get_log_suffix(){
 void logging(void *params_void){
   overlay_params *params = reinterpret_cast<overlay_params *>(params_void);
   while (loggingOn){
-      uint64_t now = os_time_get();
+      auto now = Clock::now();
       elapsedLog = now - log_start;
 
       currentLogData.fps = fps;
@@ -101,11 +101,11 @@ void logging(void *params_void){
       if (logUpdate)
         logArray.push_back(currentLogData);
 
-      if (params->log_duration && (elapsedLog) >= params->log_duration * 1000000)
+      if (params->log_duration && (elapsedLog >= std::chrono::seconds(params->log_duration)))
         loggingOn = false;
       else
         if (logUpdate)
-          this_thread::sleep_for(chrono::milliseconds(params->log_interval));
+          this_thread::sleep_for(std::chrono::milliseconds(params->log_interval));
         else
           this_thread::sleep_for(chrono::milliseconds(0));
   }

--- a/src/logging.h
+++ b/src/logging.h
@@ -4,7 +4,7 @@
 #include <chrono>
 #include <thread>
 
-#include "mesa/util/os_time.h"
+#include "timing.hpp"
 
 using namespace std;
 struct logData{
@@ -18,17 +18,17 @@ struct logData{
   float gpu_vram_used;
   float ram_used;
 
-  uint64_t previous;
+  Clock::duration previous;
 };
 
 extern string os, cpu, gpu, ram, kernel, driver;
 extern bool sysInfoFetched;
-extern uint64_t elapsedLog;
+extern Clock::duration elapsedLog;
 extern std::vector<std::string> logFiles;
 extern double fps;
 extern std::vector<logData> logArray;
 extern bool loggingOn;
-extern uint64_t log_start, log_end;
+extern Clock::time_point log_start, log_end;
 extern logData currentLogData;
 extern bool logUpdate;
 

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -2381,11 +2381,11 @@ static void overlay_DestroySwapchainKHR(
 void FpsLimiter(struct fps_limit& stats){
    stats.sleepTime = stats.targetFrameTime - (stats.frameStart - stats.frameEnd);
    if (stats.sleepTime > stats.frameOverhead) {
-      int64_t adjustedSleep = stats.sleepTime - stats.frameOverhead;
-      this_thread::sleep_for(chrono::nanoseconds(adjustedSleep));
-      stats.frameOverhead = ((os_time_get_nano() - stats.frameStart) - adjustedSleep);
+      auto adjustedSleep = stats.sleepTime - stats.frameOverhead;
+      this_thread::sleep_for(adjustedSleep);
+      stats.frameOverhead = ((Clock::now() - stats.frameStart) - adjustedSleep);
       if (stats.frameOverhead > stats.targetFrameTime)
-         stats.frameOverhead = 0;
+         stats.frameOverhead = Clock::duration(0);
    }
 }
 
@@ -2435,10 +2435,12 @@ static VkResult overlay_QueuePresentKHR(
          result = chain_result;
    }
 
-   if (fps_limit_stats.targetFrameTime > 0){
-      fps_limit_stats.frameStart = os_time_get_nano();
+   using namespace std::chrono_literals;
+   
+   if (fps_limit_stats.targetFrameTime > 0s){
+      fps_limit_stats.frameStart = Clock::now();
       FpsLimiter(fps_limit_stats);
-      fps_limit_stats.frameEnd = os_time_get_nano();
+      fps_limit_stats.frameEnd = Clock::now();
    }
 
    return result;

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -4,6 +4,7 @@
 #include "imgui.h"
 #include "overlay_params.h"
 #include "iostats.h"
+#include "timing.hpp"
 
 struct frame_stat {
    uint64_t stats[OVERLAY_PLOTS_MAX];
@@ -44,11 +45,11 @@ struct swapchain_stats {
 };
 
 struct fps_limit {
-   int64_t frameStart;
-   int64_t frameEnd;
-   int64_t targetFrameTime;
-   int64_t frameOverhead;
-   int64_t sleepTime;
+   Clock::time_point frameStart;
+   Clock::time_point frameEnd;
+   Clock::duration targetFrameTime;
+   Clock::duration frameOverhead;
+   Clock::duration sleepTime;
 };
 
 struct benchmark_stats {

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -485,8 +485,9 @@ parse_overlay_config(struct overlay_params *params,
    }
 
    // set frametime limit
+   using namespace std::chrono;
    if (params->fps_limit >= 0)
-      fps_limit_stats.targetFrameTime = int64_t(1000000000.0 / params->fps_limit);
+      fps_limit_stats.targetFrameTime = duration_cast<Clock::duration>(duration<double>(1) / params->fps_limit);
 
 #ifdef HAVE_DBUS
    if (params->enabled[OVERLAY_PARAM_ENABLED_media_player]) {

--- a/src/timing.hpp
+++ b/src/timing.hpp
@@ -1,0 +1,20 @@
+#ifndef MANGOHUD_TIMING_HPP
+#define MANGOHUD_TIMING_HPP
+#include <chrono>
+
+#include "mesa/util/os_time.h"
+
+class MesaClock {
+public:
+    using rep = int64_t;
+    using period = std::nano;
+    using duration = std::chrono::duration<rep, period>;
+    using time_point = std::chrono::time_point<MesaClock>;
+    const static bool is_steady = true;
+    static time_point now() noexcept {
+        return time_point(duration(os_time_get_nano()));
+    }
+};
+
+using Clock = MesaClock;
+#endif //MANGOHUD_TIMING_HPP


### PR DESCRIPTION
I created a `MesaClock` class to wrap the `os_time_get_nano` function and replaced most timing calculations with `chrono`s helper classes. This lets us write things like `elapsedTime >= chrono::seconds(12)`, or `elapsedTime >= 12s`, which is much easier to read than `elapsedTime/1000000 >= 12`.

@jackun I would like to use a `Clock::duration` for the values in the `overlay_params` struct, too, however it is declared as `extern C` (in fact, the whole header is). I'm not sure why that is, it doesn't seem like it is included in any C-files. 