### PR TITLE
Blacklist gamescope compositor

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -41,6 +41,7 @@ static bool check_blacklisted() {
         "LeagueClient.exe",
         "LeagueClientUxRender.exe",
         "SocialClubHelper.exe",
+        "gamescope",
     };
 
     std::string proc_name = get_proc_name();


### PR DESCRIPTION
This blacklists [gamescope](https://github.com/Plagman/gamescope) compositor and allows cascaded games to utilize MangoHud. 