### PR TITLE
General cleanup

### DIFF
--- a/src/blacklist.h
+++ b/src/blacklist.h
@@ -1,3 +1,7 @@
 #pragma once
+#ifndef MANGOHUD_BLACKLIST_H
+#define MANGOHUD_BLACKLIST_H
 
 bool is_blacklisted(bool force_recheck = false);
+
+#endif //MANGOHUD_BLACKLIST_H

--- a/src/config.h
+++ b/src/config.h
@@ -1,4 +1,8 @@
 #pragma once
+#ifndef MANGOHUD_CONFIG_H
+#define MANGOHUD_CONFIG_H
 
 #include "overlay_params.h"
 void parseConfigFile(overlay_params& p);
+
+#endif //MANGOHUD_CONFIG_H

--- a/src/config.h
+++ b/src/config.h
@@ -1,2 +1,4 @@
+#pragma once
+
 #include "overlay_params.h"
 void parseConfigFile(overlay_params& p);

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -28,26 +28,26 @@
 #include "file_utils.h"
 
 void calculateCPUData(CPUData& cpuData,
-    uint64_t usertime,
-    uint64_t nicetime,
-    uint64_t systemtime,
-    uint64_t idletime,
-    uint64_t ioWait,
-    uint64_t irq,
-    uint64_t softIrq,
-    uint64_t steal,
-    uint64_t guest,
-    uint64_t guestnice)
+    unsigned long long int usertime,
+    unsigned long long int nicetime,
+    unsigned long long int systemtime,
+    unsigned long long int idletime,
+    unsigned long long int ioWait,
+    unsigned long long int irq,
+    unsigned long long int softIrq,
+    unsigned long long int steal,
+    unsigned long long int guest,
+    unsigned long long int guestnice)
 {
     // Guest time is already accounted in usertime
     usertime = usertime - guest;
     nicetime = nicetime - guestnice;
     // Fields existing on kernels >= 2.6
     // (and RHEL's patched kernel 2.4...)
-    uint64_t idlealltime = idletime + ioWait;
-    uint64_t systemalltime = systemtime + irq + softIrq;
-    uint64_t virtalltime = guest + guestnice;
-    uint64_t totaltime = usertime + nicetime + systemalltime + idlealltime + steal + virtalltime;
+    unsigned long long int idlealltime = idletime + ioWait;
+    unsigned long long int systemalltime = systemtime + irq + softIrq;
+    unsigned long long int virtalltime = guest + guestnice;
+    unsigned long long int totaltime = usertime + nicetime + systemalltime + idlealltime + steal + virtalltime;
 
     // Since we do a subtraction (usertime - guest) and cputime64_to_clock_t()
     // used in /proc/stat rounds down numbers, it can lead to a case where the
@@ -154,8 +154,8 @@ bool CPUStats::Init()
 //TODO take sampling interval into account?
 bool CPUStats::UpdateCPUData()
 {
-    uint64_t usertime, nicetime, systemtime, idletime;
-    uint64_t ioWait, irq, softIrq, steal, guest, guestnice;
+    unsigned long long int usertime, nicetime, systemtime, idletime;
+    unsigned long long int ioWait, irq, softIrq, steal, guest, guestnice;
     int cpuid = -1;
 
     if (!m_inited)

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -28,26 +28,26 @@
 #include "file_utils.h"
 
 void calculateCPUData(CPUData& cpuData,
-    unsigned long long int usertime,
-    unsigned long long int nicetime,
-    unsigned long long int systemtime,
-    unsigned long long int idletime,
-    unsigned long long int ioWait,
-    unsigned long long int irq,
-    unsigned long long int softIrq,
-    unsigned long long int steal,
-    unsigned long long int guest,
-    unsigned long long int guestnice)
+    uint64_t usertime,
+    uint64_t nicetime,
+    uint64_t systemtime,
+    uint64_t idletime,
+    uint64_t ioWait,
+    uint64_t irq,
+    uint64_t softIrq,
+    uint64_t steal,
+    uint64_t guest,
+    uint64_t guestnice)
 {
     // Guest time is already accounted in usertime
     usertime = usertime - guest;
     nicetime = nicetime - guestnice;
     // Fields existing on kernels >= 2.6
     // (and RHEL's patched kernel 2.4...)
-    unsigned long long int idlealltime = idletime + ioWait;
-    unsigned long long int systemalltime = systemtime + irq + softIrq;
-    unsigned long long int virtalltime = guest + guestnice;
-    unsigned long long int totaltime = usertime + nicetime + systemalltime + idlealltime + steal + virtalltime;
+    uint64_t idlealltime = idletime + ioWait;
+    uint64_t systemalltime = systemtime + irq + softIrq;
+    uint64_t virtalltime = guest + guestnice;
+    uint64_t totaltime = usertime + nicetime + systemalltime + idlealltime + steal + virtalltime;
 
     // Since we do a subtraction (usertime - guest) and cputime64_to_clock_t()
     // used in /proc/stat rounds down numbers, it can lead to a case where the
@@ -154,8 +154,8 @@ bool CPUStats::Init()
 //TODO take sampling interval into account?
 bool CPUStats::UpdateCPUData()
 {
-    unsigned long long int usertime, nicetime, systemtime, idletime;
-    unsigned long long int ioWait, irq, softIrq, steal, guest, guestnice;
+    uint64_t usertime, nicetime, systemtime, idletime;
+    uint64_t ioWait, irq, softIrq, steal, guest, guestnice;
     int cpuid = -1;
 
     if (!m_inited)

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -7,31 +7,31 @@
 #include <cstdio>
 
 typedef struct CPUData_ {
-   uint64_t totalTime;
-   uint64_t userTime;
-   uint64_t systemTime;
-   uint64_t systemAllTime;
-   uint64_t idleAllTime;
-   uint64_t idleTime;
-   uint64_t niceTime;
-   uint64_t ioWaitTime;
-   uint64_t irqTime;
-   uint64_t softIrqTime;
-   uint64_t stealTime;
-   uint64_t guestTime;
+   unsigned long long int totalTime;
+   unsigned long long int userTime;
+   unsigned long long int systemTime;
+   unsigned long long int systemAllTime;
+   unsigned long long int idleAllTime;
+   unsigned long long int idleTime;
+   unsigned long long int niceTime;
+   unsigned long long int ioWaitTime;
+   unsigned long long int irqTime;
+   unsigned long long int softIrqTime;
+   unsigned long long int stealTime;
+   unsigned long long int guestTime;
 
-   uint64_t totalPeriod;
-   uint64_t userPeriod;
-   uint64_t systemPeriod;
-   uint64_t systemAllPeriod;
-   uint64_t idleAllPeriod;
-   uint64_t idlePeriod;
-   uint64_t nicePeriod;
-   uint64_t ioWaitPeriod;
-   uint64_t irqPeriod;
-   uint64_t softIrqPeriod;
-   uint64_t stealPeriod;
-   uint64_t guestPeriod;
+   unsigned long long int totalPeriod;
+   unsigned long long int userPeriod;
+   unsigned long long int systemPeriod;
+   unsigned long long int systemAllPeriod;
+   unsigned long long int idleAllPeriod;
+   unsigned long long int idlePeriod;
+   unsigned long long int nicePeriod;
+   unsigned long long int ioWaitPeriod;
+   unsigned long long int irqPeriod;
+   unsigned long long int softIrqPeriod;
+   unsigned long long int stealPeriod;
+   unsigned long long int guestPeriod;
    float percent;
    int mhz;
    int temp;
@@ -61,7 +61,7 @@ public:
       return m_cpuDataTotal;
    }
 private:
-   uint64_t m_boottime = 0;
+   unsigned long long int m_boottime = 0;
    std::vector<CPUData> m_cpuData;
    CPUData m_cpuDataTotal {};
    std::vector<int> m_coreMhz;

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -1,33 +1,37 @@
+#pragma once
+#ifndef MANGOHUD_CPU_H
+#define MANGOHUD_CPU_H
+
 #include <vector>
 #include <cstdint>
 #include <cstdio>
 
 typedef struct CPUData_ {
-   unsigned long long int totalTime;
-   unsigned long long int userTime;
-   unsigned long long int systemTime;
-   unsigned long long int systemAllTime;
-   unsigned long long int idleAllTime;
-   unsigned long long int idleTime;
-   unsigned long long int niceTime;
-   unsigned long long int ioWaitTime;
-   unsigned long long int irqTime;
-   unsigned long long int softIrqTime;
-   unsigned long long int stealTime;
-   unsigned long long int guestTime;
+   uint64_t totalTime;
+   uint64_t userTime;
+   uint64_t systemTime;
+   uint64_t systemAllTime;
+   uint64_t idleAllTime;
+   uint64_t idleTime;
+   uint64_t niceTime;
+   uint64_t ioWaitTime;
+   uint64_t irqTime;
+   uint64_t softIrqTime;
+   uint64_t stealTime;
+   uint64_t guestTime;
 
-   unsigned long long int totalPeriod;
-   unsigned long long int userPeriod;
-   unsigned long long int systemPeriod;
-   unsigned long long int systemAllPeriod;
-   unsigned long long int idleAllPeriod;
-   unsigned long long int idlePeriod;
-   unsigned long long int nicePeriod;
-   unsigned long long int ioWaitPeriod;
-   unsigned long long int irqPeriod;
-   unsigned long long int softIrqPeriod;
-   unsigned long long int stealPeriod;
-   unsigned long long int guestPeriod;
+   uint64_t totalPeriod;
+   uint64_t userPeriod;
+   uint64_t systemPeriod;
+   uint64_t systemAllPeriod;
+   uint64_t idleAllPeriod;
+   uint64_t idlePeriod;
+   uint64_t nicePeriod;
+   uint64_t ioWaitPeriod;
+   uint64_t irqPeriod;
+   uint64_t softIrqPeriod;
+   uint64_t stealPeriod;
+   uint64_t guestPeriod;
    float percent;
    int mhz;
    int temp;
@@ -57,7 +61,7 @@ public:
       return m_cpuDataTotal;
    }
 private:
-   unsigned long long int m_boottime = 0;
+   uint64_t m_boottime = 0;
    std::vector<CPUData> m_cpuData;
    CPUData m_cpuDataTotal {};
    std::vector<int> m_coreMhz;
@@ -68,3 +72,5 @@ private:
 };
 
 extern CPUStats cpuStats;
+
+#endif //MANGOHUD_CPU_H

--- a/src/dbus_info.h
+++ b/src/dbus_info.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef MANGOHUD_DBUS_INFO_H
+#define MANGOHUD_DBUS_INFO_H
+
 #include <array>
 #include <stdexcept>
 #include <thread>
@@ -135,3 +138,5 @@ namespace dbusmgr {
 }
 
 bool get_media_player_metadata(dbusmgr::dbus_manager& dbus, const std::string& name, metadata& meta);
+
+#endif //MANGOHUD_DBUS_INFO_H

--- a/src/file_utils.h
+++ b/src/file_utils.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef MANGOHUD_FILE_UTILS_H
+#define MANGOHUD_FILE_UTILS_H
+
 #include <string>
 #include <vector>
 
@@ -21,3 +24,5 @@ bool get_wine_exe_name(std::string& name, bool keep_ext = false);
 std::string get_home_dir();
 std::string get_data_dir();
 std::string get_config_dir();
+
+#endif //MANGOHUD_FILE_UTILS_H

--- a/src/font_default.h
+++ b/src/font_default.h
@@ -1,5 +1,6 @@
-#ifndef FONT_DEFAULT_H
-#define FONT_DEFAULT_H
+#pragma once
+#ifndef MANGOHUD_FONT_DEFAULT_H
+#define MANGOHUD_FONT_DEFAULT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -11,4 +12,4 @@ const char* GetDefaultCompressedFontDataTTFBase85(void);
 }
 #endif
 
-#endif
+#endif // MANGOHUD_FONT_DEFAULT_H

--- a/src/gl/gl.h
+++ b/src/gl/gl.h
@@ -1,8 +1,10 @@
 #pragma once
+#ifndef MANGOHUD_GL_GL_H
+#define MANGOHUD_GL_GL_H
 
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif //__cplusplus
 
 void * glXCreateContext(void *, void *, void *, int);
 void glXDestroyContext(void *, void*);
@@ -24,4 +26,6 @@ unsigned int eglSwapBuffers( void*, void* );
 
 #ifdef __cplusplus
 }
