### PR TITLE
 Prevent infinite recursion when using Mesa zink.

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -611,8 +611,16 @@ void init_system_info(){
       trim(os);
       gpu = exec("lspci | grep VGA | head -n1 | awk -vRS=']' -vFS='[' '{print $2}' | sed '/^$/d' | tail -n1");
       trim(gpu);
-      driver = exec("glxinfo | grep 'OpenGL version' | sed 's/^.*: //' | cut -d' ' --output-delimiter=$'\n' -f1- | grep -v '(' | grep -v ')' | tr '\n' ' ' | cut -c 1-");
-      trim(driver);
+
+      const char* mangohud_recursion = getenv("MANGOHUD_RECURSION");
+      if (!mangohud_recursion) {
+         setenv("MANGOHUD_RECURSION", "1", 1);
+         driver = exec("glxinfo -B | grep 'OpenGL version' | sed 's/^.*: //' | cut -d' ' --output-delimiter=$'\n' -f1- | grep -v '(' | grep -v ')' | tr '\n' ' ' | cut -c 1-");
+         trim(driver);
+         unsetenv("MANGOHUD_RECURSION");
+      } else {
+         driver = "MangoHud glxinfo recurssion detected";
+      }
 
 // Get WINE version
 


### PR DESCRIPTION
When using zink (`MESA_LOADER_DRIVER_OVERRIDE=zink`),
running any app (OpenGL or Vulkan), will trigger running
`glxinfo`. Unsetting of `LD_PRELOAD` is not sufficient,
because if using `zink`, it will load Vulkan, and load Vulkan
implicit layer for Mangohud, using `/usr/share/vulkan/implicit_layer.d/MangoHud.json`,
which will cause it to reenter this function in another process,
causing infinite recursion (until the Vulkan driver finally errors
out with too many VkDevices  / contexts created).
I have easily have seen recursion depths of 200+ until this happen,
and sometimes takes up to 2 minutes, with 2000 extra shell and `cut`
processes in the process tree.

Fix this by marking recursion entrance.

This makes glxmark start in less than 1 second, instead
about 60 seconds.

When at it us `glxinfo -B`, which is significantly faster
on zink, yet provides all information we need.