### PR TITLE
Perform updates of gpuInfo struct in more atomic way

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -57,23 +57,25 @@ nvapi_util();
 }
 
 void getAmdGpuInfo(){
-    int64_t value = 0;
-
     if (amdgpu.busy) {
         rewind(amdgpu.busy);
         fflush(amdgpu.busy);
-        if (fscanf(amdgpu.busy, "%d", &gpu_info.load) != 1)
-            gpu_info.load = 0;
-        gpu_info.load = gpu_info.load;
+        int value = 0;
+        if (fscanf(amdgpu.busy, "%d", &value) != 1)
+            value = 0;
+        gpu_info.load = value;
     }
 
     if (amdgpu.temp) {
         rewind(amdgpu.temp);
         fflush(amdgpu.temp);
-        if (fscanf(amdgpu.temp, "%d", &gpu_info.temp) != 1)
-            gpu_info.temp = 0;
-        gpu_info.temp /= 1000;
+        int value = 0;
+        if (fscanf(amdgpu.temp, "%d", &value) != 1)
+            value = 0;
+        gpu_info.temp = value / 1000;
     }
+
+    int64_t value = 0;
 
     if (amdgpu.vram_total) {
         rewind(amdgpu.vram_total);


### PR DESCRIPTION
The issue is that value might be temporarily set to 0,
or original miliC (i.e. 35000), while the other thread is reading
it from the memory.

Instead use single writes to the target location, only with intended
end value.

This is a not a full proper fix (like using mutex between overlay and the thread
doing hw info update), but should alleviate issue of logging sometimes
having value 0, or original value of miliC for temperature.

Fixes #406