### PR TITLE
Add param to enable/disable fps milliseconds text

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `cpu_load_color`                   | Set the colors for the gpu load change low,medium and high. e.g `cpu_load_color=0000FF,00FFFF,FF00FF`      |
 | `cpu_load_value`                   | Set the values for medium and high load e.g `cpu_load_value=50,90`                    |
 | `cellpadding_y`                    | Set the vertical cellpadding, default is `-0.085` |
+| `frametime`                        | Display frametime next to fps text                                                    |
 
 Example: `MANGOHUD_CONFIG=cpu_temp,gpu_temp,position=top-right,height=500,font_size=32`
 

--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -38,6 +38,10 @@ gpu_stats
 # gpu_load_value
 # gpu_load_color
 
+### Display FPS and frametime
+fps
+frametime
+
 ### Display loaded MangoHud architecture
 # arch
 

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -233,12 +233,14 @@ if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fps]){
         ImGui::PushFont(HUDElements.sw_stats->font1);
         ImGui::Text("FPS");
         ImGui::PopFont();
-        ImGui::TableNextCell();
-        right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%.1f", 1000 / HUDElements.sw_stats->fps);
-        ImGui::SameLine(0, 1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
-        ImGui::Text("ms");
-        ImGui::PopFont();
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_frametime]){
+            ImGui::TableNextCell();
+            right_aligned_text(HUDElements.sw_stats->colors.text, HUDElements.ralign_width, "%.1f", 1000 / HUDElements.sw_stats->fps);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::Text("ms");
+            ImGui::PopFont();
+        }
     }
 }
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -500,6 +500,7 @@ parse_overlay_config(struct overlay_params *params,
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_load_change] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_load_change] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_legacy_layout] = true;
+   params->enabled[OVERLAY_PARAM_ENABLED_frametime] = true;
    params->fps_sampling_period = 500000; /* 500ms */
    params->width = 0;
    params->height = 140;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -56,6 +56,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(graphs)                        \
    OVERLAY_PARAM_BOOL(legacy_layout)                 \
    OVERLAY_PARAM_BOOL(cpu_mhz)                       \
+   OVERLAY_PARAM_BOOL(frametime)                     \
    OVERLAY_PARAM_CUSTOM(fps_sampling_period)         \
    OVERLAY_PARAM_CUSTOM(output_folder)               \
    OVERLAY_PARAM_CUSTOM(output_file)                 \


### PR DESCRIPTION
set `show_ms = 0` in the config file to remove the milliseconds for the fps param

Set enabled by default


![mango_ms](https://user-images.githubusercontent.com/9098121/99159558-2ef7bb00-2692-11eb-8d3b-611f001bae04.jpeg)