-#endif
+#endif //__cplusplus
+
+#endif //MANGOHUD_GL_GL_H

--- a/src/gl/imgui_hud.h
+++ b/src/gl/imgui_hud.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef MANGOHUD_GL_IMGUI_HUD_H
+#define MANGOHUD_GL_IMGUI_HUD_H
 
 #include "overlay.h"
 #include "imgui_impl_opengl3.h"
@@ -13,3 +15,5 @@ void imgui_set_context(void *ctx);
 void imgui_render(unsigned int width, unsigned int height);
 
 }} // namespace
+
+#endif //MANGOHUD_GL_IMGUI_HUD_H

--- a/src/gl/imgui_impl_opengl3.h
+++ b/src/gl/imgui_impl_opengl3.h
@@ -22,6 +22,8 @@
 //  Only override if your GL version doesn't handle this GLSL version. See GLSL version table at the top of imgui_impl_opengl3.cpp.
 
 #pragma once
+#ifndef MANGOHUD_IMGUI_IMPL_OPENGL3_H
+#define MANGOHUD_IMGUI_IMPL_OPENGL3_H
 
 namespace MangoHud {
 
@@ -40,3 +42,5 @@ IMGUI_IMPL_API void     ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data);
 //IMGUI_IMPL_API void     ImGui_ImplOpenGL3_DestroyDeviceObjects();
 
 }
