### PR TITLE
Use raw clocks if available

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -417,7 +417,7 @@ void HudElements::frame_timing(){
         char hash[40];
         snprintf(hash, sizeof(hash), "##%s", overlay_param_names[OVERLAY_PARAM_ENABLED_frame_timing]);
         HUDElements.sw_stats->stat_selector = OVERLAY_PLOTS_frame_timing;
-        HUDElements.sw_stats->time_dividor = 1000.0f;
+        HUDElements.sw_stats->time_dividor = 1000000.0f; /* ns -> ms */
         ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
         double min_time = 0.0f;
         double max_time = 50.0f;

--- a/src/mesa/util/os_time.c
+++ b/src/mesa/util/os_time.c
@@ -54,6 +54,13 @@
 #  error Unsupported OS
 #endif
 
+#if defined(CLOCK_MONOTONIC_RAW) /* linux */
+#define MANGOHUD_CLOCKTYPE CLOCK_MONOTONIC_RAW
+#elif defined(CLOCK_MONOTONIC_FAST) /* freebsd */
+#define MANGOHUD_CLOCKTYPE CLOCK_MONOTONIC_FAST
+#else /* fallback */
+#define MANGOHUD_CLOCKTYPE CLOCK_MONOTONIC
+#endif
 
 int64_t
 os_time_get_nano(void)
@@ -61,7 +68,7 @@ os_time_get_nano(void)
 #if DETECT_OS_LINUX || DETECT_OS_BSD
 
    struct timespec tv;
-   clock_gettime(CLOCK_MONOTONIC, &tv);
+   clock_gettime(MANGOHUD_CLOCKTYPE, &tv);
    return tv.tv_nsec + tv.tv_sec*INT64_C(1000000000);
 
 #elif DETECT_OS_UNIX
@@ -102,7 +109,7 @@ os_time_sleep(int64_t usecs)
    struct timespec time;
    time.tv_sec = usecs / 1000000;
    time.tv_nsec = (usecs % 1000000) * 1000;
-   while (clock_nanosleep(CLOCK_MONOTONIC, 0, &time, &time) == EINTR);
+   while (clock_nanosleep(MANGOHUD_CLOCKTYPE, 0, &time, &time) == EINTR);
 
 #elif DETECT_OS_UNIX
    usleep(usecs);

--- a/src/mesa/util/os_time.h
+++ b/src/mesa/util/os_time.h
@@ -53,16 +53,6 @@ os_time_get_nano(void);
 
 
 /*
- * Get the current time in microseconds from an unknown base.
- */
-static inline int64_t
-os_time_get(void)
-{
-   return os_time_get_nano() / 1000;
-}
-
-
-/*
  * Sleep.
  */
 void

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -71,9 +71,9 @@ void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& par
 
 void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID){
    uint32_t f_idx = sw_stats.n_frames % ARRAY_SIZE(sw_stats.frames_stats);
-   uint64_t now = os_time_get(); /* us */
-   double elapsed = (double)(now - sw_stats.last_fps_update); /* us */
-   fps = 1000000.0f * sw_stats.n_frames_since_update / elapsed;
+   uint64_t now = os_time_get_nano(); /* ns */
+   double elapsed = (double)(now - sw_stats.last_fps_update); /* ns */
+   fps = 1000000000.0 * sw_stats.n_frames_since_update / elapsed;
    if (logger->is_active())
       benchmark.fps_data.push_back(fps);
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -132,7 +132,7 @@ parse_string_to_keysym_vec(const char *str)
 static uint32_t
 parse_fps_sampling_period(const char *str)
 {
-   return strtol(str, NULL, 0) * 1000;
+   return strtol(str, NULL, 0) * 1000000; /* ms to ns */
 }
 
 static std::vector<std::uint32_t>
@@ -538,7 +538,7 @@ parse_overlay_config(struct overlay_params *params,
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_load_change] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_legacy_layout] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_frametime] = true;
-   params->fps_sampling_period = 500000; /* 500ms */
+   params->fps_sampling_period = 500000000; /* 500ms */
    params->width = 0;
    params->height = 140;
    params->control = -1;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -164,7 +164,7 @@ struct overlay_params {
    bool enabled[OVERLAY_PARAM_ENABLED_MAX];
    enum overlay_param_position position;
    int control;
-   uint32_t fps_sampling_period; /* us */
+   uint32_t fps_sampling_period; /* ns */
    std::vector<std::uint32_t> fps_limit;
    bool help;
    bool no_display;


### PR DESCRIPTION
Avoids NTP synchronization having impact on frametime pacing.