### PR TITLE
fix: cut --output-delimiter

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -608,7 +608,7 @@ void init_system_info(){
       trim(os);
       gpu = exec("lspci | grep VGA | head -n1 | awk -vRS=']' -vFS='[' '{print $2}' | sed '/^$/d' | tail -n1");
       trim(gpu);
-      driver = exec("glxinfo | grep 'OpenGL version' | sed 's/^.*: //' | cut -d' ' --output-delimiter=$'\n' -f1- | grep -v '(' | grep -v ')' | tr '\n' ' ' | cut -c 1-");
+      driver = exec("glxinfo | grep 'OpenGL version' | sed 's/^.*: //' | tr -s ' ' '\n' | grep -v '(' | grep -v ')' | tr '\n' ' ' | cut -c 1-");
       trim(driver);
 
 // Get WINE version


### PR DESCRIPTION
I have a problem with the command
cut --- output-delimiter
The busysbox does not support the "output-delimiter" parameter and I get an error message on the terminal.
![print_2020-12-08_05 06 41](https://user-images.githubusercontent.com/47663685/101440938-d70a4800-390f-11eb-9106-8d9b79409988.jpg)