+
+#endif //MANGOHUD_IMGUI_IMPL_OPENGL3_H

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef MANGOHUD_GPU_H
+#define MANGOHUD_GPU_H
+
 #include <thread>
 #include <inttypes.h>
 #include <stdlib.h>
@@ -34,3 +38,5 @@ extern struct gpuInfo gpu_info;
 
 void getNvidiaGpuInfo(void);
 void getAmdGpuInfo(void);
+
+#endif //MANGOHUD_GPU_H

--- a/src/iostats.h
+++ b/src/iostats.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef MANGOHUD_IOSTATS_H
+#define MANGOHUD_IOSTATS_H
+
 #include <pthread.h>
 #include <inttypes.h>
 
@@ -18,3 +21,5 @@ struct iostats {
 };
 
 void getIoStats(void *args);
+
+#endif //MANGOHUD_IOSTATS_H

--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef MANGOHUD_KEYBINDS_H
+#define MANGOHUD_KEYBINDS_H
+
 #include "shared_x11.h"
 #include "loaders/loader_x11.h"
 
@@ -34,4 +37,6 @@ bool keys_are_pressed(const std::vector<KeySym>& keys) {
 
     return false;
 }
-#endif
+#endif //HAVE_X11
+
+#endif //MANGOHUD_KEYBINDS_H

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef MANGOHUD_LOGGING_H
+#define MANGOHUD_LOGGING_H
+
 #include <iostream>
 #include <vector>
 #include <fstream>
