### PR TITLE
Fix meson.build version

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('MangoHud',
   ['c', 'cpp'],
-  version : 'v0.4.0',
+  version : 'v0.5.1',
   license : 'MIT',
   default_options : ['buildtype=release', 'c_std=c99', 'cpp_std=c++14']
 )


### PR DESCRIPTION
You forgot to update the version on meson.build file :P it prints "MangoHud v0.4.0" when building, which is misleading.