### PR TITLE
Sorting hud elements

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -6,7 +6,7 @@
 #include "config.h"
 #include "file_utils.h"
 #include "string_utils.h"
-
+#include "hud_elements.h"
 std::string program_name;
 
 void parseConfigLine(std::string line, std::unordered_map<std::string,std::string>& options) {
@@ -24,8 +24,10 @@ void parseConfigLine(std::string line, std::unordered_map<std::string,std::strin
     param = line.substr(0, equal);
     trim(param);
     trim(value);
-    if (!param.empty())
+    if (!param.empty()){
+        HUDElements.options.push_back(param);
         options[param] = value;
+    }
 }
 
 void enumerate_config_files(std::vector<std::string>& paths)
@@ -67,6 +69,7 @@ void enumerate_config_files(std::vector<std::string>& paths)
 }
 
 void parseConfigFile(overlay_params& params) {
+    HUDElements.options.clear();
     params.options.clear();
     std::vector<std::string> paths;
     const char *cfg_file = getenv("MANGOHUD_CONFIGFILE");

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -25,7 +25,7 @@ void parseConfigLine(std::string line, std::unordered_map<std::string,std::strin
     trim(param);
     trim(value);
     if (!param.empty()){
-        HUDElements.options.push_back(param);
+        HUDElements.options.push_back({param, value});
         options[param] = value;
     }
 }

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -392,6 +392,8 @@ void HudElements::graphs(){
     }
 
     if (value == "gpu_temp"){
+        if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp])
+            HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp] = true;
         for (auto& it : graph_data){
             arr.push_back(float(it.gpu_temp));
             arr.erase(arr.begin());

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -3,23 +3,6 @@
 #include "cpu.h"
 #include "memory.h"
 #include "mesa/util/macros.h"
-// void HudElements::newRow(){
-//     ImGui::TableNextRow();
-// }
-
-// void HudElements::text(){
-//     auto text = HUDElements.options.at(HUDElements.place);
-//     text.erase(std::remove(text.begin(), text.end(), '%'), text.end());
-//     size_t underscores_found = text.find("_");
-//     // remove all underscores
-//     for (size_t i = 0; i < underscores_found; i++)
-//     {
-//         text.replace(text.find("_"), 1, " ");
-//     }
-
-//     printf("%s\n", text.c_str());
-//     ImGui::Text(text.c_str());
-// }
 
 void HudElements::time(){
     ImGui::TableNextRow();
@@ -102,31 +85,31 @@ void HudElements::cpu_stats(){
         ImGui::TableNextCell();
         auto text_color = HUDElements.sw_stats->colors.text;
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_load_change]){
-        int cpu_load_percent = int(cpuStats.GetCPUDataTotal().percent);
-        struct LOAD_DATA cpu_data = {HUDElements.sw_stats->colors.cpu_load_high,
-                                        HUDElements.sw_stats->colors.cpu_load_med,
-                                        HUDElements.sw_stats->colors.cpu_load_low,
-                                        HUDElements.params->cpu_load_value[0],
-                                        HUDElements.params->cpu_load_value[1]
-                                    };
+            int cpu_load_percent = int(cpuStats.GetCPUDataTotal().percent);
+            struct LOAD_DATA cpu_data = {HUDElements.sw_stats->colors.cpu_load_high,
+                                            HUDElements.sw_stats->colors.cpu_load_med,
+                                            HUDElements.sw_stats->colors.cpu_load_low,
+                                            HUDElements.params->cpu_load_value[0],
+                                            HUDElements.params->cpu_load_value[1]
+                                        };
 
         
-        auto load_color = change_on_load_temp(cpu_data, cpu_load_percent);
-        right_aligned_text(load_color, HUDElements.ralign_width, "%d", cpu_load_percent);
-        ImGui::SameLine(0, 1.0f);
-        ImGui::TextColored(load_color, "%%");
+            auto load_color = change_on_load_temp(cpu_data, cpu_load_percent);
+            right_aligned_text(load_color, HUDElements.ralign_width, "%d", cpu_load_percent);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::TextColored(load_color, "%%");
         }
         else {
-        right_aligned_text(text_color, HUDElements.ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
-        ImGui::SameLine(0, 1.0f);
-        ImGui::Text("%%");
+            right_aligned_text(text_color, HUDElements.ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
+            ImGui::SameLine(0, 1.0f);
+            ImGui::Text("%%");
         }
 
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp]){
-        ImGui::TableNextCell();
-        right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
-        ImGui::SameLine(0, 1.0f);
-        ImGui::Text("°C");
+            ImGui::TableNextCell();
+            right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::Text("°C");
         }
     }
 }
@@ -360,39 +343,149 @@ void HudElements::media_player(){
 #endif
 }
 
