### PR TITLE
Add Solus install option via package manager on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ If you are using Fedora, to install the [MangoHud](https://src.fedoraproject.org
 sudo dnf install mangohud
 ```
 
+#### Solus
+
+If you are using Solus, to install [MangoHud](https://dev.getsol.us/source/mangohud/) simply execute:
+
+```
+sudo eopkg it mangohud
+```
+
 #### Flatpak
 
 If you are using Flatpaks, you will have to add the [Flathub repository](https://flatpak.org/setup/) for your specific distribution, and then, to install it, execute:


### PR DESCRIPTION
Simple pull request for letting people know they can install mangohud on Solus using the distro package manager.  Solus repos contain the latest tag and is normally quickly up to date with new versions