### PR TITLE
Use alternate method of checking for distro

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ for os_release in ${OS_RELEASE_FILES[@]} ; do
     if [[ ! -e "${os_release}" ]]; then
         continue
     fi
-    DISTRO=$(sed -rn 's/^NAME=(.+)/\1/p' ${os_release} | sed 's/"//g')
+    DISTRO=$(sed -rn 's/^ID(_LIKE)*=(.+)/\2/p' ${os_release} | sed 's/"//g')
 done
 
 dependencies() {
@@ -53,13 +53,13 @@ dependencies() {
         echo "# Checking Dependencies"
 
         case $DISTRO in
-            "Arch Linux"|"Manjaro Linux")
+            *arch*|*manjaro*)
                 MANAGER_QUERY="pacman -Q"
                 MANAGER_INSTALL="pacman -S"
                 DEPS="{gcc,meson,pkgconf,python-mako,glslang,libglvnd,lib32-libglvnd,libxnvctrl}"
                 dep_install
             ;;
-            "Fedora")
+            *fedora*)
                 MANAGER_QUERY="dnf list installed"
                 MANAGER_INSTALL="dnf install"
                 DEPS="{meson,gcc,gcc-c++,libX11-devel,glslang,python3-mako,mesa-libGL-devel,libXNVCtrl-devel,dbus-devel}"
@@ -69,7 +69,7 @@ dependencies() {
                 DEPS="{glibc-devel.i686,libstdc++-devel.i686,libX11-devel.i686}"
                 dep_install
             ;;
-            *"buntu"|"Linux Mint"|"Debian GNU/Linux"|"Zorin OS"|"Pop!_OS"|"elementary OS"|"KDE neon")
+            *debian*|*ubuntu*)
                 MANAGER_QUERY="dpkg-query -s"
                 MANAGER_INSTALL="apt install"
                 DEPS="{gcc,g++,gcc-multilib,g++-multilib,ninja-build,python3-pip,python3-setuptools,python3-wheel,pkg-config,mesa-common-dev,libx11-dev,libxnvctrl-dev,libdbus-1-dev}"
@@ -85,19 +85,12 @@ dependencies() {
                     rm bin/glslangValidator glslang-master-linux-Release.zip
                 fi
             ;;
-            "openSUSE Leap"|"openSUSE Tumbleweed")
+            *suse*)
 
                 PACKMAN_PKGS="libXNVCtrl-devel"
-                case $DISTRO in
-                    "openSUSE Leap")
-                        echo "You may have to enable packman repository for some extra packages: ${PACKMAN_PKGS}"
-                        echo "zypper ar -cfp 90 https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_15.1/ packman"
-                    ;;
-                    "openSUSE Tumbleweed")
-                        echo "You may have to enable packman repository for some extra packages: ${PACKMAN_PKGS}"
-                        echo "zypper ar -cfp 90 http://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Tumbleweed/ packman"
-                    ;;
-                esac
+                echo "You may have to enable packman repository for some extra packages: ${PACKMAN_PKGS}"
+                echo "Leap:       zypper ar -cfp 90 https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_15.1/ packman"
+                echo "Tumbleweed: zypper ar -cfp 90 http://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Tumbleweed/ packman"
 
                 MANAGER_QUERY="rpm -q"
                 MANAGER_INSTALL="zypper install"
@@ -108,7 +101,7 @@ dependencies() {
                     $SU_CMD pip3 install 'meson>=0.54'
                 fi
             ;;
-            "Solus")
+            *solus*)
                 unset MANAGER_QUERY
                 unset DEPS
                 MANAGER_INSTALL="eopkg it"


### PR DESCRIPTION
Use ID/ID_LIKE instead of NAME which will allow less popular forks of
distros to work properly, for example archlabs, whose ID_LIKE will be
arch. And due to the simpler format this should be more
future-compatible.

It appears that some distros don't have ID_LIKE so it also includes ID
in the DISTRO variable.

There are a few downsides to this approach, notably:
 - The OpenSUSE message won't be able to detect whether the user is on
    leap or tumbleweed, so I made it print the command for both.
 - This requires some more globbing since the ID field will be before
    the ID_LIKE field, and the ID_LIKE field can include multiple
    distros.

https://freedesktop.org/software/systemd/man/os-release.html

[Note that I haven't tested distros other than ubuntu, so if you're able to test them please do so]