-void HudElements::sort_elements(std::string string){
-    if (string == "version")
-        ordered_functions.push_back(version);
-    if (string == "time")
-        ordered_functions.push_back(time);
-    if (string == "gpu_stats")
-        ordered_functions.push_back(gpu_stats);
-    if (string == "cpu_stats")
-        ordered_functions.push_back(cpu_stats);
-    if (string == "core_load")
-        ordered_functions.push_back(core_load);
-    if (string == "io_stats")
-        ordered_functions.push_back(io_stats);
-    if (string == "vram")
-        ordered_functions.push_back(vram);
-    if (string == "ram")
-        ordered_functions.push_back(ram);
-    if (string == "fps")
-        ordered_functions.push_back(fps);
-    if (string == "engine_version")
-        ordered_functions.push_back(engine_version);
-    if (string == "gpu_name")
-        ordered_functions.push_back(gpu_name);
-    if (string == "vulkan_driver")
-        ordered_functions.push_back(vulkan_driver);
-    if (string == "arch")
-        ordered_functions.push_back(arch);
-    if (string == "wine")
-        ordered_functions.push_back(wine);
-    if (string == "frame_timing")
-        ordered_functions.push_back(frame_timing);
-    if (string == "media_player")
-        ordered_functions.push_back(media_player);
+void HudElements::graphs(){
+
+    ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
+    std::string value = HUDElements.ordered_functions[HUDElements.place].second;
+    std::vector<float> arr;
+
+    for (size_t i = 0; i < 50; i++)
+    {
+        arr.push_back(0);
+    }
+    if (value == "cpu_load"){
+        for (auto& it : graph_data){
+            arr.push_back(float(it.cpu_load));
+            arr.erase(arr.begin());
+        }
+        HUDElements.max = 100; HUDElements.min = 0;
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "CPU Load");
+        ImGui::PopFont();
+    }
+
+    if (value == "gpu_load"){
+        for (auto& it : graph_data){
+            arr.push_back(float(it.gpu_load));
+            arr.erase(arr.begin());
+        }
+        HUDElements.max = 100; HUDElements.min = 0;
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "GPU Load");
+        ImGui::PopFont();
+    }
+    
+    if (value == "gpu_core_clock"){
+        for (auto& it : graph_data){
+            arr.push_back(float(it.gpu_core_clock));
+            arr.erase(arr.begin());
+        }
+        if (int(arr.back()) > HUDElements.gpu_core_max)
+            HUDElements.gpu_core_max = arr.back();
+        HUDElements.max = HUDElements.gpu_core_max;
+        HUDElements.min = 0;
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "GPU Core Clock");
+        ImGui::PopFont();
+    }
+
+    if (value == "gpu_mem_clock"){
+        for (auto& it : graph_data){
+            arr.push_back(float(it.gpu_mem_clock));
+            arr.erase(arr.begin());
+        }
+        if (int(arr.back()) > HUDElements.gpu_mem_max)
+            HUDElements.gpu_mem_max = arr.back();
+        HUDElements.max = HUDElements.gpu_mem_max;
+        HUDElements.min = 0;
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "GPU Mem Clock");
+        ImGui::PopFont();
+    }
+    
+    if (value == "vram"){
+        for (auto& it : graph_data){
+            arr.push_back(float(it.gpu_vram_used));
+            arr.erase(arr.begin());
+        }
+        HUDElements.max = gpu_info.memoryTotal;
+        HUDElements.min = 0;
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "VRAM");
+        ImGui::PopFont();
+    }
+
+    if (value == "ram"){
+        if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram])
+            HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram] = true;
+        for (auto& it : graph_data){
+            arr.push_back(float(it.ram_used));
+            arr.erase(arr.begin());
+        }
+        HUDElements.max = memmax;
+        HUDElements.min = 0;
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "RAM");
+        ImGui::PopFont();
+    }
+    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+    ImGui::TableNextRow();
+    ImGui::PlotLines("", arr.data(),
+            arr.size(), 0,
+            NULL, HUDElements.min, HUDElements.max,
+            ImVec2(ImGui::GetContentRegionAvailWidth() * 2.5, 50));
+    ImGui::PopStyleColor(1);
+}
+
+void HudElements::sort_elements(std::pair<std::string, std::string> option){
+    auto param = option.first;
+    auto value = option.second;
+
+    if (param == "version")
+        ordered_functions.push_back({version, value});
+    if (param == "time")
+        ordered_functions.push_back({time, value});
+    if (param == "gpu_stats")
+        ordered_functions.push_back({gpu_stats, value});
+    if (param == "cpu_stats")
+        ordered_functions.push_back({cpu_stats, value});
+    if (param == "core_load")
+        ordered_functions.push_back({core_load, value});
+    if (param == "io_stats")
+        ordered_functions.push_back({io_stats, value});
+    if (param == "vram")
+        ordered_functions.push_back({vram, value});
+    if (param == "ram")
+        ordered_functions.push_back({ram, value});
+    if (param == "fps")
+        ordered_functions.push_back({fps, value});
+    if (param == "engine_version")
+        ordered_functions.push_back({engine_version, value});
+    if (param == "gpu_name")
+        ordered_functions.push_back({gpu_name, value});
+    if (param == "vulkan_driver")
+        ordered_functions.push_back({vulkan_driver, value});
+    if (param == "arch")
+        ordered_functions.push_back({arch, value});
+    if (param == "wine")
+        ordered_functions.push_back({wine, value});
+    if (param == "frame_timing")
+        ordered_functions.push_back({frame_timing, value});
+    if (param == "media_player")
+        ordered_functions.push_back({media_player, value});
+    if (param == "graphs"){
+        std::vector<std::string> permitted_params = {
+            "gpu_load", "cpu_load", "gpu_core_clock", "gpu_mem_clock",
+            "vram", "ram"
+        };
+        std::stringstream ss; ss << value;
+        while (std::getline(ss, value, '+')) {
+            if (std::find(permitted_params.begin(), permitted_params.end(), value) != permitted_params.end())
+                ordered_functions.push_back({graphs, value});
+            else
+                printf("MANGOHUD: Unrecognized graph type: %s\n", value.c_str());
+        }
+    }
 }
 
 HudElements HUDElements;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -362,7 +362,7 @@ void HudElements::media_player(){
 
 void HudElements::sort_elements(std::string string){
     if (string == "version")
-        ordered_functions.push_back(&version);
+        ordered_functions.push_back(version);
     if (string == "time")
         ordered_functions.push_back(time);
     if (string == "gpu_stats")

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1,0 +1,3 @@
+#include "hud_elements.h"
+
+HudElements HUDElements;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -374,6 +374,36 @@ void HudElements::graphs(){
         ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "GPU Load");
         ImGui::PopFont();
     }
+
+    if (value == "cpu_temp"){
+        if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp])
+            HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp] = true;
+        for (auto& it : graph_data){
+            arr.push_back(float(it.cpu_temp));
+            arr.erase(arr.begin());
+        }
+        if (int(arr.back()) > HUDElements.cpu_temp_max)
+            HUDElements.cpu_temp_max = arr.back();
+        HUDElements.max = HUDElements.cpu_temp_max;
+        HUDElements.min = 0;
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "CPU Temp");
+        ImGui::PopFont();
+    }
+
+    if (value == "gpu_temp"){
+        for (auto& it : graph_data){
+            arr.push_back(float(it.gpu_temp));
+            arr.erase(arr.begin());
+        }
+        if (int(arr.back()) > HUDElements.gpu_temp_max)
+            HUDElements.gpu_temp_max = arr.back();
+        HUDElements.max = HUDElements.gpu_temp_max;
+        HUDElements.min = 0;
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "GPU Temp");
+        ImGui::PopFont();
+    }
     
     if (value == "gpu_core_clock"){
         for (auto& it : graph_data){
@@ -476,7 +506,7 @@ void HudElements::sort_elements(std::pair<std::string, std::string> option){
     if (param == "graphs"){
         std::vector<std::string> permitted_params = {
             "gpu_load", "cpu_load", "gpu_core_clock", "gpu_mem_clock",
-            "vram", "ram"
+            "vram", "ram", "cpu_temp", "gpu_temp"
         };
         std::stringstream ss; ss << value;
         while (std::getline(ss, value, '+')) {

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -344,6 +344,22 @@ void HudElements::frame_timing(){
     }
 }
 
+void HudElements::media_player(){
+#ifdef HAVE_DBUS
+    ImGui::TableNextRow();
+    uint32_t f_idx = (HUDElements.sw_stats->n_frames - 1) % ARRAY_SIZE(HUDElements.sw_stats->frames_stats);
+    uint64_t frame_timing = HUDElements.sw_stats->frames_stats[f_idx].stats[OVERLAY_PLOTS_frame_timing];
+    ImFont scaled_font = *HUDElements.sw_stats->font_text;
+    scaled_font.Scale = HUDElements.params->font_scale_media_player;
+    ImGui::PushFont(&scaled_font);
+    {
+        std::lock_guard<std::mutex> lck(main_metadata.mtx);
+        render_mpris_metadata(*HUDElements.params, main_metadata, frame_timing, true);
+    }
+    ImGui::PopFont();
+#endif
+}
+
 void HudElements::sort_elements(std::string string){
     if (string == "version")
         ordered_functions.push_back(&version);
@@ -375,6 +391,8 @@ void HudElements::sort_elements(std::string string){
         ordered_functions.push_back(wine);
     if (string == "frame_timing")
         ordered_functions.push_back(frame_timing);
+    if (string == "media_player")
+        ordered_functions.push_back(media_player);
 }
 
 HudElements HUDElements;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1,3 +1,380 @@
+#include <algorithm>
 #include "hud_elements.h"
+#include "cpu.h"
+#include "memory.h"
+#include "mesa/util/macros.h"
+// void HudElements::newRow(){
+//     ImGui::TableNextRow();
+// }
+
+// void HudElements::text(){
+//     auto text = HUDElements.options.at(HUDElements.place);
+//     text.erase(std::remove(text.begin(), text.end(), '%'), text.end());
+//     size_t underscores_found = text.find("_");
+//     // remove all underscores
+//     for (size_t i = 0; i < underscores_found; i++)
+//     {
+//         text.replace(text.find("_"), 1, " ");
+//     }
+
+//     printf("%s\n", text.c_str());
+//     ImGui::Text(text.c_str());
+// }
+
+void HudElements::time(){
+    ImGui::TableNextRow();
+    ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 1.00f), "%s", HUDElements.sw_stats->time.c_str());
+}
+
+void HudElements::version(){
+    ImGui::TableNextRow();
+    ImGui::Text("%s", MANGOHUD_VERSION);
+}
+
+void HudElements::gpu_stats(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats]){
+        ImGui::TableNextRow();
+        const char* gpu_text;
+        if (HUDElements.params->gpu_text.empty())
+        gpu_text = "GPU";
+        else
+        gpu_text = HUDElements.params->gpu_text.c_str();
+        ImGui::TextColored(HUDElements.sw_stats->colors.gpu, "%s", gpu_text);
+        ImGui::TableNextCell();
+        auto text_color = HUDElements.sw_stats->colors.text;
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
+        struct LOAD_DATA gpu_data = {HUDElements.sw_stats->colors.gpu_load_high,
+                                        HUDElements.sw_stats->colors.gpu_load_med,
+                                        HUDElements.sw_stats->colors.gpu_load_low,
+                                        HUDElements.params->gpu_load_value[0],
+                                        HUDElements.params->gpu_load_value[1]
+                                    };
+
+        
+        auto load_color = change_on_load_temp(gpu_data, gpu_info.load);
+        right_aligned_text(load_color, HUDElements.ralign_width, "%i", gpu_info.load);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::TextColored(load_color,"%%");
+        }
+        else {
+        right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.load);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::TextColored(text_color,"%%");
+        // ImGui::SameLine(150);
+        // ImGui::Text("%s", "%");
+        }
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp]){
+        ImGui::TableNextCell();
+        right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.temp);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::Text("°C");
+        }
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock] || HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_power])
+        ImGui::TableNextRow();
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock]){
+        ImGui::TableNextCell();
+        right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.CoreClock);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("MHz");
+        ImGui::PopFont();
+        }
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_power]) {
+        ImGui::TableNextCell();
+        right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.powerUsage);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("W");
+        ImGui::PopFont();
+        }
+    }
+}
+
+void HudElements::cpu_stats(){
+    if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats]){
+        ImGui::TableNextRow();
+        const char* cpu_text;
+        if (HUDElements.params->cpu_text.empty())
+        cpu_text = "CPU";
+        else
+        cpu_text = HUDElements.params->cpu_text.c_str();
+        ImGui::TextColored(HUDElements.sw_stats->colors.cpu, "%s", cpu_text);
+        ImGui::TableNextCell();
+        auto text_color = HUDElements.sw_stats->colors.text;
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_load_change]){
+        int cpu_load_percent = int(cpuStats.GetCPUDataTotal().percent);
+        struct LOAD_DATA cpu_data = {HUDElements.sw_stats->colors.cpu_load_high,
+                                        HUDElements.sw_stats->colors.cpu_load_med,
+                                        HUDElements.sw_stats->colors.cpu_load_low,
+                                        HUDElements.params->cpu_load_value[0],
+                                        HUDElements.params->cpu_load_value[1]
+                                    };
+
+        
+        auto load_color = change_on_load_temp(cpu_data, cpu_load_percent);
+        right_aligned_text(load_color, HUDElements.ralign_width, "%d", cpu_load_percent);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::TextColored(load_color, "%%");
+        }
+        else {
+        right_aligned_text(text_color, HUDElements.ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
+        ImGui::SameLine(0, 1.0f);
+        ImGui::Text("%%");
+        }
+
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp]){
+        ImGui::TableNextCell();
+        right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::Text("°C");
+        }
+    }
+}
+
+void HudElements::core_load(){
+         int i = 0;
+         for (const CPUData &cpuData : cpuStats.GetCPUData())
+         {
+            ImGui::TableNextRow();
+            ImGui::TextColored(HUDElements.sw_stats->colors.cpu, "CPU");
+            ImGui::SameLine(0, 1.0f);
+            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::TextColored(HUDElements.sw_stats->colors.cpu,"%i", i);
+            ImGui::PopFont();
+            ImGui::TableNextCell();
+            right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%i", int(cpuData.percent));
+            ImGui::SameLine(0, 1.0f);
+            ImGui::Text("%%");
+            ImGui::TableNextCell();
+            right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%i", cpuData.mhz);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::Text("MHz");
+            ImGui::PopFont();
+            i++;
+         }
+}
+void HudElements::io_stats(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read] || HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write]){
+        auto sampling = HUDElements.params->fps_sampling_period;
+        ImGui::TableNextRow();
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write])
+        ImGui::TextColored(HUDElements.sw_stats->colors.io, "IO RD");
+        else if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read] && HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write])
+        ImGui::TextColored(HUDElements.sw_stats->colors.io, "IO RW");
+        else if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read])
+        ImGui::TextColored(HUDElements.sw_stats->colors.io, "IO WR");
+
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read]){
+        ImGui::TableNextCell();
+        float val = HUDElements.sw_stats->io.diff.read * 1000000 / sampling;
+        right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, val < 100 ? "%.1f" : "%.f", val);
+        ImGui::SameLine(0,1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("MiB/s");
+        ImGui::PopFont();
+        }
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write]){
+        ImGui::TableNextCell();
+        float val = HUDElements.sw_stats->io.diff.write * 1000000 / sampling;
+        right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, val < 100 ? "%.1f" : "%.f", val);
+        ImGui::SameLine(0,1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("MiB/s");
+        ImGui::PopFont();
+        }
+    }
+}
+
+void HudElements::vram(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vram]){
+        ImGui::TableNextRow();
+        ImGui::TextColored(HUDElements.sw_stats->colors.vram, "VRAM");
+        ImGui::TableNextCell();
+        right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%.1f", gpu_info.memoryUsed);
+        ImGui::SameLine(0,1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("GiB");
+        ImGui::PopFont();
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_mem_clock]){
+            ImGui::TableNextCell();
+            right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%i", gpu_info.MemClock);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::Text("MHz");
+            ImGui::PopFont();
+        }
+    }
+}
+void HudElements::ram(){
+#ifdef __gnu_linux__  
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram]){
+         ImGui::TableNextRow();
+         ImGui::TextColored(HUDElements.sw_stats->colors.ram, "RAM");
+         ImGui::TableNextCell();
+         right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%.1f", memused);
+         ImGui::SameLine(0,1.0f);
+         ImGui::PushFont(HUDElements.sw_stats->font1);
+         ImGui::Text("GiB");
+         ImGui::PopFont();
+      }
+#endif
+}
+
+void HudElements::fps(){
+if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fps]){
+        ImGui::TableNextRow();
+        if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fps] && HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_engine_version]){
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", HUDElements.is_vulkan ? HUDElements.sw_stats->engineName.c_str() : "OpenGL");
+        }
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", HUDElements.is_vulkan ? HUDElements.sw_stats->engineName.c_str() : "OpenGL");
+        ImGui::TableNextCell();
+        right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%.0f", HUDElements.sw_stats->fps);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("FPS");
+        ImGui::PopFont();
+        ImGui::TableNextCell();
+        right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%.1f", 1000 / HUDElements.sw_stats->fps);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("ms");
+        ImGui::PopFont();
+    }
+}
+
+void HudElements::gpu_name(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_name] && !HUDElements.sw_stats->gpuName.empty()){
+        ImGui::TableNextRow();
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine,
+            "%s", HUDElements.sw_stats->gpuName.c_str());
+        ImGui::PopFont();
+    }
+}
+void HudElements::engine_version(){
+    ImGui::TableNextRow();
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_engine_version]){
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        if (HUDElements.is_vulkan) {
+            if ((HUDElements.sw_stats->engineName == "DXVK" || HUDElements.sw_stats->engineName == "VKD3D")){
+                ImGui::TextColored(HUDElements.sw_stats->colors.engine,
+                    "%s/%d.%d.%d", HUDElements.sw_stats->engineVersion.c_str(),
+                    HUDElements.sw_stats->version_vk.major,
+                    HUDElements.sw_stats->version_vk.minor,
+                    HUDElements.sw_stats->version_vk.patch);
+            } else {
+                ImGui::TextColored(HUDElements.sw_stats->colors.engine,
+                    "%d.%d.%d",
+                    HUDElements.sw_stats->version_vk.major,
+                    HUDElements.sw_stats->version_vk.minor,
+                    HUDElements.sw_stats->version_vk.patch);
+            }
+        } else {
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine,
+            "%d.%d%s", HUDElements.sw_stats->version_gl.major, HUDElements.sw_stats->version_gl.minor,
+            HUDElements.sw_stats->version_gl.is_gles ? " ES" : "");
+        }
+        // ImGui::SameLine();
+        ImGui::PopFont();
+    }
+}
+
+void HudElements::vulkan_driver(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vulkan_driver] && !HUDElements.sw_stats->driverName.empty()){
+        ImGui::TableNextRow();
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine,
+            "%s", HUDElements.sw_stats->driverName.c_str());
+        ImGui::PopFont();
+    }
+}
+
+void HudElements::arch(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_arch]){
+        ImGui::TableNextRow();
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "" MANGOHUD_ARCH);
+        ImGui::PopFont();
+    }
+}
+
+void HudElements::wine(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_wine]){
+        ImGui::TableNextRow();
+        if (!wineVersion.empty()){
+            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::TextColored(HUDElements.sw_stats->colors.wine, "%s", wineVersion.c_str());
+            ImGui::PopFont();
+        }
+    }
+}
+
+void HudElements::frame_timing(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_frame_timing]){
+        ImGui::TableNextRow();
+        ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::TextColored(HUDElements.sw_stats->colors.engine, "%s", "Frametime");
+        ImGui::PopFont();
+        ImGui::TableNextRow();
+        char hash[40];
+        snprintf(hash, sizeof(hash), "##%s", overlay_param_names[OVERLAY_PARAM_ENABLED_frame_timing]);
+        HUDElements.sw_stats->stat_selector = OVERLAY_PLOTS_frame_timing;
+        HUDElements.sw_stats->time_dividor = 1000.0f;
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+        double min_time = 0.0f;
+        double max_time = 50.0f;
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_histogram]){
+        ImGui::PlotHistogram(hash, get_time_stat, HUDElements.sw_stats,
+                                ARRAY_SIZE(HUDElements.sw_stats->frames_stats), 0,
+                                NULL, min_time, max_time,
+                                ImVec2(ImGui::GetContentRegionAvailWidth() * 2.5, 50));
+        } else {
+        ImGui::PlotLines(hash, get_time_stat, HUDElements.sw_stats,
+                    ARRAY_SIZE(HUDElements.sw_stats->frames_stats), 0,
+                    NULL, min_time, max_time,
+                    ImVec2(ImGui::GetContentRegionAvailWidth() * 2.5, 50));
+        }
+        ImGui::PopStyleColor();
+        ImGui::SameLine(0,1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("%.1f ms", 1000 / HUDElements.sw_stats->fps); //frame_timing / 1000.f);
+        ImGui::PopFont();
+    }
+}
+
+void HudElements::sort_elements(std::string string){
+    if (string == "version")
+        HUDElements.ordered_functions.push_back(HUDElements.version);
+    if (string == "time")
+        HUDElements.ordered_functions.push_back(HUDElements.time);
+    if (string == "gpu_stats")
+        HUDElements.ordered_functions.push_back(HUDElements.gpu_stats);
+    if (string == "cpu_stats")
+        HUDElements.ordered_functions.push_back(HUDElements.cpu_stats);
+    if (string == "core_load")
+        HUDElements.ordered_functions.push_back(HUDElements.core_load);
+    if (string == "io_stats")
+        HUDElements.ordered_functions.push_back(HUDElements.io_stats);
+    if (string == "vram")
+        HUDElements.ordered_functions.push_back(HUDElements.vram);
+    if (string == "ram")
+        HUDElements.ordered_functions.push_back(HUDElements.ram);
+    if (string == "fps")
+        HUDElements.ordered_functions.push_back(HUDElements.fps);
+    if (string == "engine_version")
+        HUDElements.ordered_functions.push_back(HUDElements.engine_version);
+    if (string == "gpu_name")
+        HUDElements.ordered_functions.push_back(HUDElements.gpu_name);
+    if (string == "vulkan_driver")
+        HUDElements.ordered_functions.push_back(HUDElements.vulkan_driver);
+    if (string == "arch")
+        HUDElements.ordered_functions.push_back(HUDElements.arch);
+    if (string == "wine")
+        HUDElements.ordered_functions.push_back(HUDElements.wine);
+    if (string == "frame_timing")
+        HUDElements.ordered_functions.push_back(HUDElements.frame_timing);
+}
 
 HudElements HUDElements;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -5,13 +5,17 @@
 #include "mesa/util/macros.h"
 
 void HudElements::time(){
-    ImGui::TableNextRow();
-    ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 1.00f), "%s", HUDElements.sw_stats->time.c_str());
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_time]){
+        ImGui::TableNextRow();
+        ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 1.00f), "%s", HUDElements.sw_stats->time.c_str());
+    }
 }
 
 void HudElements::version(){
-    ImGui::TableNextRow();
-    ImGui::Text("%s", MANGOHUD_VERSION);
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_version]){
+        ImGui::TableNextRow();
+        ImGui::Text("%s", MANGOHUD_VERSION);
+    }
 }
 
 void HudElements::gpu_stats(){
@@ -115,6 +119,7 @@ void HudElements::cpu_stats(){
 }
 
 void HudElements::core_load(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_core_load]){
          int i = 0;
          for (const CPUData &cpuData : cpuStats.GetCPUData())
          {
@@ -136,6 +141,7 @@ void HudElements::core_load(){
             ImGui::PopFont();
             i++;
          }
+    }
 }
 void HudElements::io_stats(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read] || HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write]){
@@ -236,8 +242,8 @@ void HudElements::gpu_name(){
     }
 }
 void HudElements::engine_version(){
-    ImGui::TableNextRow();
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_engine_version]){
+        ImGui::TableNextRow();
         ImGui::PushFont(HUDElements.sw_stats->font1);
         if (HUDElements.is_vulkan) {
             if ((HUDElements.sw_stats->engineName == "DXVK" || HUDElements.sw_stats->engineName == "VKD3D")){
@@ -258,7 +264,6 @@ void HudElements::engine_version(){
             "%d.%d%s", HUDElements.sw_stats->version_gl.major, HUDElements.sw_stats->version_gl.minor,
             HUDElements.sw_stats->version_gl.is_gles ? " ES" : "");
         }
-        // ImGui::SameLine();
         ImGui::PopFont();
     }
 }
