### PR TITLE
Add output_folder config option to MangoHud.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,13 @@ All vulkan vsync options might not be supported on your device, you can check wh
 
 ## MangoHud FPS logging
 
-When you toggle logging (using the keybind `Shift_L+F2`), a file is created with your chosen name (using `output_file`) plus a date & timestamp.
+You must set a valid path for `output_folder` in your configuration to store logs in.
 
-This file can be uploaded to [Flightlessmango.com](https://flightlessmango.com/games/user_benchmarks) to create graphs automatically.
-you can share the created page with others, just link it.
+When you toggle logging (using the keybind `Shift_L+F2`), a file is created the game name plus a date & timestamp in your `output_folder`.
+
+Log files can be uploaded to [Flightlessmango.com](https://flightlessmango.com/games/user_benchmarks) to create graphs automatically.
+
+You can share the created page with others, just link it.
 
 #### Multiple log files
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ All vulkan vsync options might not be supported on your device, you can check wh
 
 You must set a valid path for `output_folder` in your configuration to store logs in.
 
-When you toggle logging (using the keybind `Shift_L+F2`), a file is created the game name plus a date & timestamp in your `output_folder`.
+When you toggle logging (using the keybind `Shift_L+F2`), a file is created with the game name plus a date & timestamp in your `output_folder`.
 
 Log files can be uploaded to [Flightlessmango.com](https://flightlessmango.com/games/user_benchmarks) to create graphs automatically.
 

--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -132,6 +132,8 @@ background_alpha=0.5
 # log_duration
 ### Define name and location of the output file (Required for logging)
 # output_file
+### Define folder to put logs in
+# output_folder = /home/<USERNAME>/mangologs
 ### Permit uploading logs directly to Flightlessmango.com
 # permit_upload=1
 ### Define a '+'-separated list of percentiles shown in the benchmark results.

--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -130,9 +130,7 @@ background_alpha=0.5
 
 ### Set amount of time in second that the logging will run for
 # log_duration
-### Define name and location of the output file (Required for logging)
-# output_file
-### Define folder to put logs in
+### Set location of the output files (Required for logging)
 # output_folder = /home/<USERNAME>/mangologs
 ### Permit uploading logs directly to Flightlessmango.com
 # permit_upload=1


### PR DESCRIPTION
I was trying to find the default location where logs were placed, and I checked on your discord and you mentioned on 9/04 that the `output_folder` param must be set. I tried it and it's working now, but I figured it should be added to the default/sample config provided.