### PR TITLE
Add swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `core_load`                        | Displays load & frequency per core                                                    |
 | `gpu_core_clock`<br>`gpu_mem_clock`| Displays GPU core/memory frequency                                                    |
 | `ram`<br>`vram`                    | Displays system RAM/VRAM usage                                                        |
+| `swap`                             | Displays swap space usage next to system RAM usage                                    |
 | `full`                             | Enables most of the toggleable parameters (currently excludes `histogram`)            |
 | `font_size=`                       | Customizeable font size (default=24)                                                  |
 | `font_size_text=`                  | Customizeable font size for other text like media metadata (default=24)               |

--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -104,8 +104,9 @@ position=top-left
 # io_write
 # io_stats
 
-### Display system ram / vram usage
+### Display system ram / swap space / vram usage
 # ram
+# swap
 # vram
 
 ### Display Wine version

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -329,6 +329,15 @@ void HudElements::ram(){
          ImGui::Text("GiB");
          ImGui::PopFont();
       }
+
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram] && HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_swap]){
+        ImGui::TableNextCell();
+        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", swapused);
+        ImGui::SameLine(0,1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::Text("GiB");
+        ImGui::PopFont();
+    }
 #endif
 }
 

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -53,6 +53,7 @@ class HudElements{
                 gpu,
                 vram,
                 ram,
+                swap,
                 engine,
                 io,
                 frametime,

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -6,7 +6,7 @@
 #include <thread>
 
 struct memory_information mem_info;
-float memused, memmax;
+float memused, memmax, swapused, swapmax;
 
 FILE *open_file(const char *file, int *reported) {
   FILE *fp = nullptr;
@@ -94,6 +94,9 @@ void update_meminfo(void) {
 
   memused = (float(mem_info.memmax) - float(mem_info.memeasyfree)) / (1024 * 1024);
   memmax = float(mem_info.memmax) / (1024 * 1024);
+
+  swapused = (float(mem_info.swapmax) - float(mem_info.swapfree)) / (1024 * 1024);
+  swapmax = float(mem_info.swapmax) / (1024 * 1024);
 
   fclose(meminfo_fp);
 }

--- a/src/memory.h
+++ b/src/memory.h
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <thread>
 
-extern float memused, memmax;
+extern float memused, memmax, swapused, swapmax;
 
 struct memory_information {
   /* memory information in kilobytes */

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -44,7 +44,7 @@ void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& par
    // get ram usage/max
 
 #ifdef __gnu_linux__
-   if (params.enabled[OVERLAY_PARAM_ENABLED_ram] || logger->is_active())
+   if (params.enabled[OVERLAY_PARAM_ENABLED_ram] || params.enabled[OVERLAY_PARAM_ENABLED_swap] || logger->is_active())
       update_meminfo();
    if (params.enabled[OVERLAY_PARAM_ENABLED_io_read] || params.enabled[OVERLAY_PARAM_ENABLED_io_write])
       getIoStats(&sw_stats.io);

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -533,6 +533,7 @@ parse_overlay_config(struct overlay_params *params,
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_ram] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_swap] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_vram] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_read_cfg] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_io_read] = false;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -34,6 +34,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(cpu_stats)                     \
    OVERLAY_PARAM_BOOL(gpu_stats)                     \
    OVERLAY_PARAM_BOOL(ram)                           \
+   OVERLAY_PARAM_BOOL(swap)                          \
    OVERLAY_PARAM_BOOL(vram)                          \
    OVERLAY_PARAM_BOOL(time)                          \
    OVERLAY_PARAM_BOOL(full)                          \


### PR DESCRIPTION
Displays swap space usage next to system RAM usage, requires `ram` to be enabled