### PR TITLE
Improve code for program name extraction

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -7,19 +7,13 @@
 #include "file_utils.h"
 
 static std::string get_proc_name() {
-#ifdef _GNU_SOURCE_OFF
-   std::string p(program_invocation_name);
-   std::string proc_name = p.substr(p.find_last_of("/\\") + 1);
-#else
-   std::string p = get_exe_path();
-   std::string proc_name;
-   if (ends_with(p, "wine-preloader") || ends_with(p, "wine64-preloader")) {
-      get_wine_exe_name(proc_name, true);
-   } else {
-      proc_name = p.substr(p.find_last_of("/\\") + 1);
+   // Note: It is possible to use GNU program_invocation_short_name.
+   const std::string proc_name = get_wine_exe_name(/*keep_ext=*/true);
+   if (!proc_name.empty()) {
+       return proc_name;
    }
-#endif
-    return proc_name;
+   const std::string p = get_exe_path();
+   return p.substr(p.find_last_of("/\\") + 1);
 }
 
 static  std::vector<std::string> blacklist {

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,9 @@
 #define MANGOHUD_CONFIG_H
 
 #include "overlay_params.h"
+#include <string>
+
 void parseConfigFile(overlay_params& p);
-extern std::string program_name;
+std::string get_program_name();
+
 #endif //MANGOHUD_CONFIG_H

--- a/src/file_utils.cpp
+++ b/src/file_utils.cpp
@@ -5,9 +5,9 @@
 #include <unistd.h>
 #include <dirent.h>
 #include <limits.h>
-#include <iostream>
 #include <fstream>
 #include <cstring>
+#include <string>
 
 std::string read_line(const std::string& filename)
 {
@@ -112,7 +112,7 @@ std::string get_exe_path()
     return read_symlink("/proc/self/exe");
 }
 
-bool get_wine_exe_name(std::string& name, bool keep_ext)
+std::string get_wine_exe_name(bool keep_ext)
 {
     std::string line;
     std::ifstream cmdline("/proc/self/cmdline");
@@ -126,17 +126,15 @@ bool get_wine_exe_name(std::string& name, bool keep_ext)
             auto dot = keep_ext ? std::string::npos : line.find_last_of('.');
             if (dot < n)
                 dot = line.size();
-            name = line.substr(n + 1, dot - n - 1);
-            return true;
+            return line.substr(n + 1, dot - n - 1);
         }
         else if (ends_with(line, ".exe", true))
         {
             auto dot = keep_ext ? std::string::npos : line.find_last_of('.');
-            name =  line.substr(0, dot);
-            return true;
+            return line.substr(0, dot);
         }
     }
-    return false;
+    return std::string();
 }
 
 std::string get_home_dir()

--- a/src/file_utils.h
+++ b/src/file_utils.h
@@ -20,7 +20,7 @@ bool file_exists(const std::string& path);
 bool dir_exists(const std::string& path);
 std::string read_symlink(const char * link);
 std::string get_exe_path();
-bool get_wine_exe_name(std::string& name, bool keep_ext = false);
+std::string get_wine_exe_name(bool keep_ext = false);
 std::string get_home_dir();
 std::string get_data_dir();
 std::string get_config_dir();

--- a/src/file_utils_win32.cpp
+++ b/src/file_utils_win32.cpp
@@ -1,8 +1,7 @@
 #include "file_utils.h"
 #include "string_utils.h"
-#include <iostream>
 #include <fstream>
-#include <cstring>
+#include <string>
 
 std::string read_line(const std::string& filename)
 {
@@ -43,9 +42,9 @@ std::string get_exe_path()
     return std::string();
 }
 
-bool get_wine_exe_name(std::string& name, bool keep_ext)
+std::string get_wine_exe_name(bool keep_ext)
 {
-    return false;
+    return std::string();
 }
 
 std::string get_home_dir()

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -125,7 +125,7 @@ void Logger::stop_logging() {
   std::thread(calculate_benchmark_data, m_params).detach();
 
   if(not m_params->output_folder.empty()) {
-    m_log_files.emplace_back(m_params->output_folder + "/" + program_name + "_" + get_log_suffix());
+    m_log_files.emplace_back(m_params->output_folder + "/" + get_program_name() + "_" + get_log_suffix());
     std::thread(writeFile, m_log_files.back()).detach();
   }
 }


### PR DESCRIPTION
This cleans up the code, as well fixes the bug of not setting
program_name if the MANGOHUD_CONFIG env is specified.

Instead of global variable, that could be not-initialized
use a function to get a program name in logging.

While at it, revamp code and separate things into own functions,
and return by value.