### PR TITLE
Fix for FPS limit breaking

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -2425,7 +2425,7 @@ void FpsLimiter(struct fps_limit& stats){
       auto adjustedSleep = stats.sleepTime - stats.frameOverhead;
       this_thread::sleep_for(adjustedSleep);
       stats.frameOverhead = ((Clock::now() - stats.frameStart) - adjustedSleep);
-      if (stats.frameOverhead > stats.targetFrameTime)
+      if (stats.frameOverhead > stats.targetFrameTime / 2)
          stats.frameOverhead = Clock::duration(0);
    }
 }


### PR DESCRIPTION
Checks if sleep time is higher than 0 which should be false if FPS is lower than FPS limit
With original logic if thread oversleeps longer than normally FPS limit would "break" until `stats.sleepTime > stats.frameOverhead` was true again

Fixes #127

However, this logic may cause FPS to slightly drop under set FPS limit (which is what the original frame overhead logic is supposed to prevent I assume) when FPS is only slightly higher than FPS limit