@@ -67,3 +71,5 @@ extern double fps;
 extern logData currentLogData;
 
 string exec(string command);
+
+#endif //MANGOHUD_LOGGING_H

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef MANGOHUD_MEMORY_H
+#define MANGOHUD_MEMORY_H
+
 #include <stdio.h>
 #include <thread>
 
@@ -13,3 +17,5 @@ struct memory_information {
 
 void update_meminfo(void);
 FILE *open_file(const char *file, int *reported);
+
+#endif //MANGOHUD_MEMORY_H

--- a/src/notify.h
+++ b/src/notify.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef MANGOHUD_NOTIFY_H
+#define MANGOHUD_NOTIFY_H
+
 #include <thread>
 #include <mutex>
 #include "overlay_params.h"
@@ -13,3 +17,5 @@ struct notify_thread
 
 bool start_notifier(notify_thread& nt);
 void stop_notifier(notify_thread& nt);
+
+#endif //MANGOHUD_NOTIFY_H

--- a/src/nvctrl.h
+++ b/src/nvctrl.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef MANGOHUD_NVCTRL_H
+#define MANGOHUD_NVCTRL_H
+
 struct nvctrlInfo{
     int load;
     int temp;
@@ -12,3 +16,5 @@ extern bool nvctrlSuccess;
 bool checkXNVCtrl(void);
 void getNvctrlInfo(void);
 char *get_attr_target_string(int attr, int target_type, int target_id);
+
+#endif //MANGOHUD_NVCTRL_H

--- a/src/nvidia_info.h
+++ b/src/nvidia_info.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef MANGOHUD_NVIDIA_INFO_H
+#define MANGOHUD_NVIDIA_INFO_H
+
 #include <nvml.h>
 
 extern nvmlReturn_t result;
@@ -9,3 +13,5 @@ extern bool nvmlSuccess;
 
 bool checkNVML(const char* pciBusId);
 bool getNVMLInfo(void);
+
+#endif //MANGOHUD_NVIDIA_INFO_H

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -79,21 +79,8 @@ struct benchmark_stats benchmark;
 struct instance_data {
    struct vk_instance_dispatch_table vtable;
    VkInstance instance;
-
    struct overlay_params params;
-
    uint32_t api_version;
-
-   bool first_line_printed;
-
-   int control_client;
-
-   /* Dumping of frame stats to a file has been enabled. */
-   bool capture_enabled;
-
-   /* Dumping of frame stats to a file has been enabled and started. */
-   bool capture_started;
-
    string engineName, engineVersion;
    notify_thread notifier;
 };
@@ -192,23 +179,7 @@ struct swapchain_data {
    ImGuiContext* imgui_context;
    ImVec2 window_size;
 
-   /**/
-   uint64_t last_present_time;
-
-   unsigned n_frames_since_update;
-   uint64_t last_fps_update;
-   double frametime;
-   double frametimeDisplay;
-   const char* cpuString;
-   const char* gpuString;
-
    struct swapchain_stats sw_stats;
-
-   /* Over a single frame */
-   struct frame_stat frame_stats;
-
-   /* Over fps_sampling_period */
-   struct frame_stat accumulated_stats;
 };
 
 // single global lock, for simplicity
@@ -358,7 +329,6 @@ static struct instance_data *new_instance_data(VkInstance instance)
 {
    struct instance_data *data = new instance_data();
    data->instance = instance;
-   data->control_client = -1;
    data->params = {};
    data->params.control = -1;
    map_object(HKEY(data->instance), data);

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef MANGOHUD_OVERLAY_H
+#define MANGOHUD_OVERLAY_H
 
 #include <string>
 #include <stdint.h>
@@ -81,3 +83,5 @@ void imgui_custom_style(struct overlay_params& params);
 void get_device_name(int32_t vendorID, int32_t deviceID, struct swapchain_stats& sw_stats);
 void calculate_benchmark_data(void);
 void create_fonts(const overlay_params& params, ImFont*& small_font, ImFont*& text_font);
+
+#endif //MANGOHUD_OVERLAY_H

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -1,5 +1,6 @@
-#ifndef OVERLAY_PARAMS_H
-#define OVERLAY_PARAMS_H
+#pragma once
+#ifndef MANGOHUD_OVERLAY_PARAMS_H
+#define MANGOHUD_OVERLAY_PARAMS_H
 
 #include <string>
 #include <vector>
@@ -189,4 +190,4 @@ void parse_overlay_config(struct overlay_params *params,
 }
 #endif
 
-#endif /* OVERLAY_PARAMS_H */
+#endif /* MANGOHUD_OVERLAY_PARAMS_H */

--- a/src/pci_ids.h
+++ b/src/pci_ids.h
@@ -1,3 +1,7 @@
+#pragma once
+#ifndef MANGOHUD_PCI_IDS_H
+#define MANGOHUD_PCI_IDS_H
+
 #include <map>
 #include <vector>
 
@@ -17,3 +21,5 @@ struct device
 extern std::map<uint32_t /*vendor id*/, std::pair<std::string /*vendor desc*/, std::map<uint32_t /*device id*/, device>>> pci_ids;
 
 void parse_pciids(void);
+
+#endif //MANGOHUD_PCI_IDS_H

--- a/src/real_dlsym.h
+++ b/src/real_dlsym.h
@@ -1,7 +1,11 @@
 #pragma once
+#ifndef MANGOHUD_REAL_DLSYM_H
+#define MANGOHUD_REAL_DLSYM_H
 
 #define EXPORT_C_(type) extern "C" __attribute__((__visibility__("default"))) type
 
 void *real_dlopen(const char *filename, int flag);
 void* real_dlsym( void*, const char* );
 void* get_proc_address(const char* name);
+
+#endif //MANGOHUD_REAL_DLSYM_H

--- a/src/shared_x11.h
+++ b/src/shared_x11.h
@@ -1,5 +1,10 @@
 #pragma once
+#ifndef MANGOHUD_SHARED_X11_H
+#define MANGOHUD_SHARED_X11_H
+
 #include <X11/Xlib.h>
 
 Display* get_xdisplay();
 bool init_x11();
+
+#endif //MANGOHUD_SHARED_X11_H

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef MANGOHUD_STRING_UTILS_H
+#define MANGOHUD_STRING_UTILS_H
+
 #include <string>
 #include <iomanip>
 #include <iostream>
@@ -107,3 +110,5 @@ static float parse_float(const std::string& s, std::size_t* float_len = nullptr)
 }
 
 #pragma GCC diagnostic pop
+
+#endif //MANGOHUD_STRING_UTILS_H

--- a/src/timing.hpp
+++ b/src/timing.hpp
@@ -1,5 +1,7 @@
+#pragma once
 #ifndef MANGOHUD_TIMING_HPP
 #define MANGOHUD_TIMING_HPP
+
 #include <chrono>
 
 #include "mesa/util/os_time.h"
@@ -17,4 +19,5 @@ public:
 };
 
 using Clock = MesaClock;
+
 #endif //MANGOHUD_TIMING_HPP


### PR DESCRIPTION
I removed some of the field in the structs in `overlay.cpp` that were literally never referenced. 
I also added consistent include guards to the header files. Since both C-style guards and `#pragma`s were in use, I just added both to all headers.