### PR TITLE
Toggle betwen fps_limit and unlimited or alternate fps limit via hotkey

### DIFF
--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -9,7 +9,7 @@
 typedef unsigned long KeySym;
 #endif
 
-Clock::time_point last_f2_press, last_f12_press, reload_cfg_press, last_upload_press;
+Clock::time_point last_f2_press, last_f3_press , last_f12_press, reload_cfg_press, last_upload_press;
 
 #ifdef HAVE_X11
 bool keys_are_pressed(const std::vector<KeySym>& keys) {

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -798,6 +798,7 @@ void check_keybinds(struct swapchain_stats& sw_stats, struct overlay_params& par
    bool pressed = false; // FIXME just a placeholder until wayland support
    auto now = Clock::now(); /* us */
    auto elapsedF2 = now - last_f2_press;
+   auto elapsedF3 = now - last_f3_press;
    auto elapsedF12 = now - last_f12_press;
    auto elapsedReloadCfg = now - reload_cfg_press;
    auto elapsedUpload = now - last_upload_press;
@@ -823,6 +824,22 @@ void check_keybinds(struct swapchain_stats& sw_stats, struct overlay_params& par
          benchmark.fps_data.clear();
        }
      }
+   }
+
+   if (elapsedF3 >= keyPressDelay){
+#ifdef HAVE_X11
+      pressed = keys_are_pressed(params.toggle_fps_limit);
+#else
+      pressed = false;
+#endif
+      if (pressed){
+         last_f3_press = now;
+         if(params.fps_limit > 0 && fps_limit_stats.targetFrameTime == std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(1) / params.fps_limit)){
+            fps_limit_stats.targetFrameTime = {};
+         } else {
+            fps_limit_stats.targetFrameTime = std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(1) / params.fps_limit);
+         }
+      }
    }
 
    if (elapsedF12 >= keyPressDelay){

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -835,7 +835,11 @@ void check_keybinds(struct swapchain_stats& sw_stats, struct overlay_params& par
       if (pressed){
          last_f3_press = now;
          if(params.fps_limit > 0 && fps_limit_stats.targetFrameTime == std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(1) / params.fps_limit)){
-            fps_limit_stats.targetFrameTime = {};
+            if(params.fps_limit_alt > 0) {
+               fps_limit_stats.targetFrameTime = std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(1) / params.fps_limit_alt);
+            } else {
+               fps_limit_stats.targetFrameTime = {};
+            }
          } else {
             fps_limit_stats.targetFrameTime = std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(1) / params.fps_limit);
          }

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -102,6 +102,12 @@ parse_toggle_logging(const char *str)
 }
 
 static std::vector<KeySym>
+parse_toggle_fps_limit(const char *str)
+{
+   return parse_string_to_keysym_vec(str);
+}
+
+static std::vector<KeySym>
 parse_reload_cfg(const char *str)
 {
    return parse_string_to_keysym_vec(str);
@@ -121,6 +127,7 @@ parse_upload_logs(const char *str)
 
 #else
 #define parse_toggle_hud(x)      {}
+#define parse_toggle_fps_limit(x)    {}
 #define parse_toggle_logging(x)  {}
 #define parse_reload_cfg(x)      {}
 #define parse_upload_log(x)      {}
@@ -489,6 +496,7 @@ parse_overlay_config(struct overlay_params *params,
 
 #ifdef HAVE_X11
    params->toggle_hud = { XK_Shift_R, XK_F12 };
+   params->toggle_fps_limit = { XK_Shift_L, XK_F3 };
    params->toggle_logging = { XK_Shift_L, XK_F2 };
    params->reload_cfg = { XK_Shift_L, XK_F4 };
    params->upload_log = { XK_Shift_L, XK_F3 };

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -146,6 +146,12 @@ parse_fps_limit(const char *str)
    return strtol(str, NULL, 0);
 }
 
+static uint32_t
+parse_fps_limit_alt(const char *str)
+{
+   return strtol(str, NULL, 0);
+}
+
 static bool
 parse_no_display(const char *str)
 {
@@ -467,6 +473,7 @@ parse_overlay_config(struct overlay_params *params,
    params->height = 140;
    params->control = -1;
    params->fps_limit = 0;
+   params->fps_limit_alt = 0;
    params->vsync = -1;
    params->gl_vsync = -2;
    params->offset_x = 0;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -66,10 +66,11 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(no_display)                  \
    OVERLAY_PARAM_CUSTOM(control)                     \
    OVERLAY_PARAM_CUSTOM(fps_limit)                   \
+   OVERLAY_PARAM_CUSTOM(fps_limit_alt)               \
    OVERLAY_PARAM_CUSTOM(vsync)                       \
    OVERLAY_PARAM_CUSTOM(gl_vsync)                    \
    OVERLAY_PARAM_CUSTOM(toggle_hud)                  \
-   OVERLAY_PARAM_CUSTOM(toggle_fps_limit)                \
+   OVERLAY_PARAM_CUSTOM(toggle_fps_limit)            \
    OVERLAY_PARAM_CUSTOM(toggle_logging)              \
    OVERLAY_PARAM_CUSTOM(reload_cfg)                  \
    OVERLAY_PARAM_CUSTOM(upload_log)                  \
@@ -150,6 +151,7 @@ struct overlay_params {
    int control;
    uint32_t fps_sampling_period; /* us */
    uint32_t fps_limit;
+   uint32_t fps_limit_alt; 
    bool help;
    bool no_display;
    bool full;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -69,6 +69,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(vsync)                       \
    OVERLAY_PARAM_CUSTOM(gl_vsync)                    \
    OVERLAY_PARAM_CUSTOM(toggle_hud)                  \
+   OVERLAY_PARAM_CUSTOM(toggle_fps_limit)                \
    OVERLAY_PARAM_CUSTOM(toggle_logging)              \
    OVERLAY_PARAM_CUSTOM(reload_cfg)                  \
    OVERLAY_PARAM_CUSTOM(upload_log)                  \
@@ -168,6 +169,7 @@ struct overlay_params {
    float font_scale_media_player;
    float background_alpha, alpha;
    std::vector<KeySym> toggle_hud;
+   std::vector<KeySym> toggle_fps_limit;
    std::vector<KeySym> toggle_logging;
    std::vector<KeySym> reload_cfg;
    std::vector<KeySym> upload_log;


### PR DESCRIPTION
Implemented this to better capture game footage (specifically racing game replays) where I needed stable fps , but I also am not able to close the game itself , so this enables the fps limit on/off functionality or alternate between 2 frame rates e.g. palying the game with `fps_limit` , toggle to `fps_limit_alt` to capture replay etc.

So far no documentation changes and or readme updates because naming/key combo is most probably not final.