### PR TITLE
ManoguHud.conf: add some parameters and fix typos

### DIFF
--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -5,19 +5,19 @@
 
 ################ PERFORMANCE #################
 
-### Limit the application FPS. Comma-separated list of one or more FPS values (e.g. 0,30,60). 0 means unlimited (unless v-synced).
+### Limit the application FPS. Comma-separated list of one or more FPS values (e.g. 0,30,60). 0 means unlimited (unless VSynced).
 # fps_limit=
 
-### VSYNC [0-3] 0 = adaptive; 1 = off; 2 = mailbox; 3 = on
+### VSync [0-3] 0 = adaptive; 1 = off; 2 = mailbox; 3 = on
 # vsync=
 
-### OpenGL VSYNC [0-N] 0 = off; >=1 = wait for N v-blanks, N > 1 acts as a fps limiter (fps = display refresh rate / N)
+### OpenGL VSync [0-N] 0 = off; >=1 = wait for N v-blanks, N > 1 acts as a FPS limiter (FPS = display refresh rate / N)
 # gl_vsync=
 
 ################### VISUAL ###################
 
-### Legacy Layout
-legacy_layout
+### Legacy layout
+# legacy_layout = false
 
 ### Display the current CPU information
 cpu_stats
@@ -44,6 +44,7 @@ gpu_stats
 
 ### Display FPS and frametime
 fps
+# fps_sampling_period=
 frametime
 
 ### Display loaded MangoHud architecture
@@ -59,7 +60,7 @@ frame_timing
 ### Time formatting examples
 # time_format = %H:%M
 # time_format = [ %T %F ]
-# time_format = %X # locally formatted time, because of limited glyph range, missing characters may show as '?' (e.g. japanese)
+# time_format = %X # locally formatted time, because of limited glyph range, missing characters may show as '?' (e.g. Japanese)
 
 ### Change the hud font size (default is 24)
 font_size=24
@@ -91,11 +92,13 @@ position=top-left
 # io_write
 # io_stats
 
-### Display system ram / vram usage
+### Display system RAM / VRAM usage
 # ram
 # vram
 
-### Display Wine version
+### Display MangoHud, engine or Wine version
+# version
+# engine_version
 # wine
 
 ### Disable / hide the hud by deafult
@@ -138,25 +141,25 @@ background_alpha=0.5
 # pci_dev = 0:0a:0.0
 
 ### Blacklist
-#blacklist =
+# blacklist =
 
 ################## INTERACTION #################
 
 ### Change toggle keybinds for the hud & logging
-#toggle_hud=Shift_R+F12
-#toggle_fps_limit=Shift_L+F1
-#toggle_logging=Shift_L+F2
-#reload_cfg=Shift_L+F4
-#upload_log=Shift_L+F3
+# toggle_hud=Shift_R+F12
+# toggle_fps_limit=Shift_L+F1
+# toggle_logging=Shift_L+F2
+# reload_cfg=Shift_L+F4
+# upload_log=Shift_L+F3
 
 ################## LOG #################
 ### Automatically start the log after X seconds
 # autostart_log = 1
-### Set amount of time in second that the logging will run for
+### Set amount of time in seconds that the logging will run for
 # log_duration
-### Set location of the output files (Required for logging)
+### Set location of the output files (required for logging)
 # output_folder = /home/<USERNAME>/mangologs
-### Permit uploading logs directly to Flightlessmango.com
+### Permit uploading logs directly to FlightlessMango.com
 # permit_upload=1
 ### Define a '+'-separated list of percentiles shown in the benchmark results.
 ### Use "AVG" to get a mean average. Default percentiles are 97+AVG+1+0.1


### PR DESCRIPTION
* Added (commented out `fps_sampling_period`, `version` and `engine_version`)
* Commented out `legacy_layout` by default and added `=false` if one want to enable new layout
* Unified VSync, FPS, RAM and other minor names while at it
* Added space after comments sign for options that were missing it to unify formatting