### PR TITLE
Media Player autodetect

### DIFF
--- a/src/dbus_helpers.hpp
+++ b/src/dbus_helpers.hpp
@@ -1,0 +1,362 @@
+#pragma once
+#ifndef MANGOHUD_DBUS_HELPERS
+#define MANGOHUD_DBUS_HELPERS
+
+#include "loaders/loader_dbus.h"
+
+namespace DBus_helpers{
+namespace detail{
+template<class T> struct dbus_type_identifier{};
+template<> struct dbus_type_identifier<uint8_t> { const int value = DBUS_TYPE_BYTE; };
+template<> struct dbus_type_identifier<uint16_t> { const int value = DBUS_TYPE_UINT16; };
+template<> struct dbus_type_identifier<uint32_t> { const int value = DBUS_TYPE_UINT32; };
+template<> struct dbus_type_identifier<uint64_t> { const int value = DBUS_TYPE_UINT64; };
+template<> struct dbus_type_identifier<int16_t> { const int value = DBUS_TYPE_INT16; };
+template<> struct dbus_type_identifier<int32_t> { const int value = DBUS_TYPE_INT32; };
+template<> struct dbus_type_identifier<int64_t> { const int value = DBUS_TYPE_INT64; };
+template<> struct dbus_type_identifier<double> { const int value = DBUS_TYPE_DOUBLE; };
+template<> struct dbus_type_identifier<const char*> { const int value = DBUS_TYPE_STRING; };
+
+template<class T>
+const int dbus_type_identifier_v = dbus_type_identifier<T>().value;
+} //namespace detail
+
+class DBusMessageIter_wrap {
+
+public:
+    DBusMessageIter_wrap(DBusMessage* msg, libdbus_loader* loader)
+    {
+        m_DBus = loader;
+        if(msg){
+            m_DBus->message_iter_init(msg, &m_Iter);
+            m_resolved_iter = resolve_variants();
+            m_type = m_DBus->message_iter_get_arg_type(&m_resolved_iter);
+        }
+        else {
+            m_type = DBUS_TYPE_INVALID;
+        }
+    }
+
+    DBusMessageIter_wrap(DBusMessageIter iter, libdbus_loader* loader)
+        : m_Iter(iter), m_DBus(loader)
+    {
+        m_resolved_iter = resolve_variants();
+        m_type = m_DBus->message_iter_get_arg_type(&m_resolved_iter);
+    }
+
+    
+
+    int type() const noexcept { return m_type; }    
+    bool is_unsigned() const noexcept;
+    bool is_signed() const noexcept;
+    bool is_string() const noexcept;
+    bool is_double() const noexcept;
+    bool is_primitive() const noexcept;
+    bool is_array() const noexcept;
+    operator bool() const noexcept {
+        return type() != DBUS_TYPE_INVALID;
+    }
+
+    
+    template<class T>
+    auto get_primitive() -> T;
+    auto get_unsigned() -> uint64_t;
+    auto get_signed() -> int64_t;
+    auto get_stringified() -> std::string;
+
+    auto get_array_iter() -> DBusMessageIter_wrap;
+    auto get_dict_entry_iter() -> DBusMessageIter_wrap;
+
+    auto next() {
+        m_DBus->message_iter_next(&m_Iter);
+        // Resolve any variants
+        m_resolved_iter = resolve_variants();
+        m_type = m_DBus->message_iter_get_arg_type(&m_resolved_iter);
+        return *this;
+    }
+private:
+    DBusMessageIter resolve_variants() {
+        auto iter = m_Iter;
+        auto field_type = m_DBus->message_iter_get_arg_type(&m_Iter);
+        while(field_type == DBUS_TYPE_VARIANT){
+            m_DBus->message_iter_recurse(&iter, &iter);
+            field_type = m_DBus->message_iter_get_arg_type(&iter);
+        }
+        return iter;
+    }
+
+    DBusMessageIter m_Iter;
+    DBusMessageIter m_resolved_iter;
+    int m_type;
+    libdbus_loader* m_DBus;
+};
+
+
+
+bool DBusMessageIter_wrap::is_unsigned() const noexcept {
+    return (
+        (type() == DBUS_TYPE_BYTE) ||
+        (type() == DBUS_TYPE_INT16) ||
+        (type() == DBUS_TYPE_INT32) ||
+        (type() == DBUS_TYPE_INT64)
+    );
+}
+
+bool DBusMessageIter_wrap::is_signed() const noexcept {
+    return (
+        (type() == DBUS_TYPE_INT16) ||
+        (type() == DBUS_TYPE_INT32) ||
+        (type() == DBUS_TYPE_INT64)
+    );
+}
+
+bool DBusMessageIter_wrap::is_string() const noexcept {
+    return (type() == DBUS_TYPE_STRING);
+}
+
+bool DBusMessageIter_wrap::is_double() const noexcept {
+    return (type() == DBUS_TYPE_DOUBLE);
+}
+
+bool DBusMessageIter_wrap::is_primitive() const noexcept {
+    return (
+        is_double() ||
+        is_signed() ||
+        is_unsigned() ||
+        is_string()
+    );
+}
+
+bool DBusMessageIter_wrap::is_array() const noexcept {
+    return (type() == DBUS_TYPE_ARRAY);
+}
+
+
+template<class T>
+auto DBusMessageIter_wrap::get_primitive() -> T {
+    auto requested_type = detail::dbus_type_identifier_v<T>;
+    if(requested_type != type()){
+        std::cerr << "Type mismatch: '" << (char) requested_type << "' vs '" << (char) type() << "'\n";
+#ifndef NDEBUG
+        exit(-1);
+#else
+        return T();
+#endif
+    }
+
+    T ret;
+    m_DBus->message_iter_get_basic(&m_resolved_iter, &ret);
+    return ret;
+}
+
+template<>
+auto DBusMessageIter_wrap::get_primitive<std::string>() -> std::string {
+    return std::string(get_primitive<const char*>());
+}
+
+uint64_t DBusMessageIter_wrap::get_unsigned() {
+    auto t = type();
+    switch (t)
+    {
+    case DBUS_TYPE_BYTE:
+        return get_primitive<uint8_t>();
+    case DBUS_TYPE_UINT16:
+        return get_primitive<uint16_t>();
+    case DBUS_TYPE_UINT32:
+        return get_primitive<uint32_t>();
+    case DBUS_TYPE_UINT64:
+        return get_primitive<uint64_t>();
+    default:
+        return 0;
+    }
+}
+
+int64_t DBusMessageIter_wrap::get_signed() {
+    auto t = type();
+    switch (t)
+    {
+    case DBUS_TYPE_INT16:
+        return get_primitive<int16_t>();
+    case DBUS_TYPE_INT32:
+        return get_primitive<int32_t>();
+    case DBUS_TYPE_INT64:
+        return get_primitive<int64_t>();
+    default:
+        return 0;
+    }
+}
+
+auto DBusMessageIter_wrap::get_stringified() -> std::string {
+    if(is_string()) return get_primitive<std::string>();
+    if(is_unsigned()) return std::to_string(get_unsigned());
+    if(is_signed()) return std::to_string(get_signed());
+    if(is_double()) return std::to_string(get_primitive<double>());
+    std::cerr << "stringify failed\n";
+    return std::string();
+}
+
+auto DBusMessageIter_wrap::get_array_iter() -> DBusMessageIter_wrap {
+    if(not is_array()) {
+        std::cerr << "Not an array\n";
+        return DBusMessageIter_wrap(DBusMessageIter{}, m_DBus);
+    }
+
+    DBusMessageIter ret;
+    m_DBus->message_iter_recurse(&m_resolved_iter, &ret);
+    return DBusMessageIter_wrap(ret, m_DBus);
+}
+
+auto DBusMessageIter_wrap::get_dict_entry_iter() -> DBusMessageIter_wrap {
+    if(type() != DBUS_TYPE_DICT_ENTRY){
+        std::cerr << "Not a dict entry\n";
+        return DBusMessageIter_wrap(DBusMessageIter{}, m_DBus);
+    }
+
+    DBusMessageIter ret;
+    m_DBus->message_iter_recurse(&m_resolved_iter, &ret);
+    return DBusMessageIter_wrap(ret, m_DBus);
+}
+
+
+
+
+
+
+// Precondition: iter points to a dict of string -> any
+// executes action(key, value_iter) for all entries
+template<class T>
+void string_map_for_each(DBusMessageIter_wrap iter, T action) {
+    iter = iter.get_array_iter();
+    for(; iter; iter.next()) {
+        auto it = iter.get_dict_entry_iter();
+        auto key = it.get_primitive<std::string>();
+
+        it.next();
+        action(key, it);
+    }
+}
+
+template<class T, class Callable>
+void array_for_each(DBusMessageIter_wrap iter, Callable action) {
+    iter = iter.get_array_iter();
+    for(; iter; iter.next()){
+        action(iter.get_primitive<T>());
+    }
+}
+
+template<class Callable>
+void array_for_each_stringify(DBusMessageIter_wrap iter, Callable action) {
+    iter = iter.get_array_iter();
+    for(; iter; iter.next()){
+        action(iter.get_stringified());
+    }
+}
+
+template<class T>
+void string_multimap_for_each_stringify(DBusMessageIter_wrap iter, T action) {
+    string_map_for_each(iter, [&](const std::string& key, DBusMessageIter_wrap it){
+        if(it.is_array()){
+            array_for_each_stringify(it, [&](const std::string& val){
+                action(key, val);
+            });
+        }
+        else if(it.is_primitive()){
+            action(key, it.get_stringified());
+        }
+    });
+}
+
+
+
+class DBusMessage_wrap {
+public:
+    DBusMessage_wrap(DBusMessage* msg, libdbus_loader* ldr, bool owning = false)
+        : m_owning(owning), m_msg(msg), m_DBus(ldr)
+    {}
+
+    ~DBusMessage_wrap(){
+        free_if_owning();
+    }
+
+    DBusMessage_wrap(const DBusMessage_wrap&) = delete;
+    DBusMessage_wrap(DBusMessage_wrap&&) = default;
+
+    operator bool() const {
+        return m_msg != nullptr;
+    }
+
+    template<class T>
+    DBusMessage_wrap& argument(T arg) {
+        if(not m_msg) return *this;
+        if(not m_DBus->message_append_args(
+            m_msg, 
+            detail::dbus_type_identifier_v<T>, 
+            &arg,
+            DBUS_TYPE_INVALID
+        )){
+            free_if_owning();
+        }
+        return *this;
+    }
+
+    DBusMessage_wrap send_with_reply_and_block(DBusConnection* conn, int timeout) {
+        if(not m_msg){
+            return DBusMessage_wrap(nullptr, m_DBus);
+        }
+        DBusError err;
+        m_DBus->error_init(&err);
+        auto reply = m_DBus->connection_send_with_reply_and_block(
+            conn,
+            m_msg,
+            timeout,
+            &err
+        );
+        if(reply == nullptr) {
+            std::cerr << "MangoHud[" << __func__ << "]: " << err.message << "\n";
+            free_if_owning();
+            m_DBus->error_free(&err);
+        }
+        return DBusMessage_wrap(reply, m_DBus, true);
+    }
+
+    DBusMessageIter_wrap iter() {
+        return DBusMessageIter_wrap(m_msg, m_DBus);
+    }
+
+    static DBusMessage_wrap new_method_call(
+        const std::string& bus_name,
+        const std::string& path,
+        const std::string& iface,
+        const std::string& method,
+        libdbus_loader* loader
+    ){
+        auto msg = loader->message_new_method_call(
+            (bus_name.empty()) ? nullptr : bus_name.c_str(),
+            path.c_str(),
+            (iface.empty()) ? nullptr : iface.c_str(),
+            method.c_str()
+        );
+        return DBusMessage_wrap(msg, loader, true);
+    }
+private:
+    void free_if_owning() {
+        if(m_msg and m_owning) {
+            m_DBus->message_unref(m_msg);
+        }
+        m_msg = nullptr;
+    }
+    bool m_owning;
+    DBusMessage* m_msg;
+    libdbus_loader* m_DBus;
+    std::vector<std::string> m_args;
+};
+
+template<>
+DBusMessage_wrap& DBusMessage_wrap::argument<const std::string&>(const std::string& str)
+{
+    return argument<const char*>(str.c_str());
+}
+} //namespace DBus_helpers
+
+
+#endif //MANGOHUD_DBUS_HELPERS

