### PR TITLE
Improve code for program name extraction

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -7,19 +7,13 @@
 #include "file_utils.h"
 
 static std::string get_proc_name() {
-#ifdef _GNU_SOURCE_OFF
-   std::string p(program_invocation_name);
-   std::string proc_name = p.substr(p.find_last_of("/\\") + 1);
-#else
-   std::string p = get_exe_path();
-   std::string proc_name;
-   if (ends_with(p, "wine-preloader") || ends_with(p, "wine64-preloader")) {
-      get_wine_exe_name(proc_name, true);
-   } else {
-      proc_name = p.substr(p.find_last_of("/\\") + 1);
+   // Note: It is possible to use GNU program_invocation_short_name.
+   const std::string proc_name = get_wine_exe_name(/*keep_ext=*/true);
+   if (!proc_name.empty()) {
+       return proc_name;
    }
-#endif
-    return proc_name;
+   const std::string p = get_exe_path();
+   return p.substr(p.find_last_of("/\\") + 1);
 }
 
 static  std::vector<std::string> blacklist {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -3,13 +3,14 @@
 #include <iostream>
 #include <string.h>
 #include <thread>
+#include <unordered_map>
+#include <string>
 #include "config.h"
 #include "file_utils.h"
 #include "string_utils.h"
 #include "hud_elements.h"
-std::string program_name;
 
-void parseConfigLine(std::string line, std::unordered_map<std::string,std::string>& options) {
+static void parseConfigLine(std::string line, std::unordered_map<std::string, std::string>& options) {
     std::string param, value;
 
     if (line.find("#") != std::string::npos)
@@ -30,42 +31,67 @@ void parseConfigLine(std::string line, std::unordered_map<std::string,std::strin
     }
 }
 
-void enumerate_config_files(std::vector<std::string>& paths)
-{
+static std::string get_program_dir() {
+    const std::string exe_path = get_exe_path();
+    if (exe_path.empty()) {
+        return std::string();
+    }
+    const auto n = exe_path.find_last_of('/');
+    if (n != std::string::npos) {
+        return exe_path.substr(0, n);
+    }
+    return std::string();
+}
+
+std::string get_program_name() {
+    const std::string exe_path = get_exe_path();
+    std::string basename = "unknown";
+    if (exe_path.empty()) {
+        return basename;
+    }
+    const auto n = exe_path.find_last_of('/');
+    if (n == std::string::npos) {
+        return basename;
+    }
+    if (n < exe_path.size() - 1) {
+        // An executable's name.
+        basename = exe_path.substr(n + 1);
+    }
+    return basename;
+}
+
+static void enumerate_config_files(std::vector<std::string>& paths) {
     static const char *mangohud_dir = "/MangoHud/";
 
-    std::string env_data = get_data_dir();
-    std::string env_config = get_config_dir();
+    const std::string data_dir = get_data_dir();
+    const std::string config_dir = get_config_dir();
 
-    if (!env_config.empty())
-        paths.push_back(env_config + mangohud_dir + "MangoHud.conf");
+    const std::string program_name = get_program_name();
+
+    if (config_dir.empty()) {
+        // If we can't find 'HOME' just abandon hope.
+        return;
+    }
+
+    paths.push_back(config_dir + mangohud_dir + "MangoHud.conf");
+
 #ifdef _WIN32
     paths.push_back("C:\\mangohud\\MangoHud.conf");
 #endif
-    std::string exe_path = get_exe_path();
-    auto n = exe_path.find_last_of('/');
-    if (!exe_path.empty() && n != std::string::npos && n < exe_path.size() - 1) {
-        // as executable's name
-        std::string basename = exe_path.substr(n + 1);
-        program_name = basename;
-        if (!env_config.empty())
-            paths.push_back(env_config + mangohud_dir + basename + ".conf");
 
-        // in executable's folder though not much sense in /usr/bin/
-        paths.push_back(exe_path.substr(0, n) + "/MangoHud.conf");
-
-        // find executable's path when run in Wine
-        if (!env_config.empty() && (basename == "wine-preloader" || basename == "wine64-preloader")) {
-            
-            std::string name;
-            if (get_wine_exe_name(name)) {
-                paths.push_back(env_config + mangohud_dir + "wine-" + name + ".conf");
-            }
-            program_name = name;
-        }
+    if (!program_name.empty()) {
+        paths.push_back(config_dir + mangohud_dir + program_name + ".conf");
     }
-    if (program_name.empty())
-        program_name = "Unknown";
+
+    const std::string program_dir = get_program_dir();
+    if (!program_dir.empty()) {
+        paths.push_back(program_dir + "/MangoHud.conf");
+    }
+
+    const std::string wine_program_name = get_wine_exe_name();
+    if (!wine_program_name.empty()) {
+        paths.push_back(config_dir + mangohud_dir + "wine-" + wine_program_name + ".conf");
+     }
 }
 
 void parseConfigFile(overlay_params& params) {

--- a/src/config.h
+++ b/src/config.h
@@ -3,6 +3,9 @@
 #define MANGOHUD_CONFIG_H
 
 #include "overlay_params.h"
+#include <string>
+
 void parseConfigFile(overlay_params& p);
-extern std::string program_name;
+std::string get_program_name();
+
 #endif //MANGOHUD_CONFIG_H

--- a/src/file_utils.h
+++ b/src/file_utils.h
@@ -20,7 +20,7 @@ bool file_exists(const std::string& path);
 bool dir_exists(const std::string& path);
 std::string read_symlink(const char * link);
 std::string get_exe_path();
-bool get_wine_exe_name(std::string& name, bool keep_ext = false);
+std::string get_wine_exe_name(bool keep_ext = false);
 std::string get_home_dir();
 std::string get_data_dir();
 std::string get_config_dir();

--- a/src/file_utils_win32.cpp
+++ b/src/file_utils_win32.cpp
@@ -1,8 +1,7 @@
 #include "file_utils.h"
 #include "string_utils.h"
-#include <iostream>
 #include <fstream>
-#include <cstring>
+#include <string>
 
 std::string read_line(const std::string& filename)
 {
@@ -43,9 +42,9 @@ std::string get_exe_path()
     return std::string();
 }
 
-bool get_wine_exe_name(std::string& name, bool keep_ext)
+std::string get_wine_exe_name(bool keep_ext)
 {
-    return false;
+    return std::string();
 }
 
 std::string get_home_dir()

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -127,7 +127,7 @@ void Logger::stop_logging() {
   std::thread(calculate_benchmark_data, m_params).detach();
 
   if(!m_params->output_folder.empty()) {
-    m_log_files.emplace_back(m_params->output_folder + "/" + program_name + "_" + get_log_suffix());
+    m_log_files.emplace_back(m_params->output_folder + "/" + get_program_name() + "_" + get_log_suffix());
     std::thread(writeFile, m_log_files.back()).detach();
   }
 }


### PR DESCRIPTION
This cleans up the code, as well fixes the bug of not setting
program_name if the MANGOHUD_CONFIG env is specified.
Otherwise, it would make program_name == "",
and log to files without a prefix.

Instead of global variable, that could be not-initialized
use a function to get a program name in logging.

While at it, revamp code and separate things into own functions,
and return by value, and make them easier to use / share code.