### PR TITLE
Change color depending on load

### DIFF
--- a/src/overlay.h
+++ b/src/overlay.h
@@ -57,7 +57,10 @@ struct swapchain_stats {
          background,
          text,
          media_player,
-         wine;
+         wine,
+         gpu_load_high,
+         gpu_load_med,
+         gpu_load_low;
    } colors;
 };
 

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -60,7 +60,10 @@ struct swapchain_stats {
          wine,
          gpu_load_high,
          gpu_load_med,
-         gpu_load_low;
+         gpu_load_low,
+         cpu_load_high,
+         cpu_load_med,
+         cpu_load_low;
    } colors;
 };
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -152,6 +152,19 @@ parse_color(const char *str)
    return strtol(str, NULL, 16);
 }
 
+static std::vector<unsigned>
+parse_load_color(const char *str)
+{
+   std::vector<unsigned> load_colors;
+   std::stringstream ss(str);
+   std::string token;
+   while (std::getline(ss, token, ',')) {
+      trim(token);
+      load_colors.push_back(std::stoi(token, NULL, 16));
+   }
+    return load_colors;
+}
+
 static unsigned
 parse_unsigned(const char *str)
 {
@@ -324,9 +337,7 @@ parse_font_glyph_ranges(const char *str)
 #define parse_text_color(s) parse_color(s)
 #define parse_media_player_color(s) parse_color(s)
 #define parse_wine_color(s) parse_color(s)
-#define parse_gpu_load_high_color(s) parse_color(s)
-#define parse_gpu_load_med_color(s) parse_color(s)
-#define parse_gpu_load_low_color(s) parse_color(s)
+#define parse_gpu_load_color(s) parse_load_color(s)
 #define parse_gpu_load_high(s) parse_unsigned(s)
 #define parse_gpu_load_med(s) parse_unsigned(s)
 #define parse_cpu_load_high_color(s) parse_color(s)
@@ -495,9 +506,7 @@ parse_overlay_config(struct overlay_params *params,
    params->media_player_name = "";
    params->font_scale = 1.0f;
    params->wine_color = 0xeb5b5b;
-   params->gpu_load_high_color = 0xb22222;
-   params->gpu_load_med_color = 0xfdfd09;
-   params->gpu_load_low_color = 0x39f900;
+   params->gpu_load_color = {0xb22222,0xfdfd09,0x39f900};
    params->cpu_load_high_color = 0xb22222;
    params->cpu_load_med_color = 0xfdfd09;
    params->cpu_load_low_color = 0x39f900;
@@ -511,6 +520,7 @@ parse_overlay_config(struct overlay_params *params,
    params->gpu_load_med = 60;
    params->cpu_load_high = 90;
    params->cpu_load_med = 60;
+
 
 #ifdef HAVE_X11
    params->toggle_hud = { XK_Shift_R, XK_F12 };
@@ -598,12 +608,12 @@ parse_overlay_config(struct overlay_params *params,
       &params->text_color,
       &params->media_player_color,
       &params->wine_color,
-      &params->gpu_load_high_color,
-      &params->gpu_load_med_color,
-      &params->gpu_load_low_color,
       &params->cpu_load_high_color,
       &params->cpu_load_med_color,
       &params->cpu_load_low_color,
+      &params->gpu_load_color[0],
+      &params->gpu_load_color[1],
+      &params->gpu_load_color[2],
 
    };
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -425,6 +425,8 @@ parse_overlay_env(struct overlay_params *params,
 #undef OVERLAY_PARAM_BOOL
 #undef OVERLAY_PARAM_CUSTOM
          params->enabled[OVERLAY_PARAM_ENABLED_histogram] = 0;
+         params->enabled[OVERLAY_PARAM_ENABLED_gpu_load_change] = 0;
+         params->enabled[OVERLAY_PARAM_ENABLED_cpu_load_change] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_read_cfg] = read_cfg;
       }
 #define OVERLAY_PARAM_BOOL(name)                                       \

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -329,7 +329,11 @@ parse_font_glyph_ranges(const char *str)
 #define parse_gpu_load_low_color(s) parse_color(s)
 #define parse_gpu_load_high(s) parse_unsigned(s)
 #define parse_gpu_load_med(s) parse_unsigned(s)
-#define parse_gpu_load_low(s) parse_unsigned(s)
+#define parse_cpu_load_high_color(s) parse_color(s)
+#define parse_cpu_load_med_color(s) parse_color(s)
+#define parse_cpu_load_low_color(s) parse_color(s)
+#define parse_cpu_load_high(s) parse_unsigned(s)
+#define parse_cpu_load_med(s) parse_unsigned(s)
 
 static bool
 parse_help(const char *str)
@@ -490,6 +494,9 @@ parse_overlay_config(struct overlay_params *params,
    params->gpu_load_high_color=0xb22222;
    params->gpu_load_med_color=0xfdfd09;
    params->gpu_load_low_color=0x39f900;
+   params->cpu_load_high_color=0xb22222;
+   params->cpu_load_med_color=0xfdfd09;
+   params->cpu_load_low_color=0x39f900;
    params->font_scale_media_player = 0.55f;
    params->log_interval = 100;
    params->media_player_order = { MP_ORDER_TITLE, MP_ORDER_ARTIST, MP_ORDER_ALBUM };
@@ -571,7 +578,7 @@ parse_overlay_config(struct overlay_params *params,
       params->font_scale_media_player = 0.55f;
 
    // Convert from 0xRRGGBB to ImGui's format
-   std::array<unsigned *, 14> colors = {
+   std::array<unsigned *, 17> colors = {
       &params->cpu_color,
       &params->gpu_color,
       &params->vram_color,
@@ -586,6 +593,9 @@ parse_overlay_config(struct overlay_params *params,
       &params->gpu_load_high_color,
       &params-> gpu_load_med_color,
       &params->gpu_load_low_color,
+      &params->cpu_load_high_color,
+      &params->cpu_load_med_color,
+      &params->cpu_load_low_color,
 
    };
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -324,6 +324,12 @@ parse_font_glyph_ranges(const char *str)
 #define parse_text_color(s) parse_color(s)
 #define parse_media_player_color(s) parse_color(s)
 #define parse_wine_color(s) parse_color(s)
+#define parse_gpu_load_high_color(s) parse_color(s)
+#define parse_gpu_load_med_color(s) parse_color(s)
+#define parse_gpu_load_low_color(s) parse_color(s)
+#define parse_gpu_load_high(s) parse_unsigned(s)
+#define parse_gpu_load_med(s) parse_unsigned(s)
+#define parse_gpu_load_low(s) parse_unsigned(s)
 
 static bool
 parse_help(const char *str)
@@ -481,6 +487,9 @@ parse_overlay_config(struct overlay_params *params,
    params->media_player_name = "";
    params->font_scale = 1.0f;
    params->wine_color = 0xeb5b5b;
+   params->gpu_load_high_color=0xb22222;
+   params->gpu_load_med_color=0xfdfd09;
+   params->gpu_load_low_color=0x39f900;
    params->font_scale_media_player = 0.55f;
    params->log_interval = 100;
    params->media_player_order = { MP_ORDER_TITLE, MP_ORDER_ARTIST, MP_ORDER_ALBUM };
@@ -562,7 +571,7 @@ parse_overlay_config(struct overlay_params *params,
       params->font_scale_media_player = 0.55f;
 
    // Convert from 0xRRGGBB to ImGui's format
-   std::array<unsigned *, 11> colors = {
+   std::array<unsigned *, 14> colors = {
       &params->cpu_color,
       &params->gpu_color,
       &params->vram_color,
@@ -574,6 +583,10 @@ parse_overlay_config(struct overlay_params *params,
       &params->text_color,
       &params->media_player_color,
       &params->wine_color,
+      &params->gpu_load_high_color,
+      &params-> gpu_load_med_color,
+      &params->gpu_load_low_color,
+
    };
 
    for (auto color : colors){

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -165,6 +165,20 @@ parse_load_color(const char *str)
     return load_colors;
 }
 
+static std::vector<unsigned>
+parse_load_value(const char *str)
+{
+   std::vector<unsigned> load_value;
+   std::stringstream ss(str);
+   std::string token;
+   while (std::getline(ss, token, ',')) {
+      trim(token);
+      load_value.push_back(std::stoi(token));
+   }
+    return load_value;
+}
+
+
 static unsigned
 parse_unsigned(const char *str)
 {
@@ -339,10 +353,8 @@ parse_font_glyph_ranges(const char *str)
 #define parse_wine_color(s) parse_color(s)
 #define parse_gpu_load_color(s) parse_load_color(s)
 #define parse_cpu_load_color(s) parse_load_color(s)
-#define parse_gpu_load_high(s) parse_unsigned(s)
-#define parse_gpu_load_med(s) parse_unsigned(s)
-#define parse_cpu_load_high(s) parse_unsigned(s)
-#define parse_cpu_load_med(s) parse_unsigned(s)
+#define parse_gpu_load_value(s) parse_load_value(s)
+#define parse_cpu_load_value(s) parse_load_value(s)
 
 static bool
 parse_help(const char *str)
@@ -512,10 +524,9 @@ parse_overlay_config(struct overlay_params *params,
    params->permit_upload = 0;
    params->render_mango = 0;
    params->benchmark_percentiles = { "97", "AVG", "1", "0.1" };
-   params->gpu_load_high = 90;
-   params->gpu_load_med = 60;
-   params->cpu_load_high = 90;
-   params->cpu_load_med = 60;
+   params->gpu_load_value = { 90, 60 };
+   params->cpu_load_value = { 90, 60 };
+
 
 
 #ifdef HAVE_X11

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -338,11 +338,9 @@ parse_font_glyph_ranges(const char *str)
 #define parse_media_player_color(s) parse_color(s)
 #define parse_wine_color(s) parse_color(s)
 #define parse_gpu_load_color(s) parse_load_color(s)
+#define parse_cpu_load_color(s) parse_load_color(s)
 #define parse_gpu_load_high(s) parse_unsigned(s)
 #define parse_gpu_load_med(s) parse_unsigned(s)
-#define parse_cpu_load_high_color(s) parse_color(s)
-#define parse_cpu_load_med_color(s) parse_color(s)
-#define parse_cpu_load_low_color(s) parse_color(s)
 #define parse_cpu_load_high(s) parse_unsigned(s)
 #define parse_cpu_load_med(s) parse_unsigned(s)
 
@@ -506,10 +504,8 @@ parse_overlay_config(struct overlay_params *params,
    params->media_player_name = "";
    params->font_scale = 1.0f;
    params->wine_color = 0xeb5b5b;
-   params->gpu_load_color = {0xb22222,0xfdfd09,0x39f900};
-   params->cpu_load_high_color = 0xb22222;
-   params->cpu_load_med_color = 0xfdfd09;
-   params->cpu_load_low_color = 0x39f900;
+   params->gpu_load_color = { 0xb22222, 0xfdfd09, 0x39f900 };
+   params->cpu_load_color = { 0xb22222, 0xfdfd09, 0x39f900 };
    params->font_scale_media_player = 0.55f;
    params->log_interval = 100;
    params->media_player_order = { MP_ORDER_TITLE, MP_ORDER_ARTIST, MP_ORDER_ALBUM };
@@ -608,12 +604,12 @@ parse_overlay_config(struct overlay_params *params,
       &params->text_color,
       &params->media_player_color,
       &params->wine_color,
-      &params->cpu_load_high_color,
-      &params->cpu_load_med_color,
-      &params->cpu_load_low_color,
       &params->gpu_load_color[0],
       &params->gpu_load_color[1],
       &params->gpu_load_color[2],
+      &params->cpu_load_color[0],
+      &params->cpu_load_color[1],
+      &params->cpu_load_color[2],
 
    };
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -466,6 +466,8 @@ parse_overlay_config(struct overlay_params *params,
    params->enabled[OVERLAY_PARAM_ENABLED_io_read] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_io_write] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_wine] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_gpu_load_change] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_cpu_load_change] = false;
    params->fps_sampling_period = 500000; /* 500ms */
    params->width = 0;
    params->height = 140;
@@ -503,6 +505,10 @@ parse_overlay_config(struct overlay_params *params,
    params->permit_upload = 0;
    params->render_mango = 0;
    params->benchmark_percentiles = { "97", "AVG", "1", "0.1" };
+   params->gpu_load_high = 90;
+   params->gpu_load_med = 60;
+   params->cpu_load_high = 90;
+   params->cpu_load_med= 60;
 
 #ifdef HAVE_X11
    params->toggle_hud = { XK_Shift_R, XK_F12 };

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -495,12 +495,12 @@ parse_overlay_config(struct overlay_params *params,
    params->media_player_name = "";
    params->font_scale = 1.0f;
    params->wine_color = 0xeb5b5b;
-   params->gpu_load_high_color=0xb22222;
-   params->gpu_load_med_color=0xfdfd09;
-   params->gpu_load_low_color=0x39f900;
-   params->cpu_load_high_color=0xb22222;
-   params->cpu_load_med_color=0xfdfd09;
-   params->cpu_load_low_color=0x39f900;
+   params->gpu_load_high_color = 0xb22222;
+   params->gpu_load_med_color = 0xfdfd09;
+   params->gpu_load_low_color = 0x39f900;
+   params->cpu_load_high_color = 0xb22222;
+   params->cpu_load_med_color = 0xfdfd09;
+   params->cpu_load_low_color = 0x39f900;
    params->font_scale_media_player = 0.55f;
    params->log_interval = 100;
    params->media_player_order = { MP_ORDER_TITLE, MP_ORDER_ARTIST, MP_ORDER_ALBUM };
@@ -510,7 +510,7 @@ parse_overlay_config(struct overlay_params *params,
    params->gpu_load_high = 90;
    params->gpu_load_med = 60;
    params->cpu_load_high = 90;
-   params->cpu_load_med= 60;
+   params->cpu_load_med = 60;
 
 #ifdef HAVE_X11
    params->toggle_hud = { XK_Shift_R, XK_F12 };
@@ -599,7 +599,7 @@ parse_overlay_config(struct overlay_params *params,
       &params->media_player_color,
       &params->wine_color,
       &params->gpu_load_high_color,
-      &params-> gpu_load_med_color,
+      &params->gpu_load_med_color,
       &params->gpu_load_low_color,
       &params->cpu_load_high_color,
       &params->cpu_load_med_color,

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -92,9 +92,6 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(io_color)                    \
    OVERLAY_PARAM_CUSTOM(text_color)                  \
    OVERLAY_PARAM_CUSTOM (wine_color)                 \
-   OVERLAY_PARAM_CUSTOM(gpu_load_high_color)         \
-   OVERLAY_PARAM_CUSTOM(gpu_load_med_color)          \
-   OVERLAY_PARAM_CUSTOM(gpu_load_low_color)          \
    OVERLAY_PARAM_CUSTOM(cpu_load_high_color)         \
    OVERLAY_PARAM_CUSTOM(cpu_load_med_color)          \
    OVERLAY_PARAM_CUSTOM(cpu_load_low_color)          \
@@ -114,7 +111,8 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(gpu_load_high)               \
    OVERLAY_PARAM_CUSTOM(gpu_load_med)                \
    OVERLAY_PARAM_CUSTOM(cpu_load_high)               \
-   OVERLAY_PARAM_CUSTOM(cpu_load_med)
+   OVERLAY_PARAM_CUSTOM(cpu_load_med)                \
+   OVERLAY_PARAM_CUSTOM (gpu_load_color)
 
 
 enum overlay_param_position {
@@ -174,8 +172,8 @@ struct overlay_params {
    int gl_vsync;
    uint64_t log_duration;
    unsigned cpu_color, gpu_color, vram_color, ram_color, engine_color, io_color, frametime_color, background_color, text_color, wine_color;
-   unsigned gpu_load_high_color, gpu_load_med_color, gpu_load_low_color;
    unsigned cpu_load_high_color, cpu_load_med_color, cpu_load_low_color;
+   std::vector<unsigned> gpu_load_color;
    int gpu_load_high, gpu_load_med, gpu_load_change;
    int cpu_load_high, cpu_load_med, cpu_load_change;
    unsigned media_player_color;
@@ -198,7 +196,6 @@ struct overlay_params {
    unsigned log_interval;
    std::vector<media_player_order> media_player_order;
    std::vector<std::string> benchmark_percentiles;
-
    std::string font_file, font_file_text;
    uint32_t font_glyph_ranges;
 

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -92,9 +92,6 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(io_color)                    \
    OVERLAY_PARAM_CUSTOM(text_color)                  \
    OVERLAY_PARAM_CUSTOM (wine_color)                 \
-   OVERLAY_PARAM_CUSTOM(cpu_load_high_color)         \
-   OVERLAY_PARAM_CUSTOM(cpu_load_med_color)          \
-   OVERLAY_PARAM_CUSTOM(cpu_load_low_color)          \
    OVERLAY_PARAM_CUSTOM(alpha)                       \
    OVERLAY_PARAM_CUSTOM(log_duration)                \
    OVERLAY_PARAM_CUSTOM(pci_dev)                     \
@@ -112,7 +109,8 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(gpu_load_med)                \
    OVERLAY_PARAM_CUSTOM(cpu_load_high)               \
    OVERLAY_PARAM_CUSTOM(cpu_load_med)                \
-   OVERLAY_PARAM_CUSTOM (gpu_load_color)
+   OVERLAY_PARAM_CUSTOM (gpu_load_color)             \
+   OVERLAY_PARAM_CUSTOM (cpu_load_color)
 
 
 enum overlay_param_position {
@@ -172,8 +170,8 @@ struct overlay_params {
    int gl_vsync;
    uint64_t log_duration;
    unsigned cpu_color, gpu_color, vram_color, ram_color, engine_color, io_color, frametime_color, background_color, text_color, wine_color;
-   unsigned cpu_load_high_color, cpu_load_med_color, cpu_load_low_color;
    std::vector<unsigned> gpu_load_color;
+   std::vector<unsigned> cpu_load_color;
    int gpu_load_high, gpu_load_med, gpu_load_change;
    int cpu_load_high, cpu_load_med, cpu_load_change;
    unsigned media_player_color;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -51,6 +51,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(histogram)                     \
    OVERLAY_PARAM_BOOL(wine)                          \
    OVERLAY_PARAM_BOOL(gpu_load_change)               \
+   OVERLAY_PARAM_BOOL(cpu_load_change)               \
    OVERLAY_PARAM_CUSTOM(fps_sampling_period)         \
    OVERLAY_PARAM_CUSTOM(output_folder)               \
    OVERLAY_PARAM_CUSTOM(output_file)                 \
@@ -94,6 +95,9 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(gpu_load_high_color)         \
    OVERLAY_PARAM_CUSTOM(gpu_load_med_color)          \
    OVERLAY_PARAM_CUSTOM(gpu_load_low_color)          \
+   OVERLAY_PARAM_CUSTOM(cpu_load_high_color)         \
+   OVERLAY_PARAM_CUSTOM(cpu_load_med_color)          \
+   OVERLAY_PARAM_CUSTOM(cpu_load_low_color)          \
    OVERLAY_PARAM_CUSTOM(alpha)                       \
    OVERLAY_PARAM_CUSTOM(log_duration)                \
    OVERLAY_PARAM_CUSTOM(pci_dev)                     \
@@ -108,7 +112,9 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(benchmark_percentiles)       \
    OVERLAY_PARAM_CUSTOM(help)                        \
    OVERLAY_PARAM_CUSTOM(gpu_load_high)               \
-   OVERLAY_PARAM_CUSTOM(gpu_load_med)
+   OVERLAY_PARAM_CUSTOM(gpu_load_med)                \
+   OVERLAY_PARAM_CUSTOM(cpu_load_high)               \
+   OVERLAY_PARAM_CUSTOM(cpu_load_med)
 
 
 enum overlay_param_position {
@@ -168,8 +174,10 @@ struct overlay_params {
    int gl_vsync;
    uint64_t log_duration;
    unsigned cpu_color, gpu_color, vram_color, ram_color, engine_color, io_color, frametime_color, background_color, text_color, wine_color;
-   unsigned gpu_load_high_color,gpu_load_med_color,gpu_load_low_color;
-   int gpu_load_high,gpu_load_med,gpu_load_change;
+   unsigned gpu_load_high_color, gpu_load_med_color, gpu_load_low_color;
+   unsigned cpu_load_high_color, cpu_load_med_color, cpu_load_low_color;
+   int gpu_load_high, gpu_load_med, gpu_load_change;
+   int cpu_load_high, cpu_load_med, cpu_load_change;
    unsigned media_player_color;
    unsigned tableCols;
    unsigned render_mango;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -105,10 +105,8 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(render_mango)                \
    OVERLAY_PARAM_CUSTOM(benchmark_percentiles)       \
    OVERLAY_PARAM_CUSTOM(help)                        \
-   OVERLAY_PARAM_CUSTOM(gpu_load_high)               \
-   OVERLAY_PARAM_CUSTOM(gpu_load_med)                \
-   OVERLAY_PARAM_CUSTOM(cpu_load_high)               \
-   OVERLAY_PARAM_CUSTOM(cpu_load_med)                \
+   OVERLAY_PARAM_CUSTOM(gpu_load_value)              \
+   OVERLAY_PARAM_CUSTOM(cpu_load_value)              \
    OVERLAY_PARAM_CUSTOM (gpu_load_color)             \
    OVERLAY_PARAM_CUSTOM (cpu_load_color)
 
@@ -172,6 +170,8 @@ struct overlay_params {
    unsigned cpu_color, gpu_color, vram_color, ram_color, engine_color, io_color, frametime_color, background_color, text_color, wine_color;
    std::vector<unsigned> gpu_load_color;
    std::vector<unsigned> cpu_load_color;
+   std::vector<unsigned> gpu_load_value;
+   std::vector<unsigned> cpu_load_value;
    int gpu_load_high, gpu_load_med, gpu_load_change;
    int cpu_load_high, cpu_load_med, cpu_load_change;
    unsigned media_player_color;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -172,7 +172,7 @@ struct overlay_params {
    std::vector<unsigned> cpu_load_color;
    std::vector<unsigned> gpu_load_value;
    std::vector<unsigned> cpu_load_value;
-   int  gpu_load_change, cpu_load_change;
+   //int  gpu_load_change, cpu_load_change;
    unsigned media_player_color;
    unsigned tableCols;
    unsigned render_mango;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -50,6 +50,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(engine_version)                \
    OVERLAY_PARAM_BOOL(histogram)                     \
    OVERLAY_PARAM_BOOL(wine)                          \
+   OVERLAY_PARAM_BOOL(gpu_load_change)               \
    OVERLAY_PARAM_CUSTOM(fps_sampling_period)         \
    OVERLAY_PARAM_CUSTOM(output_folder)               \
    OVERLAY_PARAM_CUSTOM(output_file)                 \
@@ -90,6 +91,9 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(io_color)                    \
    OVERLAY_PARAM_CUSTOM(text_color)                  \
    OVERLAY_PARAM_CUSTOM (wine_color)                 \
+   OVERLAY_PARAM_CUSTOM(gpu_load_high_color)         \
+   OVERLAY_PARAM_CUSTOM(gpu_load_med_color)          \
+   OVERLAY_PARAM_CUSTOM(gpu_load_low_color)          \
    OVERLAY_PARAM_CUSTOM(alpha)                       \
    OVERLAY_PARAM_CUSTOM(log_duration)                \
    OVERLAY_PARAM_CUSTOM(pci_dev)                     \
@@ -102,7 +106,11 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(permit_upload)               \
    OVERLAY_PARAM_CUSTOM(render_mango)                \
    OVERLAY_PARAM_CUSTOM(benchmark_percentiles)       \
-   OVERLAY_PARAM_CUSTOM(help)
+   OVERLAY_PARAM_CUSTOM(help)                        \
+   OVERLAY_PARAM_CUSTOM(gpu_load_high)               \
+   OVERLAY_PARAM_CUSTOM(gpu_load_med)                \
+   OVERLAY_PARAM_CUSTOM(gpu_load_low)
+
 
 enum overlay_param_position {
    LAYER_POSITION_TOP_LEFT,
@@ -161,6 +169,8 @@ struct overlay_params {
    int gl_vsync;
    uint64_t log_duration;
    unsigned cpu_color, gpu_color, vram_color, ram_color, engine_color, io_color, frametime_color, background_color, text_color, wine_color;
+   unsigned gpu_load_high_color,gpu_load_med_color,gpu_load_low_color;
+   int gpu_load_high,gpu_load_med,gpu_load_low,gpu_load_change;
    unsigned media_player_color;
    unsigned tableCols;
    unsigned render_mango;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -108,8 +108,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(benchmark_percentiles)       \
    OVERLAY_PARAM_CUSTOM(help)                        \
    OVERLAY_PARAM_CUSTOM(gpu_load_high)               \
-   OVERLAY_PARAM_CUSTOM(gpu_load_med)                \
-   OVERLAY_PARAM_CUSTOM(gpu_load_low)
+   OVERLAY_PARAM_CUSTOM(gpu_load_med)
 
 
 enum overlay_param_position {
@@ -170,7 +169,7 @@ struct overlay_params {
    uint64_t log_duration;
    unsigned cpu_color, gpu_color, vram_color, ram_color, engine_color, io_color, frametime_color, background_color, text_color, wine_color;
    unsigned gpu_load_high_color,gpu_load_med_color,gpu_load_low_color;
-   int gpu_load_high,gpu_load_med,gpu_load_low,gpu_load_change;
+   int gpu_load_high,gpu_load_med,gpu_load_change;
    unsigned media_player_color;
    unsigned tableCols;
    unsigned render_mango;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -107,8 +107,8 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(help)                        \
    OVERLAY_PARAM_CUSTOM(gpu_load_value)              \
    OVERLAY_PARAM_CUSTOM(cpu_load_value)              \
-   OVERLAY_PARAM_CUSTOM (gpu_load_color)             \
-   OVERLAY_PARAM_CUSTOM (cpu_load_color)
+   OVERLAY_PARAM_CUSTOM(gpu_load_color)             \
+   OVERLAY_PARAM_CUSTOM(cpu_load_color)
 
 
 enum overlay_param_position {
@@ -172,7 +172,6 @@ struct overlay_params {
    std::vector<unsigned> cpu_load_color;
    std::vector<unsigned> gpu_load_value;
    std::vector<unsigned> cpu_load_value;
-   //int  gpu_load_change, cpu_load_change;
    unsigned media_player_color;
    unsigned tableCols;
    unsigned render_mango;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -172,8 +172,7 @@ struct overlay_params {
    std::vector<unsigned> cpu_load_color;
    std::vector<unsigned> gpu_load_value;
    std::vector<unsigned> cpu_load_value;
-   int gpu_load_high, gpu_load_med, gpu_load_change;
-   int cpu_load_high, cpu_load_med, cpu_load_change;
+   int  gpu_load_change, cpu_load_change;
    unsigned media_player_color;
    unsigned tableCols;
    unsigned render_mango;

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -2913,5 +2913,3 @@ extern "C" VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL overlay_GetI
    if (instance_data->vtable.GetInstanceProcAddr == NULL) return NULL;
    return instance_data->vtable.GetInstanceProcAddr(instance, funcName);
 }
-
-

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -991,7 +991,7 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
 }
 
 
-int change_on_load_temp ( int info, int high, int med) {
+int change_on_load_temp (int info, int high, int med) {
    if (info >= high) {
       return 1;
    }
@@ -1039,39 +1039,33 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             gpu_text = params.gpu_text.c_str();
          ImGui::TextColored(data.colors.gpu, "%s", gpu_text);
          ImGui::TableNextCell();
-         auto gpu_high_color = data.colors.gpu_load_high;
-         auto gpu_med_color = data.colors.gpu_load_med;
-         auto gpu_low_color = data.colors.gpu_load_low;
          auto text_color = data.colors.text;
-
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
+            auto load_color = data.colors.text;
             int gpu_load = change_on_load_temp(gpu_info.load, params.gpu_load_high, params.gpu_load_med);
             // 1 is high, 2 is medium, and 3 is low load/temp
             switch (gpu_load) {
                case 1:
-                  right_aligned_text(gpu_high_color, ralign_width, "%i", gpu_info.load);
-                  ImGui::SameLine(0, 1.0f);
-                  ImGui::TextColored(gpu_high_color, "%%");
+                  load_color = data.colors.gpu_load_high;
                   break;
                case 2:
-                  right_aligned_text(gpu_med_color, ralign_width, "%i", gpu_info.load);
-                  ImGui::SameLine(0, 1.0f);
-                  ImGui::TextColored(gpu_med_color, "%%");
+                  load_color = data.colors.gpu_load_med;
                   break;
                case 3:
-                  right_aligned_text(gpu_low_color, ralign_width, "%i", gpu_info.load);
-                  ImGui::SameLine(0, 1.0f);
-                  ImGui::TextColored(gpu_low_color, "%%");
+                  load_color = data.colors.gpu_load_low;
                   break;
             }
+            right_aligned_text(load_color, ralign_width, "%i", gpu_info.load);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::TextColored(load_color,"%%");
          }
          else {
             right_aligned_text(text_color, ralign_width, "%i", gpu_info.load);
             ImGui::SameLine(0, 1.0f);
-            ImGui::Text("%%");
+            ImGui::TextColored(text_color,"%%");
+            // ImGui::SameLine(150);
+            // ImGui::Text("%s", "%");
          }
-         // ImGui::SameLine(150);
-         // ImGui::Text("%s", "%");
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_temp]){
             ImGui::TableNextCell();
             right_aligned_text(text_color, ralign_width, "%i", gpu_info.temp);
@@ -1106,31 +1100,26 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             cpu_text = params.cpu_text.c_str();
          ImGui::TextColored(data.colors.cpu, "%s", cpu_text);
          ImGui::TableNextCell();
-         auto cpu_high_color = data.colors.cpu_load_high;
-         auto cpu_med_color = data.colors.cpu_load_med;
-         auto cpu_low_color = data.colors.cpu_load_low;
          auto text_color = data.colors.text;
-         int cpu_load_percent = int(cpuStats.GetCPUDataTotal().percent);
          if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_load_change]){
+            int cpu_load_percent = int(cpuStats.GetCPUDataTotal().percent);
+            auto load_color = data.colors.text;
             int cpu_load = change_on_load_temp(cpu_load_percent, params.cpu_load_high, params.cpu_load_med);
             // 1 is high, 2 is medium, and 3 is low load/temp
             switch (cpu_load) {
                case 1:
-                  right_aligned_text(cpu_high_color, ralign_width, "%d", cpu_load_percent);
-                  ImGui::SameLine(0, 1.0f);
-                  ImGui::TextColored(cpu_high_color, "%%");
+                  load_color = data.colors.cpu_load_high;
                   break;
                case 2:
-                  right_aligned_text(cpu_med_color, ralign_width, "%d", cpu_load_percent);
-                  ImGui::SameLine(0, 1.0f);
-                  ImGui::TextColored(cpu_med_color, "%%");
+                  load_color = data.colors.cpu_load_med;
                   break;
                case 3:
-                  right_aligned_text(cpu_low_color, ralign_width, "%d", cpu_load_percent);
-                  ImGui::SameLine(0, 1.0f);
-                  ImGui::TextColored(cpu_low_color, "%%");
+                  load_color = data.colors.cpu_load_low;
                   break;
             }
+            right_aligned_text(load_color, ralign_width, "%d", cpu_load_percent);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::TextColored(load_color, "%%");
          }
          else {
             right_aligned_text(text_color, ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -740,7 +740,7 @@ void position_layer(struct swapchain_stats& data, struct overlay_params& params,
    }
 }
 
-static void right_aligned_text(float off_x, const char *fmt, ...)
+static void right_aligned_text(ImVec4& col, float off_x, const char *fmt, ...)
 {
    ImVec2 pos = ImGui::GetCursorPos();
    char buffer[32] {};
@@ -752,7 +752,8 @@ static void right_aligned_text(float off_x, const char *fmt, ...)
 
    ImVec2 sz = ImGui::CalcTextSize(buffer);
    ImGui::SetCursorPosX(pos.x + off_x - sz.x);
-   ImGui::Text("%s", buffer);
+   //ImGui::Text("%s", buffer);
+   ImGui::TextColored(col,"%s",buffer);
 }
 
 float get_ticker_limited_pos(float pos, float tw, float& left_limit, float& right_limit)
@@ -934,7 +935,7 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             gpu_text = params.gpu_text.c_str();
          ImGui::TextColored(data.colors.gpu, "%s", gpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%i", gpu_info.load);
+         right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.load);
          ImGui::SameLine(0, 1.0f);
          ImGui::Text("%%");
       }
@@ -947,7 +948,7 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             cpu_text = params.cpu_text.c_str();
          ImGui::TextColored(data.colors.cpu, "%s", cpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
+         right_aligned_text(data.colors.text,ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
          ImGui::SameLine(0, 1.0f);
          ImGui::Text("%%");
       }
@@ -955,7 +956,7 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          ImGui::TableNextRow();
          ImGui::TextColored(data.colors.engine, "%s", is_vulkan ? data.engineName.c_str() : "OpenGL");
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%.0f", data.fps);
+         right_aligned_text(data.colors.text,ralign_width, "%.0f", data.fps);
          ImGui::SameLine(0, 1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("FPS");
@@ -1025,14 +1026,14 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             gpu_text = params.gpu_text.c_str();
          ImGui::TextColored(data.colors.gpu, "%s", gpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%i", gpu_info.load);
+         right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.load);
          ImGui::SameLine(0, 1.0f);
          ImGui::Text("%%");
          // ImGui::SameLine(150);
          // ImGui::Text("%s", "%");
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_temp]){
             ImGui::TableNextCell();
-            right_aligned_text(ralign_width, "%i", gpu_info.temp);
+            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.temp);
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("°C");
          }
@@ -1040,7 +1041,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             ImGui::TableNextRow();
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock]){
             ImGui::TableNextCell();
-            right_aligned_text(ralign_width, "%i", gpu_info.CoreClock);
+            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.CoreClock);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MHz");
@@ -1048,7 +1049,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          }
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_power]) {
             ImGui::TableNextCell();
-            right_aligned_text(ralign_width, "%i", gpu_info.powerUsage);
+            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.powerUsage);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("W");
@@ -1064,7 +1065,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             cpu_text = params.cpu_text.c_str();
          ImGui::TextColored(data.colors.cpu, "%s", cpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
+         right_aligned_text(data.colors.text,ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
          ImGui::SameLine(0, 1.0f);
          ImGui::Text("%%");
          // ImGui::SameLine(150);
@@ -1072,7 +1073,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
 
          if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_temp]){
             ImGui::TableNextCell();
-            right_aligned_text(ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
+            right_aligned_text(data.colors.text,ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("°C");
          }
@@ -1089,11 +1090,11 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             ImGui::TextColored(data.colors.cpu,"%i", i);
             ImGui::PopFont();
             ImGui::TableNextCell();
-            right_aligned_text(ralign_width, "%i", int(cpuData.percent));
+            right_aligned_text(data.colors.text,ralign_width, "%i", int(cpuData.percent));
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("%%");
             ImGui::TableNextCell();
-            right_aligned_text(ralign_width, "%i", cpuData.mhz);
+            right_aligned_text(data.colors.text,ralign_width, "%i", cpuData.mhz);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MHz");
@@ -1114,7 +1115,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          if (params.enabled[OVERLAY_PARAM_ENABLED_io_read]){
             ImGui::TableNextCell();
             float val = data.io.diff.read * 1000000 / sampling;
-            right_aligned_text(ralign_width, val < 100 ? "%.1f" : "%.f", val);
+            right_aligned_text(data.colors.text,ralign_width, val < 100 ? "%.1f" : "%.f", val);
             ImGui::SameLine(0,1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MiB/s");
@@ -1123,7 +1124,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          if (params.enabled[OVERLAY_PARAM_ENABLED_io_write]){
             ImGui::TableNextCell();
             float val = data.io.diff.write * 1000000 / sampling;
-            right_aligned_text(ralign_width, val < 100 ? "%.1f" : "%.f", val);
+            right_aligned_text(data.colors.text,ralign_width, val < 100 ? "%.1f" : "%.f", val);
             ImGui::SameLine(0,1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MiB/s");
@@ -1134,14 +1135,14 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          ImGui::TableNextRow();
          ImGui::TextColored(data.colors.vram, "VRAM");
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%.1f", gpu_info.memoryUsed);
+         right_aligned_text(data.colors.text,ralign_width, "%.1f", gpu_info.memoryUsed);
          ImGui::SameLine(0,1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("GiB");
          ImGui::PopFont();
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_mem_clock]){
             ImGui::TableNextCell();
-            right_aligned_text(ralign_width, "%i", gpu_info.MemClock);
+            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.MemClock);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MHz");
@@ -1153,7 +1154,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          ImGui::TableNextRow();
          ImGui::TextColored(data.colors.ram, "RAM");
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%.1f", memused);
+         right_aligned_text(data.colors.text,ralign_width, "%.1f", memused);
          ImGui::SameLine(0,1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("GiB");
@@ -1164,13 +1165,13 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          ImGui::TableNextRow();
          ImGui::TextColored(data.colors.engine, "%s", is_vulkan ? data.engineName.c_str() : "OpenGL");
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%.0f", data.fps);
+         right_aligned_text(data.colors.text,ralign_width, "%.0f", data.fps);
          ImGui::SameLine(0, 1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("FPS");
          ImGui::PopFont();
          ImGui::TableNextCell();
-         right_aligned_text(ralign_width, "%.1f", 1000 / data.fps);
+         right_aligned_text(data.colors.text,ralign_width, "%.1f", 1000 / data.fps);
          ImGui::SameLine(0, 1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("ms");

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1046,6 +1046,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             // 1 is high, 2 is medium, and 3 is low load/temp
             switch (gpu_load) {
                case 1:
+                  ///load_color = data.colors.gpu_load_high;
                   load_color = data.colors.gpu_load_high;
                   break;
                case 2:
@@ -2154,12 +2155,15 @@ void convert_colors(bool do_conv, struct swapchain_stats& sw_stats, struct overl
    sw_stats.colors.text = convert(params.text_color);
    sw_stats.colors.media_player = convert(params.media_player_color);
    sw_stats.colors.wine = convert(params.wine_color);
-   sw_stats.colors.gpu_load_high = convert(params.gpu_load_high_color);
-   sw_stats.colors.gpu_load_med = convert(params.gpu_load_med_color);
-   sw_stats.colors.gpu_load_low = convert(params.gpu_load_low_color);
+   sw_stats.colors.gpu_load_high = convert(params.gpu_load_color[0]);
+   sw_stats.colors.gpu_load_med = convert(params.gpu_load_color[1]);
+   sw_stats.colors.gpu_load_low = convert(params.gpu_load_color[2]);
+
    sw_stats.colors.cpu_load_high = convert(params.cpu_load_high_color);
    sw_stats.colors.cpu_load_med = convert(params.cpu_load_med_color);
    sw_stats.colors.cpu_load_low = convert(params.cpu_load_low_color);
+
+
 
    ImGuiStyle& style = ImGui::GetStyle();
    style.Colors[ImGuiCol_PlotLines] = convert(params.frametime_color);

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1042,7 +1042,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          auto text_color = data.colors.text;
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
             auto load_color = data.colors.text;
-            int gpu_load = change_on_load_temp(gpu_info.load, params.gpu_load_high, params.gpu_load_med);
+            int gpu_load = change_on_load_temp(gpu_info.load, params.gpu_load_value[0], params.gpu_load_value[1]);
             // 1 is high, 2 is medium, and 3 is low load/temp
             switch (gpu_load) {
                case 1:
@@ -1104,7 +1104,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_load_change]){
             int cpu_load_percent = int(cpuStats.GetCPUDataTotal().percent);
             auto load_color = data.colors.text;
-            int cpu_load = change_on_load_temp(cpu_load_percent, params.cpu_load_high, params.cpu_load_med);
+            int cpu_load = change_on_load_temp(cpu_load_percent, params.cpu_load_value[0], params.cpu_load_value[1]);
             // 1 is high, 2 is medium, and 3 is low load/temp
             switch (cpu_load) {
                case 1:

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -992,10 +992,10 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
 
 
 int change_on_load_temp ( int info, int high, int med) {
-    if (info >= high){
+   if (info >= high) {
       return 1;
-    }
-    else if (info >= med && info < high) {
+   }
+   else if (info >= med && info < high) {
       return 2;
    }
    else {
@@ -1106,9 +1106,37 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             cpu_text = params.cpu_text.c_str();
          ImGui::TextColored(data.colors.cpu, "%s", cpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text, ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
-         ImGui::SameLine(0, 1.0f);
-         ImGui::Text("%%");
+         auto cpu_high_color = data.colors.cpu_load_high;
+         auto cpu_med_color = data.colors.cpu_load_med;
+         auto cpu_low_color = data.colors.cpu_load_low;
+         auto text_color = data.colors.text;
+         int cpu_load_percent = int(cpuStats.GetCPUDataTotal().percent);
+         if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_load_change]){
+            int cpu_load = change_on_load_temp(cpu_load_percent, params.cpu_load_high, params.cpu_load_med);
+            // 1 is high, 2 is medium, and 3 is low load/temp
+            switch (cpu_load) {
+               case 1:
+                  right_aligned_text(cpu_high_color, ralign_width, "%d", cpu_load_percent);
+                  ImGui::SameLine(0, 1.0f);
+                  ImGui::TextColored(cpu_high_color, "%%");
+                  break;
+               case 2:
+                  right_aligned_text(cpu_med_color, ralign_width, "%d", cpu_load_percent);
+                  ImGui::SameLine(0, 1.0f);
+                  ImGui::TextColored(cpu_med_color, "%%");
+                  break;
+               case 3:
+                  right_aligned_text(cpu_low_color, ralign_width, "%d", cpu_load_percent);
+                  ImGui::SameLine(0, 1.0f);
+                  ImGui::TextColored(cpu_low_color, "%%");
+                  break;
+            }
+         }
+         else {
+            right_aligned_text(text_color, ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
+            ImGui::SameLine(0, 1.0f);
+            ImGui::Text("%%");
+         }
          // ImGui::SameLine(150);
          // ImGui::Text("%s", "%");
 
@@ -2140,6 +2168,9 @@ void convert_colors(bool do_conv, struct swapchain_stats& sw_stats, struct overl
    sw_stats.colors.gpu_load_high = convert(params.gpu_load_high_color);
    sw_stats.colors.gpu_load_med = convert(params.gpu_load_med_color);
    sw_stats.colors.gpu_load_low = convert(params.gpu_load_low_color);
+   sw_stats.colors.cpu_load_high = convert(params.cpu_load_high_color);
+   sw_stats.colors.cpu_load_med = convert(params.cpu_load_med_color);
+   sw_stats.colors.cpu_load_low = convert(params.cpu_load_low_color);
 
    ImGuiStyle& style = ImGui::GetStyle();
    style.Colors[ImGuiCol_PlotLines] = convert(params.frametime_color);

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1046,7 +1046,6 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             // 1 is high, 2 is medium, and 3 is low load/temp
             switch (gpu_load) {
                case 1:
-                  ///load_color = data.colors.gpu_load_high;
                   load_color = data.colors.gpu_load_high;
                   break;
                case 2:
@@ -2158,10 +2157,9 @@ void convert_colors(bool do_conv, struct swapchain_stats& sw_stats, struct overl
    sw_stats.colors.gpu_load_high = convert(params.gpu_load_color[0]);
    sw_stats.colors.gpu_load_med = convert(params.gpu_load_color[1]);
    sw_stats.colors.gpu_load_low = convert(params.gpu_load_color[2]);
-
-   sw_stats.colors.cpu_load_high = convert(params.cpu_load_high_color);
-   sw_stats.colors.cpu_load_med = convert(params.cpu_load_med_color);
-   sw_stats.colors.cpu_load_low = convert(params.cpu_load_low_color);
+   sw_stats.colors.cpu_load_high = convert(params.cpu_load_color[0]);
+   sw_stats.colors.cpu_load_med = convert(params.cpu_load_color[1]);
+   sw_stats.colors.cpu_load_low = convert(params.cpu_load_color[2]);
 
 
 

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -935,7 +935,7 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             gpu_text = params.gpu_text.c_str();
          ImGui::TextColored(data.colors.gpu, "%s", gpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.load);
+         right_aligned_text(data.colors.text, ralign_width, "%i", gpu_info.load);
          ImGui::SameLine(0, 1.0f);
          ImGui::Text("%%");
       }
@@ -948,7 +948,7 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             cpu_text = params.cpu_text.c_str();
          ImGui::TextColored(data.colors.cpu, "%s", cpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
+         right_aligned_text(data.colors.text, ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
          ImGui::SameLine(0, 1.0f);
          ImGui::Text("%%");
       }
@@ -956,7 +956,7 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          ImGui::TableNextRow();
          ImGui::TextColored(data.colors.engine, "%s", is_vulkan ? data.engineName.c_str() : "OpenGL");
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%.0f", data.fps);
+         right_aligned_text(data.colors.text, ralign_width, "%.0f", data.fps);
          ImGui::SameLine(0, 1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("FPS");
@@ -1026,25 +1026,29 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             gpu_text = params.gpu_text.c_str();
          ImGui::TextColored(data.colors.gpu, "%s", gpu_text);
          ImGui::TableNextCell();
-         if(params.enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
-            if(gpu_info.load >= params.gpu_load_high){
-                right_aligned_text(data.colors.gpu_load_high,ralign_width, "%i", gpu_info.load);
-                ImGui::SameLine(0, 1.0f);
-                ImGui::TextColored(data.colors.gpu_load_high,"%%");
+         auto gpu_high_color = data.colors.gpu_load_high;
+         auto gpu_med_color = data.colors.gpu_load_med;
+         auto gpu_low_color = data.colors.gpu_load_low;
+         auto text_color = data.colors.text;
+         if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
+            if (gpu_info.load >= params.gpu_load_high){
+               right_aligned_text(gpu_high_color, ralign_width, "%i", gpu_info.load);
+               ImGui::SameLine(0, 1.0f);
+               ImGui::TextColored(gpu_high_color, "%%");
             }
             else if (gpu_info.load >= params.gpu_load_med && gpu_info.load < params.gpu_load_high && gpu_info.load > params.gpu_load_low) {
-                right_aligned_text(data.colors.gpu_load_med,ralign_width, "%i", gpu_info.load);
+                right_aligned_text(gpu_med_color, ralign_width, "%i", gpu_info.load);
                 ImGui::SameLine(0, 1.0f);
-                ImGui::TextColored(data.colors.gpu_load_med,"%%");
+                ImGui::TextColored(gpu_med_color, "%%");
             }
             else {
-               right_aligned_text(data.colors.gpu_load_low,ralign_width, "%i", gpu_info.load);
+               right_aligned_text(gpu_low_color, ralign_width, "%i", gpu_info.load);
                ImGui::SameLine(0, 1.0f);
-               ImGui::TextColored(data.colors.gpu_load_low,"%%");
+               ImGui::TextColored(gpu_low_color, "%%");
             }
          }
          else {
-            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.load);
+            right_aligned_text(text_color, ralign_width, "%i", gpu_info.load);
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("%%");
          }
@@ -1052,7 +1056,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          // ImGui::Text("%s", "%");
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_temp]){
             ImGui::TableNextCell();
-            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.temp);
+            right_aligned_text(text_color, ralign_width, "%i", gpu_info.temp);
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("°C");
          }
@@ -1060,7 +1064,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             ImGui::TableNextRow();
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock]){
             ImGui::TableNextCell();
-            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.CoreClock);
+            right_aligned_text(text_color, ralign_width, "%i", gpu_info.CoreClock);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MHz");
@@ -1068,7 +1072,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          }
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_power]) {
             ImGui::TableNextCell();
-            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.powerUsage);
+            right_aligned_text(text_color, ralign_width, "%i", gpu_info.powerUsage);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("W");
@@ -1084,7 +1088,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             cpu_text = params.cpu_text.c_str();
          ImGui::TextColored(data.colors.cpu, "%s", cpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
+         right_aligned_text(data.colors.text, ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
          ImGui::SameLine(0, 1.0f);
          ImGui::Text("%%");
          // ImGui::SameLine(150);
@@ -1092,7 +1096,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
 
          if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_temp]){
             ImGui::TableNextCell();
-            right_aligned_text(data.colors.text,ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
+            right_aligned_text(data.colors.text, ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("°C");
          }
@@ -1109,11 +1113,11 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             ImGui::TextColored(data.colors.cpu,"%i", i);
             ImGui::PopFont();
             ImGui::TableNextCell();
-            right_aligned_text(data.colors.text,ralign_width, "%i", int(cpuData.percent));
+            right_aligned_text(data.colors.text, ralign_width, "%i", int(cpuData.percent));
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("%%");
             ImGui::TableNextCell();
-            right_aligned_text(data.colors.text,ralign_width, "%i", cpuData.mhz);
+            right_aligned_text(data.colors.text, ralign_width, "%i", cpuData.mhz);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MHz");
@@ -1134,7 +1138,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          if (params.enabled[OVERLAY_PARAM_ENABLED_io_read]){
             ImGui::TableNextCell();
             float val = data.io.diff.read * 1000000 / sampling;
-            right_aligned_text(data.colors.text,ralign_width, val < 100 ? "%.1f" : "%.f", val);
+            right_aligned_text(data.colors.text, ralign_width, val < 100 ? "%.1f" : "%.f", val);
             ImGui::SameLine(0,1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MiB/s");
@@ -1143,7 +1147,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          if (params.enabled[OVERLAY_PARAM_ENABLED_io_write]){
             ImGui::TableNextCell();
             float val = data.io.diff.write * 1000000 / sampling;
-            right_aligned_text(data.colors.text,ralign_width, val < 100 ? "%.1f" : "%.f", val);
+            right_aligned_text(data.colors.text, ralign_width, val < 100 ? "%.1f" : "%.f", val);
             ImGui::SameLine(0,1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MiB/s");
@@ -1154,14 +1158,14 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          ImGui::TableNextRow();
          ImGui::TextColored(data.colors.vram, "VRAM");
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%.1f", gpu_info.memoryUsed);
+         right_aligned_text(data.colors.text, ralign_width, "%.1f", gpu_info.memoryUsed);
          ImGui::SameLine(0,1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("GiB");
          ImGui::PopFont();
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_mem_clock]){
             ImGui::TableNextCell();
-            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.MemClock);
+            right_aligned_text(data.colors.text, ralign_width, "%i", gpu_info.MemClock);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(data.font1);
             ImGui::Text("MHz");
@@ -1173,7 +1177,7 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          ImGui::TableNextRow();
          ImGui::TextColored(data.colors.ram, "RAM");
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%.1f", memused);
+         right_aligned_text(data.colors.text, ralign_width, "%.1f", memused);
          ImGui::SameLine(0,1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("GiB");
@@ -1184,13 +1188,13 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          ImGui::TableNextRow();
          ImGui::TextColored(data.colors.engine, "%s", is_vulkan ? data.engineName.c_str() : "OpenGL");
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%.0f", data.fps);
+         right_aligned_text(data.colors.text, ralign_width, "%.0f", data.fps);
          ImGui::SameLine(0, 1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("FPS");
          ImGui::PopFont();
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%.1f", 1000 / data.fps);
+         right_aligned_text(data.colors.text, ralign_width, "%.1f", 1000 / data.fps);
          ImGui::SameLine(0, 1.0f);
          ImGui::PushFont(data.font1);
          ImGui::Text("ms");

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -990,6 +990,19 @@ void render_mango(swapchain_stats& data, struct overlay_params& params, ImVec2& 
    window_size = ImVec2(window_size.x, 200);
 }
 
+
+int change_on_load_temp ( int info, int high, int med) {
+    if (info >= high){
+      return 1;
+    }
+    else if (info >= med && info < high) {
+      return 2;
+   }
+   else {
+      return 3;
+   }
+}
+
 void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, bool is_vulkan)
 {
    ImGui::GetIO().FontGlobalScale = params.font_scale;
@@ -1030,21 +1043,26 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
          auto gpu_med_color = data.colors.gpu_load_med;
          auto gpu_low_color = data.colors.gpu_load_low;
          auto text_color = data.colors.text;
+
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
-            if (gpu_info.load >= params.gpu_load_high){
-               right_aligned_text(gpu_high_color, ralign_width, "%i", gpu_info.load);
-               ImGui::SameLine(0, 1.0f);
-               ImGui::TextColored(gpu_high_color, "%%");
-            }
-            else if (gpu_info.load >= params.gpu_load_med && gpu_info.load < params.gpu_load_high && gpu_info.load > params.gpu_load_low) {
-                right_aligned_text(gpu_med_color, ralign_width, "%i", gpu_info.load);
-                ImGui::SameLine(0, 1.0f);
-                ImGui::TextColored(gpu_med_color, "%%");
-            }
-            else {
-               right_aligned_text(gpu_low_color, ralign_width, "%i", gpu_info.load);
-               ImGui::SameLine(0, 1.0f);
-               ImGui::TextColored(gpu_low_color, "%%");
+            int gpu_load = change_on_load_temp(gpu_info.load, params.gpu_load_high, params.gpu_load_med);
+            // 1 is high, 2 is medium, and 3 is low load/temp
+            switch (gpu_load) {
+               case 1:
+                  right_aligned_text(gpu_high_color, ralign_width, "%i", gpu_info.load);
+                  ImGui::SameLine(0, 1.0f);
+                  ImGui::TextColored(gpu_high_color, "%%");
+                  break;
+               case 2:
+                  right_aligned_text(gpu_med_color, ralign_width, "%i", gpu_info.load);
+                  ImGui::SameLine(0, 1.0f);
+                  ImGui::TextColored(gpu_med_color, "%%");
+                  break;
+               case 3:
+                  right_aligned_text(gpu_low_color, ralign_width, "%i", gpu_info.load);
+                  ImGui::SameLine(0, 1.0f);
+                  ImGui::TextColored(gpu_low_color, "%%");
+                  break;
             }
          }
          else {
@@ -2895,3 +2913,5 @@ extern "C" VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL overlay_GetI
    if (instance_data->vtable.GetInstanceProcAddr == NULL) return NULL;
    return instance_data->vtable.GetInstanceProcAddr(instance, funcName);
 }
+
+

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1026,9 +1026,28 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
             gpu_text = params.gpu_text.c_str();
          ImGui::TextColored(data.colors.gpu, "%s", gpu_text);
          ImGui::TableNextCell();
-         right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.load);
-         ImGui::SameLine(0, 1.0f);
-         ImGui::Text("%%");
+         if(params.enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
+            if(gpu_info.load >= params.gpu_load_high){
+                right_aligned_text(data.colors.gpu_load_high,ralign_width, "%i", gpu_info.load);
+                ImGui::SameLine(0, 1.0f);
+                ImGui::TextColored(data.colors.gpu_load_high,"%%");
+            }
+            else if (gpu_info.load >= params.gpu_load_med && gpu_info.load < params.gpu_load_high && gpu_info.load > params.gpu_load_low) {
+                right_aligned_text(data.colors.gpu_load_med,ralign_width, "%i", gpu_info.load);
+                ImGui::SameLine(0, 1.0f);
+                ImGui::TextColored(data.colors.gpu_load_med,"%%");
+            }
+            else {
+               right_aligned_text(data.colors.gpu_load_low,ralign_width, "%i", gpu_info.load);
+               ImGui::SameLine(0, 1.0f);
+               ImGui::TextColored(data.colors.gpu_load_low,"%%");
+            }
+         }
+         else {
+            right_aligned_text(data.colors.text,ralign_width, "%i", gpu_info.load);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::Text("%%");
+         }
          // ImGui::SameLine(150);
          // ImGui::Text("%s", "%");
          if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_temp]){
@@ -2096,6 +2115,9 @@ void convert_colors(bool do_conv, struct swapchain_stats& sw_stats, struct overl
    sw_stats.colors.text = convert(params.text_color);
    sw_stats.colors.media_player = convert(params.media_player_color);
    sw_stats.colors.wine = convert(params.wine_color);
+   sw_stats.colors.gpu_load_high = convert(params.gpu_load_high_color);
+   sw_stats.colors.gpu_load_med = convert(params.gpu_load_med_color);
+   sw_stats.colors.gpu_load_low = convert(params.gpu_load_low_color);
 
    ImGuiStyle& style = ImGui::GetStyle();
    style.Colors[ImGuiCol_PlotLines] = convert(params.frametime_color);


### PR DESCRIPTION
So far only changes gpu load percentage color based on user defined number for high, low, and medium.

`gpu_load_change=1` to turn it on
`gpu_load_high= e.g. 90` set the high amount of gpu load
`gpu_load_med= e.g.60` set the medium amout of gpu load
`gpu_load_high_color` set the color of high
`gpu_load_med_color` set the color of med
`gpu_load_low_color` set the color of low`

Still a work in progress implements #350