### PR TITLE
Add include_cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `gpu_color`<br>`gpu_color`<br>`vram_color`<br>`ram_color`<br>`io_color`<br>`engine_color`<br>`frametime_color`<br>`background_color`<br>`text_color`<br>`media_player_color`         | Change default colors: `gpu_color=RRGGBB`|
 | `alpha`                            | Set the opacity of all text and frametime graph `0.0-1.0`                             |
 | `background_alpha`                 | Set the opacity of the background `0.0-1.0`                                           |
+| `include_cfg`                      | Includes another config file, overrides params defined before it. `include_cfg` without value will include `MangoHud.conf`.<br>For example `include_cfg=maxinfo.conf` will include `maxinfo.conf` from `/home/user/.config/MangoHud` and `include_cfg=/home/user/mangohud-maxinfo.conf` will include `/home/user/mangohud-maxinfo.conf` |
 | `read_cfg`                         | Add to MANGOHUD_CONFIG as first parameter to also load config file. Otherwise only MANGOHUD_CONFIG parameters are used. |
 | `output_folder`                    | Set location of the output files (Required for logging)                               |
 | `log_duration`                     | Set amount of time the logging will run for (in seconds)                              |

--- a/src/config.h
+++ b/src/config.h
@@ -6,6 +6,7 @@
 #include <string>
 
 void parseConfigFile(overlay_params& p);
+void parseConfigFiles(overlay_params& p);
 std::string get_program_name();
 
 #endif //MANGOHUD_CONFIG_H

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -622,7 +622,7 @@ parse_overlay_config(struct overlay_params *params,
    if (!env || read_cfg) {
 
       // Get config options
-      parseConfigFile(*params);
+      parseConfigFiles(*params);
       if (params->options.find("full") != params->options.end() && params->options.find("full")->second != "0") {
 #define OVERLAY_PARAM_BOOL(name) \
             params->enabled[OVERLAY_PARAM_ENABLED_##name] = 1;


### PR DESCRIPTION
Allows including another configs (subconfigs) from a config.

Example:
`$HOME/.config/MangoHud/MangoHud.conf`:
```
cpu_stats
fps
fps_limit=80
```

`$HOME/.config/MangoHud/vkcube.conf`:
```
include_cfg=MangoHud
fps_limit=100
```

`vkcube` with MangoHud should now be limited to 100 FPS.

This PR doesn't implement watching all those configs for changes to automatically reload config(s).