@@ -473,51 +478,52 @@ void HudElements::sort_elements(std::pair<std::string, std::string> option){
     auto param = option.first;
     auto value = option.second;
 
-    if (param == "version")
-        ordered_functions.push_back({version, value});
-    if (param == "time")
-        ordered_functions.push_back({time, value});
-    if (param == "gpu_stats")
-        ordered_functions.push_back({gpu_stats, value});
-    if (param == "cpu_stats")
-        ordered_functions.push_back({cpu_stats, value});
-    if (param == "core_load")
-        ordered_functions.push_back({core_load, value});
-    if (param == "io_stats")
-        ordered_functions.push_back({io_stats, value});
-    if (param == "vram")
-        ordered_functions.push_back({vram, value});
-    if (param == "ram")
-        ordered_functions.push_back({ram, value});
-    if (param == "fps")
-        ordered_functions.push_back({fps, value});
-    if (param == "engine_version")
-        ordered_functions.push_back({engine_version, value});
-    if (param == "gpu_name")
-        ordered_functions.push_back({gpu_name, value});
-    if (param == "vulkan_driver")
-        ordered_functions.push_back({vulkan_driver, value});
-    if (param == "arch")
-        ordered_functions.push_back({arch, value});
-    if (param == "wine")
-        ordered_functions.push_back({wine, value});
-    if (param == "frame_timing")
-        ordered_functions.push_back({frame_timing, value});
-    if (param == "media_player")
-        ordered_functions.push_back({media_player, value});
+    if (param == "version")         { ordered_functions.push_back({version, value});        }
+    if (param == "time")            { ordered_functions.push_back({time, value});           }
+    if (param == "gpu_stats")       { ordered_functions.push_back({gpu_stats, value});      }
+    if (param == "cpu_stats")       { ordered_functions.push_back({cpu_stats, value});      }
+    if (param == "core_load")       { ordered_functions.push_back({core_load, value});      }
+    if (param == "io_stats")        { ordered_functions.push_back({io_stats, value});       }
+    if (param == "vram")            { ordered_functions.push_back({vram, value});           }
+    if (param == "ram")             { ordered_functions.push_back({ram, value});            }
+    if (param == "fps")             { ordered_functions.push_back({fps, value});            }
+    if (param == "engine_version")  { ordered_functions.push_back({engine_version, value}); }
+    if (param == "gpu_name")        { ordered_functions.push_back({gpu_name, value});       }
+    if (param == "vulkan_driver")   { ordered_functions.push_back({vulkan_driver, value});  }
+    if (param == "arch")            { ordered_functions.push_back({arch, value});           }    
+    if (param == "wine")            { ordered_functions.push_back({wine, value});           }
+    if (param == "frame_timing")    { ordered_functions.push_back({frame_timing, value});   }
+    if (param == "media_player")    { ordered_functions.push_back({media_player, value});   }
     if (param == "graphs"){
-        std::vector<std::string> permitted_params = {
-            "gpu_load", "cpu_load", "gpu_core_clock", "gpu_mem_clock",
-            "vram", "ram", "cpu_temp", "gpu_temp"
-        };
-        std::stringstream ss; ss << value;
-        while (std::getline(ss, value, '+')) {
-            if (std::find(permitted_params.begin(), permitted_params.end(), value) != permitted_params.end())
+    stringstream ss; ss << value;
+        while (getline(ss, value, '+')) {
+            if (find(permitted_params.begin(), permitted_params.end(), value) != permitted_params.end())
                 ordered_functions.push_back({graphs, value});
             else
                 printf("MANGOHUD: Unrecognized graph type: %s\n", value.c_str());
         }
     }
+    return;
+}
+
+void HudElements::legacy_elements(){
+    string value = "NULL";
+    ordered_functions.push_back({time,               value});
+    ordered_functions.push_back({version,            value});
+    ordered_functions.push_back({gpu_stats,          value});
+    ordered_functions.push_back({cpu_stats,          value});
+    ordered_functions.push_back({core_load,          value});
+    ordered_functions.push_back({io_stats,           value});
+    ordered_functions.push_back({vram,               value});
+    ordered_functions.push_back({ram,                value});
+    ordered_functions.push_back({fps,                value});
+    ordered_functions.push_back({engine_version,     value});
+    ordered_functions.push_back({gpu_name,           value});
+    ordered_functions.push_back({vulkan_driver,      value});
+    ordered_functions.push_back({arch,               value});
+    ordered_functions.push_back({wine,               value});
+    ordered_functions.push_back({frame_timing,       value});
+    ordered_functions.push_back({media_player,       value});
 }
 
 HudElements HUDElements;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -346,35 +346,35 @@ void HudElements::frame_timing(){
 
 void HudElements::sort_elements(std::string string){
     if (string == "version")
-        HUDElements.ordered_functions.push_back(HUDElements.version);
+        ordered_functions.push_back(&version);
     if (string == "time")
-        HUDElements.ordered_functions.push_back(HUDElements.time);
+        ordered_functions.push_back(time);
     if (string == "gpu_stats")
-        HUDElements.ordered_functions.push_back(HUDElements.gpu_stats);
+        ordered_functions.push_back(gpu_stats);
     if (string == "cpu_stats")
-        HUDElements.ordered_functions.push_back(HUDElements.cpu_stats);
+        ordered_functions.push_back(cpu_stats);
     if (string == "core_load")
-        HUDElements.ordered_functions.push_back(HUDElements.core_load);
+        ordered_functions.push_back(core_load);
     if (string == "io_stats")
-        HUDElements.ordered_functions.push_back(HUDElements.io_stats);
+        ordered_functions.push_back(io_stats);
     if (string == "vram")
-        HUDElements.ordered_functions.push_back(HUDElements.vram);
+        ordered_functions.push_back(vram);
     if (string == "ram")
-        HUDElements.ordered_functions.push_back(HUDElements.ram);
+        ordered_functions.push_back(ram);
     if (string == "fps")
-        HUDElements.ordered_functions.push_back(HUDElements.fps);
+        ordered_functions.push_back(fps);
     if (string == "engine_version")
-        HUDElements.ordered_functions.push_back(HUDElements.engine_version);
+        ordered_functions.push_back(engine_version);
     if (string == "gpu_name")
-        HUDElements.ordered_functions.push_back(HUDElements.gpu_name);
+        ordered_functions.push_back(gpu_name);
     if (string == "vulkan_driver")
-        HUDElements.ordered_functions.push_back(HUDElements.vulkan_driver);
+        ordered_functions.push_back(vulkan_driver);
     if (string == "arch")
-        HUDElements.ordered_functions.push_back(HUDElements.arch);
+        ordered_functions.push_back(arch);
     if (string == "wine")
-        HUDElements.ordered_functions.push_back(HUDElements.wine);
+        ordered_functions.push_back(wine);
     if (string == "frame_timing")
-        HUDElements.ordered_functions.push_back(HUDElements.frame_timing);
+        ordered_functions.push_back(frame_timing);
 }
 
 HudElements HUDElements;

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -16,7 +16,12 @@ class HudElements{
         std::vector<std::pair<std::string, std::string>> options;
         std::vector<std::pair<void(*)(), std::string >> ordered_functions;
         int min, max, gpu_core_max, gpu_mem_max, cpu_temp_max, gpu_temp_max;
+        std::vector<std::string> permitted_params = {
+            "gpu_load", "cpu_load", "gpu_core_clock", "gpu_mem_clock",
+            "vram", "ram", "cpu_temp", "gpu_temp"
+        };
         void sort_elements(std::pair<std::string, std::string> option);
+        void legacy_elements();
         static void version();
         static void time();
         static void gpu_stats();

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -15,7 +15,7 @@ class HudElements{
         int place;
         std::vector<std::pair<std::string, std::string>> options;
         std::vector<std::pair<void(*)(), std::string >> ordered_functions;
-        int min, max, gpu_core_max, gpu_mem_max;
+        int min, max, gpu_core_max, gpu_mem_max, cpu_temp_max, gpu_temp_max;
         void sort_elements(std::pair<std::string, std::string> option);
         static void version();
         static void time();

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -1,9 +1,33 @@
 #pragma once
 #include "overlay.h"
 #include "overlay_params.h"
+#include <functional>
+
 class HudElements{
     public:
+        struct swapchain_stats *sw_stats;
+        struct overlay_params *params;
+        float ralign_width;
+        float old_scale;
+        bool is_vulkan;
         std::vector<std::string> options;
+        std::vector<void(*)()> ordered_functions;
+        void sort_elements(std::string string);
+        static void version();
+        static void time();
+        static void gpu_stats();
+        static void cpu_stats();
+        static void core_load();
+        static void io_stats();
+        static void vram();
+        static void ram();
+        static void fps();
+        static void engine_version();
+        static void gpu_name();
+        static void vulkan_driver();
+        static void arch();
+        static void wine();
+        static void frame_timing();
 };
 
 extern HudElements HUDElements;

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -28,6 +28,7 @@ class HudElements{
         static void arch();
         static void wine();
         static void frame_timing();
+        static void media_player();
 };
 
 extern HudElements HUDElements;

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "overlay.h"
+#include "overlay_params.h"
+class HudElements{
+    public:
+        std::vector<std::string> options;
+};
+
+extern HudElements HUDElements;

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -2,6 +2,8 @@
 #include "overlay.h"
 #include "overlay_params.h"
 #include <functional>
+#include <map>
+#include <sstream>
 
 class HudElements{
     public:
@@ -10,9 +12,11 @@ class HudElements{
         float ralign_width;
         float old_scale;
         bool is_vulkan;
-        std::vector<std::string> options;
-        std::vector<void(*)()> ordered_functions;
-        void sort_elements(std::string string);
+        int place;
+        std::vector<std::pair<std::string, std::string>> options;
+        std::vector<std::pair<void(*)(), std::string >> ordered_functions;
+        int min, max, gpu_core_max, gpu_mem_max;
+        void sort_elements(std::pair<std::string, std::string> option);
         static void version();
         static void time();
         static void gpu_stats();
@@ -29,6 +33,7 @@ class HudElements{
         static void wine();
         static void frame_timing();
         static void media_player();
+        static void graphs();
 };
 
 extern HudElements HUDElements;

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,7 @@ foreach s : ['overlay.frag', 'overlay.vert']
 endforeach
 
 vklayer_files = files(
+  'hud_elements.cpp',
   'overlay.cpp',
   'overlay_params.cpp',
   'font.cpp',

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -118,4 +118,9 @@ void convert_colors(bool do_conv, struct swapchain_stats& sw_stats, struct overl
 void right_aligned_text(ImVec4& col, float off_x, const char *fmt, ...);
 ImVec4 change_on_load_temp (struct LOAD_DATA& data, int current);
 float get_time_stat(void *_data, int _idx);
+
+#ifdef HAVE_DBUS
+void render_mpris_metadata(struct overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing, bool is_main);
+#endif
+
 #endif //MANGOHUD_OVERLAY_H

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -9,7 +9,13 @@
 #include "overlay_params.h"
 #include "iostats.h"
 #include "timing.hpp"
-
+#include "hud_elements.h"
+#include "version.h"
+#include "gpu.h"
+#ifdef HAVE_DBUS
+#include "dbus_info.h"
+extern float g_overflow;
+#endif
 struct frame_stat {
    uint64_t stats[OVERLAY_PLOTS_MAX];
 };
@@ -94,6 +100,7 @@ extern int32_t deviceID;
 
 extern struct benchmark_stats benchmark;
 extern ImVec2 real_font_size;
+extern std::string wineVersion;
 
 void position_layer(struct swapchain_stats& data, struct overlay_params& params, ImVec2 window_size);
 void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, bool is_vulkan);
@@ -108,5 +115,7 @@ void get_device_name(int32_t vendorID, int32_t deviceID, struct swapchain_stats&
 void calculate_benchmark_data(void *params_void);
 void create_fonts(const overlay_params& params, ImFont*& small_font, ImFont*& text_font);
 void convert_colors(bool do_conv, struct swapchain_stats& sw_stats, struct overlay_params& params);
-
+void right_aligned_text(ImVec4& col, float off_x, const char *fmt, ...);
+ImVec4 change_on_load_temp (struct LOAD_DATA& data, int current);
+float get_time_stat(void *_data, int _idx);
 #endif //MANGOHUD_OVERLAY_H

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -12,6 +12,7 @@
 #include "hud_elements.h"
 #include "version.h"
 #include "gpu.h"
+#include "logging.h"
 #ifdef HAVE_DBUS
 #include "dbus_info.h"
 extern float g_overflow;
@@ -101,6 +102,7 @@ extern int32_t deviceID;
 extern struct benchmark_stats benchmark;
 extern ImVec2 real_font_size;
 extern std::string wineVersion;
+extern std::vector<logData> graph_data;
 
 void position_layer(struct swapchain_stats& data, struct overlay_params& params, ImVec2 window_size);
 void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, bool is_vulkan);

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -441,7 +441,7 @@ parse_overlay_env(struct overlay_params *params,
    char key[256], value[256];
    while ((num = parse_string(env, key, value)) != 0) {
       env += num;
-      HUDElements.sort_elements(key);
+      HUDElements.sort_elements({key, value});
       if (!strcmp("full", key)) {
          bool read_cfg = params->enabled[OVERLAY_PARAM_ENABLED_read_cfg];
 #define OVERLAY_PARAM_BOOL(name) \

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -497,6 +497,7 @@ parse_overlay_config(struct overlay_params *params,
    params->enabled[OVERLAY_PARAM_ENABLED_wine] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_load_change] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_load_change] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_legacy_layout] = true;
    params->fps_sampling_period = 500000; /* 500ms */
    params->width = 0;
    params->height = 140;
@@ -671,6 +672,11 @@ parse_overlay_config(struct overlay_params *params,
       printf("MANGOHUD: output_file is Deprecated, use output_folder instead\n");
    auto real_size = params->font_size * params->font_scale;
    real_font_size = ImVec2(real_size, real_size / 2);
-   for (auto& option : HUDElements.options)
-      HUDElements.sort_elements(option);
+   HUDElements.params = params;
+   if (params->enabled[OVERLAY_PARAM_ENABLED_legacy_layout]){
+        HUDElements.legacy_elements();
+   } else {
+      for (auto& option : HUDElements.options)
+         HUDElements.sort_elements(option);
+   }
 }

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -20,6 +20,7 @@
 #include "overlay.h"
 #include "config.h"
 #include "string_utils.h"
+#include "hud_elements.h"
 
 #include "mesa/util/os_socket.h"
 
@@ -491,6 +492,7 @@ parse_overlay_config(struct overlay_params *params,
    params->enabled[OVERLAY_PARAM_ENABLED_read_cfg] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_io_read] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_io_write] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_io_stats] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_wine] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_load_change] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_load_change] = false;
@@ -668,4 +670,7 @@ parse_overlay_config(struct overlay_params *params,
       printf("MANGOHUD: output_file is Deprecated, use output_folder instead\n");
    auto real_size = params->font_size * params->font_scale;
    real_font_size = ImVec2(real_size, real_size / 2);
+   HUDElements.ordered_functions.clear();
+   for (auto& option : HUDElements.options)
+      HUDElements.sort_elements(option);
 }

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -441,6 +441,7 @@ parse_overlay_env(struct overlay_params *params,
    char key[256], value[256];
    while ((num = parse_string(env, key, value)) != 0) {
       env += num;
+      HUDElements.sort_elements(key);
       if (!strcmp("full", key)) {
          bool read_cfg = params->enabled[OVERLAY_PARAM_ENABLED_read_cfg];
 #define OVERLAY_PARAM_BOOL(name) \
@@ -559,7 +560,7 @@ parse_overlay_config(struct overlay_params *params,
    #define parse_reload_cfg(x)         params->reload_cfg
 #endif
 
-
+   HUDElements.ordered_functions.clear();
    // first pass with env var
    if (env)
       parse_overlay_env(params, env);
@@ -600,8 +601,8 @@ parse_overlay_config(struct overlay_params *params,
    }
 
    // second pass, override config file settings with MANGOHUD_CONFIG
-   if (env && read_cfg)
-      parse_overlay_env(params, env);
+   // if (env && read_cfg)
+   //    parse_overlay_env(params, env);
 
    if (params->font_scale_media_player <= 0.f)
       params->font_scale_media_player = 0.55f;
@@ -670,7 +671,6 @@ parse_overlay_config(struct overlay_params *params,
       printf("MANGOHUD: output_file is Deprecated, use output_folder instead\n");
    auto real_size = params->font_size * params->font_scale;
    real_font_size = ImVec2(real_size, real_size / 2);
-   HUDElements.ordered_functions.clear();
    for (auto& option : HUDElements.options)
       HUDElements.sort_elements(option);
 }

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -54,6 +54,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(gpu_load_change)               \
    OVERLAY_PARAM_BOOL(cpu_load_change)               \
    OVERLAY_PARAM_BOOL(graphs)                        \
+   OVERLAY_PARAM_BOOL(legacy_layout)                 \
    OVERLAY_PARAM_CUSTOM(fps_sampling_period)         \
    OVERLAY_PARAM_CUSTOM(output_folder)               \
    OVERLAY_PARAM_CUSTOM(output_file)                 \

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -39,6 +39,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(read_cfg)                      \
    OVERLAY_PARAM_BOOL(io_read)                       \
    OVERLAY_PARAM_BOOL(io_write)                      \
+   OVERLAY_PARAM_BOOL(io_stats)                      \
    OVERLAY_PARAM_BOOL(gpu_mem_clock)                 \
    OVERLAY_PARAM_BOOL(gpu_core_clock)                \
    OVERLAY_PARAM_BOOL(gpu_power)                     \
@@ -159,7 +160,7 @@ struct overlay_params {
    bool help;
    bool no_display;
    bool full;
-   bool io_read, io_write;
+   bool io_read, io_write, io_stats;
    unsigned width;
    unsigned height;
    int offset_x, offset_y;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -53,6 +53,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(wine)                          \
    OVERLAY_PARAM_BOOL(gpu_load_change)               \
    OVERLAY_PARAM_BOOL(cpu_load_change)               \
+   OVERLAY_PARAM_BOOL(graphs)                        \
    OVERLAY_PARAM_CUSTOM(fps_sampling_period)         \
    OVERLAY_PARAM_CUSTOM(output_folder)               \
    OVERLAY_PARAM_CUSTOM(output_file)                 \
@@ -92,7 +93,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(background_color)            \
    OVERLAY_PARAM_CUSTOM(io_color)                    \
    OVERLAY_PARAM_CUSTOM(text_color)                  \
-   OVERLAY_PARAM_CUSTOM (wine_color)                 \
+   OVERLAY_PARAM_CUSTOM(wine_color)                  \
    OVERLAY_PARAM_CUSTOM(alpha)                       \
    OVERLAY_PARAM_CUSTOM(log_duration)                \
    OVERLAY_PARAM_CUSTOM(pci_dev)                     \
@@ -107,9 +108,8 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(help)                        \
    OVERLAY_PARAM_CUSTOM(gpu_load_value)              \
    OVERLAY_PARAM_CUSTOM(cpu_load_value)              \
-   OVERLAY_PARAM_CUSTOM(gpu_load_color)             \
-   OVERLAY_PARAM_CUSTOM(cpu_load_color)
-
+   OVERLAY_PARAM_CUSTOM(gpu_load_color)              \
+   OVERLAY_PARAM_CUSTOM(cpu_load_color)              \
 
 enum overlay_param_position {
    LAYER_POSITION_TOP_LEFT,

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -952,8 +952,11 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
    if (!params.no_display){
       ImGui::Begin("Main", &open, ImGuiWindowFlags_NoDecoration);
       ImGui::BeginTable("hud", params.tableCols, ImGuiTableFlags_NoClipX);
-      for (auto& func : HUDElements.ordered_functions)
-         func();
+      HUDElements.place = 0;
+      for (auto& func : HUDElements.ordered_functions){
+         func.first();
+         HUDElements.place += 1;
+      }
       ImGui::EndTable();
 
       if(logger->is_active())

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -939,8 +939,6 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
    HUDElements.is_vulkan = is_vulkan;
    ImGui::GetIO().FontGlobalScale = params.font_scale;
    if(not logger) logger = std::make_unique<Logger>(&params);
-   uint32_t f_idx = (data.n_frames - 1) % ARRAY_SIZE(data.frames_stats);
-   uint64_t frame_timing = data.frames_stats[f_idx].stats[OVERLAY_PLOTS_frame_timing];
    static float ralign_width = 0, old_scale = 0;
    window_size = ImVec2(params.width, params.height);
    unsigned height = ImGui::GetIO().DisplaySize.y;
@@ -957,18 +955,6 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
       for (auto& func : HUDElements.ordered_functions)
          func();
       ImGui::EndTable();
-
-#ifdef HAVE_DBUS
-      ImFont scaled_font = *data.font_text;
-      scaled_font.Scale = params.font_scale_media_player;
-      ImGui::PushFont(&scaled_font);
-      {
-         std::lock_guard<std::mutex> lck(main_metadata.mtx);
-         render_mpris_metadata(params, main_metadata, frame_timing, true);
-      }
-      //render_mpris_metadata(params, generic_mpris, frame_timing, false);
-      ImGui::PopFont();
-#endif
 
       if(logger->is_active())
          ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(data.main_window_pos.x + window_size.x - 15, data.main_window_pos.y + 15), 10, params.engine_color, 20);

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -61,12 +61,10 @@
 #include "memory.h"
 #include "notify.h"
 #include "blacklist.h"
-#include "version.h"
 #include "pci_ids.h"
 #include "timing.hpp"
 
 #ifdef HAVE_DBUS
-#include "dbus_info.h"
 float g_overflow = 50.f /* 3333ms * 0.5 / 16.6667 / 2 (to edge and back) */;
 #endif
 
@@ -689,7 +687,7 @@ static void snapshot_swapchain_frame(struct swapchain_data *data)
    // }
 }
 
-static float get_time_stat(void *_data, int _idx)
+float get_time_stat(void *_data, int _idx)
 {
    struct swapchain_stats *data = (struct swapchain_stats *) _data;
    if ((ARRAY_SIZE(data->frames_stats) - _idx) > data->n_frames)
@@ -740,7 +738,7 @@ void position_layer(struct swapchain_stats& data, struct overlay_params& params,
    }
 }
 
-static void right_aligned_text(ImVec4& col, float off_x, const char *fmt, ...)
+void right_aligned_text(ImVec4& col, float off_x, const char *fmt, ...)
 {
    ImVec2 pos = ImGui::GetCursorPos();
    char buffer[32] {};
@@ -777,7 +775,7 @@ float get_ticker_limited_pos(float pos, float tw, float& left_limit, float& righ
 }
 
 #ifdef HAVE_DBUS
-static void render_mpris_metadata(struct overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing, bool is_main)
+void render_mpris_metadata(struct overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing, bool is_main)
 {
    if (meta.meta.valid) {
       auto color = ImGui::ColorConvertU32ToFloat4(params.media_player_color);
@@ -937,6 +935,8 @@ ImVec4 change_on_load_temp (struct LOAD_DATA& data, int current) {
 
 void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, bool is_vulkan)
 {
+   HUDElements.sw_stats = &data; HUDElements.params = &params;
+   HUDElements.is_vulkan = is_vulkan;
    ImGui::GetIO().FontGlobalScale = params.font_scale;
    if(not logger) logger = std::make_unique<Logger>(&params);
    uint32_t f_idx = (data.n_frames - 1) % ARRAY_SIZE(data.frames_stats);
@@ -947,308 +947,16 @@ void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& 
    auto now = Clock::now();
 
    if (old_scale != params.font_scale) {
-      ralign_width = ImGui::CalcTextSize("A").x * 4 /* characters */;
+      HUDElements.ralign_width = ralign_width = ImGui::CalcTextSize("A").x * 4 /* characters */;
       old_scale = params.font_scale;
    }
 
    if (!params.no_display){
       ImGui::Begin("Main", &open, ImGuiWindowFlags_NoDecoration);
       ImGui::BeginTable("hud", params.tableCols, ImGuiTableFlags_NoClipX);
-      if (params.enabled[OVERLAY_PARAM_ENABLED_version]){
-         ImGui::TableNextCell();
-         ImGui::Text("%s", MANGOHUD_VERSION);
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_time]){
-         ImGui::TableNextRow();
-         ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 1.00f), "%s", data.time.c_str());
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_stats]){
-         ImGui::TableNextRow();
-         const char* gpu_text;
-         if (params.gpu_text.empty())
-            gpu_text = "GPU";
-         else
-            gpu_text = params.gpu_text.c_str();
-         ImGui::TextColored(data.colors.gpu, "%s", gpu_text);
-         ImGui::TableNextCell();
-         auto text_color = data.colors.text;
-         if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
-            struct LOAD_DATA gpu_data = {data.colors.gpu_load_high,
-                                         data.colors.gpu_load_med,
-                                         data.colors.gpu_load_low,
-                                         params.gpu_load_value[0],
-                                         params.gpu_load_value[1]
-                                        };
-
-            
-            auto load_color = change_on_load_temp(gpu_data, gpu_info.load);
-            right_aligned_text(load_color, ralign_width, "%i", gpu_info.load);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::TextColored(load_color,"%%");
-         }
-         else {
-            right_aligned_text(text_color, ralign_width, "%i", gpu_info.load);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::TextColored(text_color,"%%");
-            // ImGui::SameLine(150);
-            // ImGui::Text("%s", "%");
-         }
-         if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_temp]){
-            ImGui::TableNextCell();
-            right_aligned_text(text_color, ralign_width, "%i", gpu_info.temp);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::Text("°C");
-         }
-         if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock] || params.enabled[OVERLAY_PARAM_ENABLED_gpu_power])
-            ImGui::TableNextRow();
-         if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock]){
-            ImGui::TableNextCell();
-            right_aligned_text(text_color, ralign_width, "%i", gpu_info.CoreClock);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(data.font1);
-            ImGui::Text("MHz");
-            ImGui::PopFont();
-         }
-         if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_power]) {
-            ImGui::TableNextCell();
-            right_aligned_text(text_color, ralign_width, "%i", gpu_info.powerUsage);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(data.font1);
-            ImGui::Text("W");
-            ImGui::PopFont();
-         }
-      }
-      if(params.enabled[OVERLAY_PARAM_ENABLED_cpu_stats]){
-         ImGui::TableNextRow();
-         const char* cpu_text;
-         if (params.cpu_text.empty())
-            cpu_text = "CPU";
-         else
-            cpu_text = params.cpu_text.c_str();
-         ImGui::TextColored(data.colors.cpu, "%s", cpu_text);
-         ImGui::TableNextCell();
-         auto text_color = data.colors.text;
-         if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_load_change]){
-            int cpu_load_percent = int(cpuStats.GetCPUDataTotal().percent);
-            struct LOAD_DATA cpu_data = {data.colors.cpu_load_high,
-                                         data.colors.cpu_load_med,
-                                         data.colors.cpu_load_low,
-                                         params.cpu_load_value[0],
-                                         params.cpu_load_value[1]
-                                        };
-
-            
-            auto load_color = change_on_load_temp(cpu_data, cpu_load_percent);
-            right_aligned_text(load_color, ralign_width, "%d", cpu_load_percent);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::TextColored(load_color, "%%");
-         }
-         else {
-            right_aligned_text(text_color, ralign_width, "%d", int(cpuStats.GetCPUDataTotal().percent));
-            ImGui::SameLine(0, 1.0f);
-            ImGui::Text("%%");
-         }
-         // ImGui::SameLine(150);
-         // ImGui::Text("%s", "%");
-
-         if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_temp]){
-            ImGui::TableNextCell();
-            right_aligned_text(data.colors.text, ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::Text("°C");
-         }
-      }
-
-      if (params.enabled[OVERLAY_PARAM_ENABLED_core_load]){
-         int i = 0;
-         for (const CPUData &cpuData : cpuStats.GetCPUData())
-         {
-            ImGui::TableNextRow();
-            ImGui::TextColored(data.colors.cpu, "CPU");
-            ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(data.font1);
-            ImGui::TextColored(data.colors.cpu,"%i", i);
-            ImGui::PopFont();
-            ImGui::TableNextCell();
-            right_aligned_text(data.colors.text, ralign_width, "%i", int(cpuData.percent));
-            ImGui::SameLine(0, 1.0f);
-            ImGui::Text("%%");
-            ImGui::TableNextCell();
-            right_aligned_text(data.colors.text, ralign_width, "%i", cpuData.mhz);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(data.font1);
-            ImGui::Text("MHz");
-            ImGui::PopFont();
-            i++;
-         }
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_io_read] || params.enabled[OVERLAY_PARAM_ENABLED_io_write]){
-         auto sampling = params.fps_sampling_period;
-         ImGui::TableNextRow();
-         if (params.enabled[OVERLAY_PARAM_ENABLED_io_read] && !params.enabled[OVERLAY_PARAM_ENABLED_io_write])
-            ImGui::TextColored(data.colors.io, "IO RD");
-         else if (params.enabled[OVERLAY_PARAM_ENABLED_io_read] && params.enabled[OVERLAY_PARAM_ENABLED_io_write])
-            ImGui::TextColored(data.colors.io, "IO RW");
-         else if (params.enabled[OVERLAY_PARAM_ENABLED_io_write] && !params.enabled[OVERLAY_PARAM_ENABLED_io_read])
-            ImGui::TextColored(data.colors.io, "IO WR");
-
-         if (params.enabled[OVERLAY_PARAM_ENABLED_io_read]){
-            ImGui::TableNextCell();
-            float val = data.io.diff.read * 1000000 / sampling;
-            right_aligned_text(data.colors.text, ralign_width, val < 100 ? "%.1f" : "%.f", val);
-            ImGui::SameLine(0,1.0f);
-            ImGui::PushFont(data.font1);
-            ImGui::Text("MiB/s");
-            ImGui::PopFont();
-         }
-         if (params.enabled[OVERLAY_PARAM_ENABLED_io_write]){
-            ImGui::TableNextCell();
-            float val = data.io.diff.write * 1000000 / sampling;
-            right_aligned_text(data.colors.text, ralign_width, val < 100 ? "%.1f" : "%.f", val);
-            ImGui::SameLine(0,1.0f);
-            ImGui::PushFont(data.font1);
-            ImGui::Text("MiB/s");
-            ImGui::PopFont();
-         }
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_vram]){
-         ImGui::TableNextRow();
-         ImGui::TextColored(data.colors.vram, "VRAM");
-         ImGui::TableNextCell();
-         right_aligned_text(data.colors.text, ralign_width, "%.1f", gpu_info.memoryUsed);
-         ImGui::SameLine(0,1.0f);
-         ImGui::PushFont(data.font1);
-         ImGui::Text("GiB");
-         ImGui::PopFont();
-         if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_mem_clock]){
-            ImGui::TableNextCell();
-            right_aligned_text(data.colors.text, ralign_width, "%i", gpu_info.MemClock);
-            ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(data.font1);
-            ImGui::Text("MHz");
-            ImGui::PopFont();
-         }
-      }
-#ifdef __gnu_linux__  
-      if (params.enabled[OVERLAY_PARAM_ENABLED_ram]){
-         ImGui::TableNextRow();
-         ImGui::TextColored(data.colors.ram, "RAM");
-         ImGui::TableNextCell();
-         right_aligned_text(data.colors.text, ralign_width, "%.1f", memused);
-         ImGui::SameLine(0,1.0f);
-         ImGui::PushFont(data.font1);
-         ImGui::Text("GiB");
-         ImGui::PopFont();
-      }
-#endif
-      if (params.enabled[OVERLAY_PARAM_ENABLED_fps]){
-         ImGui::TableNextRow();
-         ImGui::TextColored(data.colors.engine, "%s", is_vulkan ? data.engineName.c_str() : "OpenGL");
-         ImGui::TableNextCell();
-         right_aligned_text(data.colors.text, ralign_width, "%.0f", data.fps);
-         ImGui::SameLine(0, 1.0f);
-         ImGui::PushFont(data.font1);
-         ImGui::Text("FPS");
-         ImGui::PopFont();
-         ImGui::TableNextCell();
-         right_aligned_text(data.colors.text, ralign_width, "%.1f", 1000 / data.fps);
-         ImGui::SameLine(0, 1.0f);
-         ImGui::PushFont(data.font1);
-         ImGui::Text("ms");
-         ImGui::PopFont();
-      }
-      if (!params.enabled[OVERLAY_PARAM_ENABLED_fps] && params.enabled[OVERLAY_PARAM_ENABLED_engine_version]){
-         ImGui::TableNextRow();
-         ImGui::TextColored(data.colors.engine, "%s", is_vulkan ? data.engineName.c_str() : "OpenGL");
-      }
+      for (auto& func : HUDElements.ordered_functions)
+         func();
       ImGui::EndTable();
