### PR TITLE
ensure minihook is not in source tarballs

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -5,6 +5,8 @@ NAME=MangoHud-$VERSION-Source
 
 # create archive via git
 git archive HEAD --format=tar --prefix=${NAME}/ --output=${NAME}.tar
+# remove unused minihook from source tarball
+tar -f ${NAME}.tar --delete ${NAME}/modules
 # create DFSG compliant version which excludes NVML
 cp ${NAME}.tar ${NAME}-DFSG.tar
 tar -f ${NAME}-DFSG.tar --delete ${NAME}/include/nvml.h


### PR DESCRIPTION
Not really required because it isn't really included anyway (because it is a git submodule, git archive won't add it), but just to be sure and to remove the empty folder from the tarball.