--- a/src/dbus_helpers.hpp
+++ b/src/dbus_helpers.hpp
@@ -2,83 +2,86 @@
 #ifndef MANGOHUD_DBUS_HELPERS
 #define MANGOHUD_DBUS_HELPERS
 
+#include <vector>
+
 #include "loaders/loader_dbus.h"
 
-namespace DBus_helpers{
-namespace detail{
-template<class T> struct dbus_type_identifier{};
-template<> struct dbus_type_identifier<uint8_t> { const int value = DBUS_TYPE_BYTE; };
-template<> struct dbus_type_identifier<uint16_t> { const int value = DBUS_TYPE_UINT16; };
-template<> struct dbus_type_identifier<uint32_t> { const int value = DBUS_TYPE_UINT32; };
-template<> struct dbus_type_identifier<uint64_t> { const int value = DBUS_TYPE_UINT64; };
-template<> struct dbus_type_identifier<int16_t> { const int value = DBUS_TYPE_INT16; };
-template<> struct dbus_type_identifier<int32_t> { const int value = DBUS_TYPE_INT32; };
-template<> struct dbus_type_identifier<int64_t> { const int value = DBUS_TYPE_INT64; };
-template<> struct dbus_type_identifier<double> { const int value = DBUS_TYPE_DOUBLE; };
-template<> struct dbus_type_identifier<const char*> { const int value = DBUS_TYPE_STRING; };
+namespace DBus_helpers {
+namespace detail {
+// clang-format off
+template<class T> struct dbus_type_traits{};
+template<> struct dbus_type_traits<uint8_t>     { const int value = DBUS_TYPE_BYTE;   const bool is_fixed = true; };
+template<> struct dbus_type_traits<uint16_t>    { const int value = DBUS_TYPE_UINT16; const bool is_fixed = true; };
+template<> struct dbus_type_traits<uint32_t>    { const int value = DBUS_TYPE_UINT32; const bool is_fixed = true; };
+template<> struct dbus_type_traits<uint64_t>    { const int value = DBUS_TYPE_UINT64; const bool is_fixed = true; };
+template<> struct dbus_type_traits<int16_t>     { const int value = DBUS_TYPE_INT16;  const bool is_fixed = true; };
+template<> struct dbus_type_traits<int32_t>     { const int value = DBUS_TYPE_INT32;  const bool is_fixed = true; };
+template<> struct dbus_type_traits<int64_t>     { const int value = DBUS_TYPE_INT64;  const bool is_fixed = true; };
+template<> struct dbus_type_traits<double>      { const int value = DBUS_TYPE_DOUBLE; const bool is_fixed = true; };
+template<> struct dbus_type_traits<const char*> { const int value = DBUS_TYPE_STRING; const bool is_fixed = false; };
+// clang-format on
 
-template<class T>
-const int dbus_type_identifier_v = dbus_type_identifier<T>().value;
-} //namespace detail
+template <class T>
+const int dbus_type_identifier = dbus_type_traits<T>().value;
+
+template <class T>
+const bool is_fixed = dbus_type_traits<T>().is_fiexd;
+}  // namespace detail
 
 class DBusMessageIter_wrap {
+   public:
+    DBusMessageIter_wrap(DBusMessage* msg, libdbus_loader* loader);
+    DBusMessageIter_wrap(DBusMessageIter iter, libdbus_loader* loader);
 
-public:
-    DBusMessageIter_wrap(DBusMessage* msg, libdbus_loader* loader)
-    {
-        m_DBus = loader;
-        if(msg){
-            m_DBus->message_iter_init(msg, &m_Iter);
-            m_resolved_iter = resolve_variants();
-            m_type = m_DBus->message_iter_get_arg_type(&m_resolved_iter);
-        }
-        else {
-            m_type = DBUS_TYPE_INVALID;
-        }
-    }
-
-    DBusMessageIter_wrap(DBusMessageIter iter, libdbus_loader* loader)
-        : m_Iter(iter), m_DBus(loader)
-    {
-        m_resolved_iter = resolve_variants();
-        m_type = m_DBus->message_iter_get_arg_type(&m_resolved_iter);
-    }
-
-    
-
-    int type() const noexcept { return m_type; }    
+    //  Type accessors
+    int type() const noexcept { return m_type; }
     bool is_unsigned() const noexcept;
     bool is_signed() const noexcept;
     bool is_string() const noexcept;
     bool is_double() const noexcept;
     bool is_primitive() const noexcept;
     bool is_array() const noexcept;
-    operator bool() const noexcept {
-        return type() != DBUS_TYPE_INVALID;
-    }
+    operator bool() const noexcept { return type() != DBUS_TYPE_INVALID; }
 
-    
-    template<class T>
+    //  Value accessors
+    //  Primitives
+    template <class T>
     auto get_primitive() -> T;
     auto get_unsigned() -> uint64_t;
     auto get_signed() -> int64_t;
     auto get_stringified() -> std::string;
 
+    //  Composites
     auto get_array_iter() -> DBusMessageIter_wrap;
     auto get_dict_entry_iter() -> DBusMessageIter_wrap;
 
+    // Looping
+    template <class Callable>
+    void array_for_each(Callable);
+    template <class Callable>
+    void array_for_each_stringify(Callable);
+    template <class T, class Callable>
+    void array_for_each_value(Callable);
+
+    template <class Callable>
+    void string_map_for_each(Callable);
+    template <class Callable>
+    void string_multimap_for_each_stringify(Callable);
+
     auto next() {
+        if (not *this) return *this;
         m_DBus->message_iter_next(&m_Iter);
         // Resolve any variants
         m_resolved_iter = resolve_variants();
         m_type = m_DBus->message_iter_get_arg_type(&m_resolved_iter);
         return *this;
     }
-private:
+
+   private:
     DBusMessageIter resolve_variants() {
         auto iter = m_Iter;
         auto field_type = m_DBus->message_iter_get_arg_type(&m_Iter);
-        while(field_type == DBUS_TYPE_VARIANT){
+        while (field_type == DBUS_TYPE_VARIANT) {
             m_DBus->message_iter_recurse(&iter, &iter);
             field_type = m_DBus->message_iter_get_arg_type(&iter);
         }
@@ -91,23 +94,33 @@ private:
     libdbus_loader* m_DBus;
 };
 
+DBusMessageIter_wrap::DBusMessageIter_wrap(DBusMessage* msg,
+                                           libdbus_loader* loader) {
+    m_DBus = loader;
+    if (msg) {
+        m_DBus->message_iter_init(msg, &m_Iter);
+        m_resolved_iter = resolve_variants();
+        m_type = m_DBus->message_iter_get_arg_type(&m_resolved_iter);
+    } else {
+        m_type = DBUS_TYPE_INVALID;
+    }
+}
 
+DBusMessageIter_wrap::DBusMessageIter_wrap(DBusMessageIter iter,
+                                           libdbus_loader* loader)
+    : m_Iter(iter), m_DBus(loader) {
+    m_resolved_iter = resolve_variants();
+    m_type = m_DBus->message_iter_get_arg_type(&m_resolved_iter);
+}
 
 bool DBusMessageIter_wrap::is_unsigned() const noexcept {
-    return (
-        (type() == DBUS_TYPE_BYTE) ||
-        (type() == DBUS_TYPE_INT16) ||
-        (type() == DBUS_TYPE_INT32) ||
-        (type() == DBUS_TYPE_INT64)
-    );
+    return ((type() == DBUS_TYPE_BYTE) || (type() == DBUS_TYPE_INT16) ||
+            (type() == DBUS_TYPE_INT32) || (type() == DBUS_TYPE_INT64));
 }
 
 bool DBusMessageIter_wrap::is_signed() const noexcept {
-    return (
-        (type() == DBUS_TYPE_INT16) ||
-        (type() == DBUS_TYPE_INT32) ||
-        (type() == DBUS_TYPE_INT64)
-    );
+    return ((type() == DBUS_TYPE_INT16) || (type() == DBUS_TYPE_INT32) ||
+            (type() == DBUS_TYPE_INT64));
 }
 
 bool DBusMessageIter_wrap::is_string() const noexcept {
@@ -119,24 +132,19 @@ bool DBusMessageIter_wrap::is_double() const noexcept {
 }
 
 bool DBusMessageIter_wrap::is_primitive() const noexcept {
-    return (
-        is_double() ||
-        is_signed() ||
-        is_unsigned() ||
-        is_string()
-    );
+    return (is_double() || is_signed() || is_unsigned() || is_string());
 }
 
 bool DBusMessageIter_wrap::is_array() const noexcept {
     return (type() == DBUS_TYPE_ARRAY);
 }
 
-
-template<class T>
+template <class T>
 auto DBusMessageIter_wrap::get_primitive() -> T {
-    auto requested_type = detail::dbus_type_identifier_v<T>;
-    if(requested_type != type()){
-        std::cerr << "Type mismatch: '" << (char) requested_type << "' vs '" << (char) type() << "'\n";
+    auto requested_type = detail::dbus_type_identifier<T>;
+    if (requested_type != type()) {
+        std::cerr << "Type mismatch: '" << ((char)requested_type) << "' vs '"
+                  << (char)type() << "'";
 #ifndef NDEBUG
         exit(-1);
 #else
@@ -149,55 +157,53 @@ auto DBusMessageIter_wrap::get_primitive() -> T {
     return ret;
 }
 
-template<>
+template <>
 auto DBusMessageIter_wrap::get_primitive<std::string>() -> std::string {
     return std::string(get_primitive<const char*>());
 }
 
 uint64_t DBusMessageIter_wrap::get_unsigned() {
     auto t = type();
-    switch (t)
-    {
-    case DBUS_TYPE_BYTE:
-        return get_primitive<uint8_t>();
-    case DBUS_TYPE_UINT16:
-        return get_primitive<uint16_t>();
-    case DBUS_TYPE_UINT32:
-        return get_primitive<uint32_t>();
-    case DBUS_TYPE_UINT64:
-        return get_primitive<uint64_t>();
-    default:
-        return 0;
+    switch (t) {
+        case DBUS_TYPE_BYTE:
+            return get_primitive<uint8_t>();
+        case DBUS_TYPE_UINT16:
+            return get_primitive<uint16_t>();
+        case DBUS_TYPE_UINT32:
+            return get_primitive<uint32_t>();
+        case DBUS_TYPE_UINT64:
+            return get_primitive<uint64_t>();
+        default:
+            return 0;
     }
 }
 
 int64_t DBusMessageIter_wrap::get_signed() {
     auto t = type();
-    switch (t)
-    {
-    case DBUS_TYPE_INT16:
-        return get_primitive<int16_t>();
-    case DBUS_TYPE_INT32:
-        return get_primitive<int32_t>();
-    case DBUS_TYPE_INT64:
-        return get_primitive<int64_t>();
-    default:
-        return 0;
+    switch (t) {
+        case DBUS_TYPE_INT16:
+            return get_primitive<int16_t>();
+        case DBUS_TYPE_INT32:
+            return get_primitive<int32_t>();
+        case DBUS_TYPE_INT64:
+            return get_primitive<int64_t>();
+        default:
+            return 0;
     }
 }
 
 auto DBusMessageIter_wrap::get_stringified() -> std::string {
-    if(is_string()) return get_primitive<std::string>();
-    if(is_unsigned()) return std::to_string(get_unsigned());
-    if(is_signed()) return std::to_string(get_signed());
-    if(is_double()) return std::to_string(get_primitive<double>());
+    if (is_string()) return get_primitive<std::string>();
+    if (is_unsigned()) return std::to_string(get_unsigned());
+    if (is_signed()) return std::to_string(get_signed());
+    if (is_double()) return std::to_string(get_primitive<double>());
     std::cerr << "stringify failed\n";
     return std::string();
 }
 
 auto DBusMessageIter_wrap::get_array_iter() -> DBusMessageIter_wrap {
-    if(not is_array()) {
-        std::cerr << "Not an array\n";
+    if (not is_array()) {
+        std::cerr << "Not an array; " << (char)type() << "\n";
         return DBusMessageIter_wrap(DBusMessageIter{}, m_DBus);
     }
 
@@ -207,8 +213,8 @@ auto DBusMessageIter_wrap::get_array_iter() -> DBusMessageIter_wrap {
 }
 
 auto DBusMessageIter_wrap::get_dict_entry_iter() -> DBusMessageIter_wrap {
-    if(type() != DBUS_TYPE_DICT_ENTRY){
-        std::cerr << "Not a dict entry\n";
+    if (type() != DBUS_TYPE_DICT_ENTRY) {
+        std::cerr << "Not a dict entry" << (char)type() << "\n";
         return DBusMessageIter_wrap(DBusMessageIter{}, m_DBus);
     }
 
@@ -217,17 +223,34 @@ auto DBusMessageIter_wrap::get_dict_entry_iter() -> DBusMessageIter_wrap {
     return DBusMessageIter_wrap(ret, m_DBus);
 }
 
+template <class T, class Callable>
+void DBusMessageIter_wrap::array_for_each_value(Callable action) {
+    auto iter = get_array_iter();
+    for (; iter; iter.next()) {
+        action(iter.get_primitive<T>());
+    }
+}
 
+template <class Callable>
+void DBusMessageIter_wrap::array_for_each(Callable action) {
+    auto iter = get_array_iter();
+    for (; iter; iter.next()) {
+        action(iter);
+    }
+}
 
+template <class Callable>
+void DBusMessageIter_wrap::array_for_each_stringify(Callable action) {
+    auto iter = get_array_iter();
+    for (; iter; iter.next()) {
+        action(iter.get_stringified());
+    }
+}
 
-
-
-// Precondition: iter points to a dict of string -> any
-// executes action(key, value_iter) for all entries
-template<class T>
-void string_map_for_each(DBusMessageIter_wrap iter, T action) {
-    iter = iter.get_array_iter();
-    for(; iter; iter.next()) {
+template <class T>
+void DBusMessageIter_wrap::string_map_for_each(T action) {
+    auto iter = get_array_iter();
+    for (; iter; iter.next()) {
         auto it = iter.get_dict_entry_iter();
         auto key = it.get_primitive<std::string>();
 
@@ -236,127 +259,103 @@ void string_map_for_each(DBusMessageIter_wrap iter, T action) {
     }
 }
 
-template<class T, class Callable>
-void array_for_each(DBusMessageIter_wrap iter, Callable action) {
-    iter = iter.get_array_iter();
-    for(; iter; iter.next()){
-        action(iter.get_primitive<T>());
-    }
+template <class T>
+void DBusMessageIter_wrap::string_multimap_for_each_stringify(T action) {
+    string_map_for_each([&action](const std::string& key, DBusMessageIter_wrap it) {
+            if (it.is_array()) {
+                it.array_for_each_stringify(
+                    [&](const std::string& val) { action(key, val); });
+            } else if (it.is_primitive()) {
+                action(key, it.get_stringified());
+            }
+        });
 }
-
-template<class Callable>
-void array_for_each_stringify(DBusMessageIter_wrap iter, Callable action) {
-    iter = iter.get_array_iter();
-    for(; iter; iter.next()){
-        action(iter.get_stringified());
-    }
-}
-
-template<class T>
-void string_multimap_for_each_stringify(DBusMessageIter_wrap iter, T action) {
-    string_map_for_each(iter, [&](const std::string& key, DBusMessageIter_wrap it){
-        if(it.is_array()){
-            array_for_each_stringify(it, [&](const std::string& val){
-                action(key, val);
-            });
-        }
-        else if(it.is_primitive()){
-            action(key, it.get_stringified());
-        }
-    });
-}
-
 
 
 class DBusMessage_wrap {
-public:
+   public:
     DBusMessage_wrap(DBusMessage* msg, libdbus_loader* ldr, bool owning = false)
-        : m_owning(owning), m_msg(msg), m_DBus(ldr)
-    {}
+        : m_owning(owning), m_msg(msg), m_DBus(ldr) {}
 
-    ~DBusMessage_wrap(){
-        free_if_owning();
-    }
+    ~DBusMessage_wrap() { free_if_owning(); }
 
     DBusMessage_wrap(const DBusMessage_wrap&) = delete;
     DBusMessage_wrap(DBusMessage_wrap&&) = default;
 
-    operator bool() const {
-        return m_msg != nullptr;
-    }
+    operator bool() const noexcept { return m_msg != nullptr; }
 
-    template<class T>
-    DBusMessage_wrap& argument(T arg) {
-        if(not m_msg) return *this;
-        if(not m_DBus->message_append_args(
-            m_msg, 
-            detail::dbus_type_identifier_v<T>, 
-            &arg,
-            DBUS_TYPE_INVALID
-        )){
-            free_if_owning();
-        }
-        return *this;
-    }
+    template <class T>
+    DBusMessage_wrap& argument(T arg);
 
-    DBusMessage_wrap send_with_reply_and_block(DBusConnection* conn, int timeout) {
-        if(not m_msg){
-            return DBusMessage_wrap(nullptr, m_DBus);
-        }
-        DBusError err;
-        m_DBus->error_init(&err);
-        auto reply = m_DBus->connection_send_with_reply_and_block(
-            conn,
-            m_msg,
-            timeout,
-            &err
-        );
-        if(reply == nullptr) {
-            std::cerr << "MangoHud[" << __func__ << "]: " << err.message << "\n";
-            free_if_owning();
-            m_DBus->error_free(&err);
-        }
-        return DBusMessage_wrap(reply, m_DBus, true);
-    }
+    DBusMessage_wrap send_with_reply_and_block(DBusConnection* conn,
+                                               int timeout);
 
-    DBusMessageIter_wrap iter() {
-        return DBusMessageIter_wrap(m_msg, m_DBus);
-    }
+    DBusMessageIter_wrap iter() { return DBusMessageIter_wrap(m_msg, m_DBus); }
 
-    static DBusMessage_wrap new_method_call(
-        const std::string& bus_name,
-        const std::string& path,
-        const std::string& iface,
-        const std::string& method,
-        libdbus_loader* loader
-    ){
-        auto msg = loader->message_new_method_call(
-            (bus_name.empty()) ? nullptr : bus_name.c_str(),
-            path.c_str(),
-            (iface.empty()) ? nullptr : iface.c_str(),
-            method.c_str()
-        );
-        return DBusMessage_wrap(msg, loader, true);
-    }
-private:
-    void free_if_owning() {
-        if(m_msg and m_owning) {
-            m_DBus->message_unref(m_msg);
-        }
-        m_msg = nullptr;
-    }
+    static DBusMessage_wrap new_method_call(const std::string& bus_name,
+                                            const std::string& path,
+                                            const std::string& iface,
+                                            const std::string& method,
+                                            libdbus_loader* loader);
+
+   private:
+    void free_if_owning();
     bool m_owning;
     DBusMessage* m_msg;
     libdbus_loader* m_DBus;
     std::vector<std::string> m_args;
 };
 
-template<>
-DBusMessage_wrap& DBusMessage_wrap::argument<const std::string&>(const std::string& str)
-{
+template <class T>
+DBusMessage_wrap& DBusMessage_wrap::argument(T arg) {
+    if (not m_msg) return *this;
+    if (not m_DBus->message_append_args(m_msg, detail::dbus_type_identifier<T>,
+                                        &arg, DBUS_TYPE_INVALID)) {
+        free_if_owning();
+    }
+    return *this;
+}
+
+template <>
+DBusMessage_wrap& DBusMessage_wrap::argument<const std::string&>(
+    const std::string& str) {
     return argument<const char*>(str.c_str());
 }
-} //namespace DBus_helpers
 
+DBusMessage_wrap DBusMessage_wrap::send_with_reply_and_block(
+    DBusConnection* conn, int timeout) {
+    if (not m_msg) {
+        return DBusMessage_wrap(nullptr, m_DBus);
+    }
+    DBusError err;
+    m_DBus->error_init(&err);
+    auto reply = m_DBus->connection_send_with_reply_and_block(conn, m_msg,
+                                                              timeout, &err);
+    if (reply == nullptr) {
+        std::cerr << "MangoHud[" << __func__ << "]: " << err.message << "\n";
+        free_if_owning();
+        m_DBus->error_free(&err);
+    }
+    return DBusMessage_wrap(reply, m_DBus, true);
+}
 
-#endif //MANGOHUD_DBUS_HELPERS
+DBusMessage_wrap DBusMessage_wrap::new_method_call(const std::string& bus_name,
+                                                   const std::string& path,
+                                                   const std::string& iface,
+                                                   const std::string& method,
+                                                   libdbus_loader* loader) {
+    auto msg = loader->message_new_method_call(
+        (bus_name.empty()) ? nullptr : bus_name.c_str(), path.c_str(),
+        (iface.empty()) ? nullptr : iface.c_str(), method.c_str());
+    return DBusMessage_wrap(msg, loader, true);
+}
+
+void DBusMessage_wrap::free_if_owning() {
+    if (m_msg and m_owning) {
+        m_DBus->message_unref(m_msg);
+    }
+    m_msg = nullptr;
+}
+}  // namespace DBus_helpers
+
+#endif  // MANGOHUD_DBUS_HELPERS

--- a/src/dbus_info.h
+++ b/src/dbus_info.h
@@ -35,7 +35,6 @@ struct metadata {
     } ticker;
 
     bool valid = false;
-    std::mutex mutex;
 
     void clear()
     {
@@ -49,6 +48,11 @@ struct metadata {
     }
 };
 
+struct mutexed_metadata {
+    std::mutex mtx;
+    metadata meta;
+};
+
 enum SignalType
 {
     ST_NAMEOWNERCHANGED,
@@ -56,7 +60,7 @@ enum SignalType
 };
 
 
-extern struct metadata main_metadata;
+extern struct mutexed_metadata main_metadata;
 
 namespace dbusmgr {
 

--- a/src/dbus_info.h
+++ b/src/dbus_info.h
@@ -35,6 +35,8 @@ struct metadata {
     } ticker;
 
     bool valid = false;
+    bool got_song_data = false;
+    bool got_playback_data = false;
 
     void clear()
     {

--- a/src/dbus_info.h
+++ b/src/dbus_info.h
@@ -13,6 +13,8 @@
 #include <mutex>
 #include "loaders/loader_dbus.h"
 
+typedef std::unordered_map<std::string, std::string> string_map;
+
 struct metadata {
     //std::vector<std::string> artists;
     std::string artists; // pre-concatenate
@@ -61,7 +63,6 @@ struct DBusSignal
 };
 
 extern struct metadata main_metadata;
-extern struct metadata generic_mpris;
 
 namespace dbusmgr {
     using callback_func = std::function<void(/*metadata*/)>;
@@ -72,21 +73,6 @@ namespace dbusmgr {
         CB_NEW_METADATA,
     };
 
-/*    class dbus_error : public std::runtime_error
-    {
-    public:
-        dbus_error(libdbus_loader& dbus_, DBusError *src) : std::runtime_error(src->message)
-        {
-            dbus = &dbus_;
-            dbus->error_init(&error);
-            dbus->move_error (src, &error);
-        }
-        virtual ~dbus_error() { dbus->error_free (&error); }
-    private:
-        DBusError error;
-        libdbus_loader *dbus;
-    };*/
-
     class dbus_manager
     {
     public:
@@ -96,8 +82,9 @@ namespace dbusmgr {
 
         ~dbus_manager();
 
-        bool init(const std::string& dest);
+        bool init(const std::string& requested_player);
         void deinit();
+        bool get_media_player_metadata(metadata& meta, std::string name = "");
         void add_callback(CBENUM type, callback_func func);
         void connect_to_signals();
         void disconnect_from_signals();
@@ -113,7 +100,10 @@ namespace dbusmgr {
     protected:
         void stop_thread();
         void start_thread();
-        static void dbus_thread(dbus_manager *pmgr);
+        void dbus_thread();
+
+        bool dbus_list_name_to_owner();
+        bool select_active_player();
 
         DBusError m_error;
         DBusConnection * m_dbus_conn = nullptr;
@@ -125,7 +115,10 @@ namespace dbusmgr {
         std::map<CBENUM, callback_func> m_callbacks;
         libdbus_loader m_dbus_ldr;
         std::unordered_map<std::string, std::string> m_name_owners;
-        std::string m_dest;
+        std::string m_requested_player;
+        std::string m_active_player; 
+
+
 
         const std::array<DBusSignal, 2> m_signals {{
             { "org.freedesktop.DBus", "NameOwnerChanged", ST_NAMEOWNERCHANGED },
@@ -137,6 +130,10 @@ namespace dbusmgr {
     extern dbus_manager dbus_mgr;
 }
 
+<<<<<<< HEAD
 bool get_media_player_metadata(dbusmgr::dbus_manager& dbus, const std::string& name, metadata& meta);
 
 #endif //MANGOHUD_DBUS_INFO_H
+=======
+//bool get_media_player_metadata(dbusmgr::dbus_manager& dbus, const std::string& name, metadata& meta);
+>>>>>>> 9c064df... Change the media player functionality to allow changing active media

--- a/src/dbus_info.h
+++ b/src/dbus_info.h
@@ -13,8 +13,6 @@
 #include <mutex>
 #include "loaders/loader_dbus.h"
 
-typedef std::unordered_map<std::string, std::string> string_map;
-
 struct metadata {
     //std::vector<std::string> artists;
     std::string artists; // pre-concatenate
@@ -23,17 +21,7 @@ struct metadata {
     std::string something;
     std::string artUrl;
     bool playing = false;
-    struct {
-        float pos;
-        float longest;
-        int dir = -1;
-        bool needs_recalc;
-
-        float tw0;
-        float tw1;
-        float tw2;
-    } ticker;
-
+    
     bool valid = false;
     bool got_song_data = false;
     bool got_playback_data = false;
@@ -44,8 +32,6 @@ struct metadata {
         title.clear();
         album.clear();
         artUrl.clear();
-        ticker = {};
-        ticker.dir = -1;
         valid = false;
     }
 };
@@ -53,6 +39,16 @@ struct metadata {
 struct mutexed_metadata {
     std::mutex mtx;
     metadata meta;
+    struct {
+        float pos;
+        float longest;
+        int dir = -1;
+        bool needs_recalc = true;
+
+        float tw0;
+        float tw1;
+        float tw2;
+    } ticker;
 };
 
 enum SignalType
@@ -114,7 +110,7 @@ namespace dbusmgr {
         void dbus_thread();
 
         bool dbus_list_name_to_owner();
-        bool select_active_player();
+        bool select_active_player(metadata* meta = nullptr);
 
         static DBusHandlerResult filter_signals(DBusConnection*, DBusMessage*, void*);
 

--- a/src/loaders/loader_dbus.cpp
+++ b/src/loaders/loader_dbus.cpp
@@ -63,6 +63,14 @@ bool libdbus_loader::Load(const std::string& library_name) {
     return false;
   }
 
+  connection_add_filter =
+      reinterpret_cast<decltype(this->connection_add_filter)>(
+          dlsym(library_, "dbus_connection_add_filter"));
+  if (!connection_add_filter) {
+    CleanUp(true);
+    return false;
+  }
+
   connection_pop_message =
       reinterpret_cast<decltype(this->connection_pop_message)>(
           dlsym(library_, "dbus_connection_pop_message"));
@@ -75,6 +83,22 @@ bool libdbus_loader::Load(const std::string& library_name) {
       reinterpret_cast<decltype(this->connection_read_write)>(
           dlsym(library_, "dbus_connection_read_write"));
   if (!connection_read_write) {
+    CleanUp(true);
+    return false;
+  }
+
+  connection_read_write_dispatch =
+      reinterpret_cast<decltype(this->connection_read_write)>(
+          dlsym(library_, "dbus_connection_read_write_dispatch"));
+  if (!connection_read_write_dispatch) {
+    CleanUp(true);
+    return false;
+  }
+
+  connection_remove_filter =
+      reinterpret_cast<decltype(this->connection_remove_filter)>(
+          dlsym(library_, "dbus_connection_remove_filter"));
+  if (!connection_remove_filter) {
     CleanUp(true);
     return false;
   }
@@ -123,6 +147,22 @@ bool libdbus_loader::Load(const std::string& library_name) {
       reinterpret_cast<decltype(this->message_append_args)>(
           dlsym(library_, "dbus_message_append_args"));
   if (!message_append_args) {
+    CleanUp(true);
+    return false;
+  }
+
+  message_get_interface =
+      reinterpret_cast<decltype(this->message_get_interface)>(
+          dlsym(library_, "dbus_message_get_interface"));
+  if (!message_get_interface) {
+    CleanUp(true);
+    return false;
+  }
+
+  message_get_member =
+      reinterpret_cast<decltype(this->message_get_member)>(
+          dlsym(library_, "dbus_message_get_member"));
+  if (!message_get_member) {
     CleanUp(true);
     return false;
   }

--- a/src/loaders/loader_dbus.h
+++ b/src/loaders/loader_dbus.h
@@ -24,14 +24,20 @@ class libdbus_loader {
   decltype(&::dbus_bus_get) bus_get;
   decltype(&::dbus_bus_get_unique_name) bus_get_unique_name;
   decltype(&::dbus_bus_remove_match) bus_remove_match;
+  decltype(&::dbus_connection_add_filter) connection_add_filter;
   decltype(&::dbus_connection_pop_message) connection_pop_message;
   decltype(&::dbus_connection_read_write) connection_read_write;
+  decltype(&::dbus_connection_read_write_dispatch) connection_read_write_dispatch;
+  decltype(&::dbus_connection_remove_filter) connection_remove_filter;
   decltype(&::dbus_connection_send_with_reply_and_block) connection_send_with_reply_and_block;
   decltype(&::dbus_connection_unref) connection_unref;
   decltype(&::dbus_error_free) error_free;
   decltype(&::dbus_error_init) error_init;
   decltype(&::dbus_error_is_set) error_is_set;
   decltype(&::dbus_message_append_args) message_append_args;
+  decltype(&::dbus_message_get_sender) message_get_sender;
+  decltype(&::dbus_message_get_interface) message_get_interface;
+  decltype(&::dbus_message_get_member) message_get_member;
   decltype(&::dbus_message_is_signal) message_is_signal;
   decltype(&::dbus_message_iter_get_arg_type) message_iter_get_arg_type;
   decltype(&::dbus_message_iter_get_basic) message_iter_get_basic;
@@ -42,7 +48,6 @@ class libdbus_loader {
   decltype(&::dbus_message_unref) message_unref;
   decltype(&::dbus_move_error) move_error;
   decltype(&::dbus_threads_init_default) threads_init_default;
-  decltype(&::dbus_message_get_sender) message_get_sender;
 
 
  private:

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -971,18 +971,18 @@ float get_ticker_limited_pos(float pos, float tw, float& left_limit, float& righ
 }
 
 #ifdef HAVE_DBUS
-static void render_mpris_metadata(struct overlay_params& params, metadata& meta, uint64_t frame_timing, bool is_main)
+static void render_mpris_metadata(struct overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing, bool is_main)
 {
-   if (meta.valid) {
+   if (meta.meta.valid) {
       auto color = ImGui::ColorConvertU32ToFloat4(params.media_player_color);
       ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8,0));
       ImGui::Dummy(ImVec2(0.0f, 20.0f));
       //ImGui::PushFont(data.font1);
 
       if (meta.ticker.needs_recalc) {
-         meta.ticker.tw0 = ImGui::CalcTextSize(meta.title.c_str()).x;
-         meta.ticker.tw1 = ImGui::CalcTextSize(meta.artists.c_str()).x;
-         meta.ticker.tw2 = ImGui::CalcTextSize(meta.album.c_str()).x;
+         meta.ticker.tw0 = ImGui::CalcTextSize(meta.meta.title.c_str()).x;
+         meta.ticker.tw1 = ImGui::CalcTextSize(meta.meta.artists.c_str()).x;
+         meta.ticker.tw2 = ImGui::CalcTextSize(meta.meta.album.c_str()).x;
          meta.ticker.longest = std::max(std::max(
                meta.ticker.tw0,
                meta.ticker.tw1),
@@ -1009,23 +1009,23 @@ static void render_mpris_metadata(struct overlay_params& params, metadata& meta,
             {
                new_pos = get_ticker_limited_pos(meta.ticker.pos, meta.ticker.tw0, left_limit, right_limit);
                ImGui::SetCursorPosX(new_pos);
-               ImGui::TextColored(color, "%s", meta.title.c_str());
+               ImGui::TextColored(color, "%s", meta.meta.title.c_str());
             }
             break;
             case MP_ORDER_ARTIST:
             {
                new_pos = get_ticker_limited_pos(meta.ticker.pos, meta.ticker.tw1, left_limit, right_limit);
                ImGui::SetCursorPosX(new_pos);
-               ImGui::TextColored(color, "%s", meta.artists.c_str());
+               ImGui::TextColored(color, "%s", meta.meta.artists.c_str());
             }
             break;
             case MP_ORDER_ALBUM:
             {
                //ImGui::NewLine();
-               if (!meta.album.empty()) {
+               if (!meta.meta.album.empty()) {
                   new_pos = get_ticker_limited_pos(meta.ticker.pos, meta.ticker.tw2, left_limit, right_limit);
                   ImGui::SetCursorPosX(new_pos);
-                  ImGui::TextColored(color, "%s", meta.album.c_str());
+                  ImGui::TextColored(color, "%s", meta.meta.album.c_str());
                }
             }
             break;
@@ -1033,7 +1033,7 @@ static void render_mpris_metadata(struct overlay_params& params, metadata& meta,
          }
       }
 
-      if (!meta.playing) {
+      if (!meta.meta.playing) {
          ImGui::TextColored(color, "(paused)");
       }
 
@@ -1385,7 +1385,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
       ImGui::PushFont(&scaled_font);
       {
          std::lock_guard<std::mutex> lck(main_metadata.mtx);
-         render_mpris_metadata(params, main_metadata.meta, frame_timing, true);
+         render_mpris_metadata(params, main_metadata, frame_timing, true);
       }
       //render_mpris_metadata(params, generic_mpris, frame_timing, false);
       ImGui::PopFont();

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -1385,7 +1385,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
       scaled_font.Scale = params.font_scale_media_player;
       ImGui::PushFont(&scaled_font);
       render_mpris_metadata(params, main_metadata, frame_timing, true);
-      render_mpris_metadata(params, generic_mpris, frame_timing, false);
+      //render_mpris_metadata(params, generic_mpris, frame_timing, false);
       ImGui::PopFont();
 #endif
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -532,18 +532,13 @@ parse_overlay_config(struct overlay_params *params,
          std::lock_guard<std::mutex> lk(main_metadata.mutex);
          main_metadata.clear();
       }
-      {
-         std::lock_guard<std::mutex> lk(generic_mpris.mutex);
-         generic_mpris.clear();
-      }
       if (dbusmgr::dbus_mgr.init(params->media_player_name)) {
-         if (!get_media_player_metadata(dbusmgr::dbus_mgr, params->media_player_name, main_metadata))
+         if (!dbusmgr::dbus_mgr.get_media_player_metadata(main_metadata))
             std::cerr << "MANGOHUD: Failed to get initial media player metadata." << std::endl;
       }
    } else {
       dbusmgr::dbus_mgr.deinit();
       main_metadata.valid = false;
-      generic_mpris.valid = false;
    }
 #endif
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -529,16 +529,13 @@ parse_overlay_config(struct overlay_params *params,
    if (params->enabled[OVERLAY_PARAM_ENABLED_media_player]) {
       // lock mutexes for config file change notifier thread
       {
-         std::lock_guard<std::mutex> lk(main_metadata.mutex);
-         main_metadata.clear();
+         std::lock_guard<std::mutex> lk(main_metadata.mtx);
+         main_metadata.meta.clear();
       }
-      if (dbusmgr::dbus_mgr.init(params->media_player_name)) {
-         if (!dbusmgr::dbus_mgr.get_media_player_metadata(main_metadata))
-            std::cerr << "MANGOHUD: Failed to get initial media player metadata." << std::endl;
-      }
+      dbusmgr::dbus_mgr.init(params->media_player_name);
    } else {
       dbusmgr::dbus_mgr.deinit();
-      main_metadata.valid = false;
+      main_metadata.meta.valid = false;
    }
 #endif
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -423,7 +423,7 @@ parse_overlay_config(struct overlay_params *params,
    params->background_color = 0x020202;
    params->text_color = 0xffffff;
    params->media_player_color = 0xffffff;
-   params->media_player_name = "spotify";
+   params->media_player_name = "";
    params->font_scale = 1.0f;
    params->font_scale_media_player = 0.55f;
    params->log_interval = 100;


### PR DESCRIPTION
#254
This is a draft, because I don't think we've reached a consensus what the media player functionality should look like. 
Right now, this PR removes the secondary media player display and lets MangoHud switch between media players.
`media_player_name` acts as a preferred media player. If that media player isn't running, any active one will be chosen.