-      if (params.enabled[OVERLAY_PARAM_ENABLED_engine_version]){
-         ImGui::PushFont(data.font1);
-         ImGui::Dummy(ImVec2(0, 8.0f));
-         if (is_vulkan) {
-            if ((data.engineName == "DXVK" || data.engineName == "VKD3D")){
-               ImGui::TextColored(data.colors.engine,
-                  "%s/%d.%d.%d", data.engineVersion.c_str(),
-                  data.version_vk.major,
-                  data.version_vk.minor,
-                  data.version_vk.patch);
-            } else {
-               ImGui::TextColored(data.colors.engine,
-                  "%d.%d.%d",
-                  data.version_vk.major,
-                  data.version_vk.minor,
-                  data.version_vk.patch);
-            }
-         } else {
-            ImGui::TextColored(data.colors.engine,
-               "%d.%d%s", data.version_gl.major, data.version_gl.minor,
-               data.version_gl.is_gles ? " ES" : "");
-         }
-         // ImGui::SameLine();
-         ImGui::PopFont();
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_name] && !data.gpuName.empty()){
-         ImGui::PushFont(data.font1);
-         ImGui::Dummy(ImVec2(0.0,5.0f));
-         ImGui::TextColored(data.colors.engine,
-               "%s", data.gpuName.c_str());
-         ImGui::PopFont();
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_vulkan_driver] && !data.driverName.empty()){
-         ImGui::PushFont(data.font1);
-         ImGui::Dummy(ImVec2(0.0,5.0f));
-         ImGui::TextColored(data.colors.engine,
-               "%s", data.driverName.c_str());
-         ImGui::PopFont();
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_arch]){
-         ImGui::PushFont(data.font1);
-         ImGui::Dummy(ImVec2(0.0,5.0f));
-         ImGui::TextColored(data.colors.engine, "%s", "" MANGOHUD_ARCH);
-         ImGui::PopFont();
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_wine]){
-         if (!wineVersion.empty()){
-            //ImGui::TextColored(data.colors.wine, "%s", "WINE");
-            ImGui::PushFont(data.font1);
-            ImGui::Dummy(ImVec2(0.0,5.0f));
-            ImGui::TextColored(data.colors.wine, "%s", wineVersion.c_str());
-            ImGui::PopFont();
-         }
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_frame_timing]){
-         ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
-         ImGui::PushFont(data.font1);
-         ImGui::TextColored(data.colors.engine, "%s", "Frametime");
-         ImGui::PopFont();
-
-         char hash[40];
-         snprintf(hash, sizeof(hash), "##%s", overlay_param_names[OVERLAY_PARAM_ENABLED_frame_timing]);
-         data.stat_selector = OVERLAY_PLOTS_frame_timing;
-         data.time_dividor = 1000.0f;
-
-         ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
-         double min_time = 0.0f;
-         double max_time = 50.0f;
-         if (params.enabled[OVERLAY_PARAM_ENABLED_histogram]){
-            ImGui::PlotHistogram(hash, get_time_stat, &data,
-                                 ARRAY_SIZE(data.frames_stats), 0,
-                                 NULL, min_time, max_time,
-                                 ImVec2(ImGui::GetContentRegionAvailWidth() - real_font_size.x * 2.2, 50));
-         } else {
-            ImGui::PlotLines(hash, get_time_stat, &data,
-                     ARRAY_SIZE(data.frames_stats), 0,
-                     NULL, min_time, max_time,
-                     ImVec2(ImGui::GetContentRegionAvailWidth() - real_font_size.x * 2.2, 50));
-         }
-         ImGui::PopStyleColor();
-      }
-      if (params.enabled[OVERLAY_PARAM_ENABLED_frame_timing]){
-         ImGui::SameLine(0,1.0f);
-         ImGui::PushFont(data.font1);
-         ImGui::Text("%.1f ms", 1000 / data.fps); //frame_timing / 1000.f);
-         ImGui::PopFont();
-      }
 
 #ifdef HAVE_DBUS
       ImFont scaled_font = *data.font_text;


### PR DESCRIPTION
#64 This makes it possible to set the order the hud elements appear in. It sorts after the order they appear in the config file.
This also makes it possible to add multiple of the same hud element (whatever that would be good for) and currently everything needs to be manually enabled or the hud is empty.

TODO: add media_player