### PR TITLE
imgui wrap from WrapDB and build-source.sh rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ build
 builddir
 __pycache__
 .vscode
-MangoHud*.tar.gz
+MangoHud*.tar.*
 pkg
 mangohud*.tar.*
 lib32-mangohud*.tar.*

--- a/meson.build
+++ b/meson.build
@@ -216,8 +216,24 @@ elif sizeof_ptr == 4
   pre_args += '-DMANGOHUD_ARCH="32bit"'
 endif
 
-dearimgui_sp = subproject('imgui')
-dearimgui_dep = dearimgui_sp.get_variable('dearimgui_dep')
+dearimgui_sp = subproject('imgui', default_options: [
+  'default_library=static',
+  # use 'auto_features=disabled' once available: https://github.com/mesonbuild/meson/issues/5320
+  'dx9=disabled',
+  'dx10=disabled',
+  'dx11=disabled',
+  'dx12=disabled',
+  'metal=disabled',
+  'opengl=disabled',
+  'vulkan=disabled',
+  'glfw=disabled',
+  'sdl2=disabled',
+  'osx=disabled',
+  'win=disabled',
+  'marmalade=disabled',
+  'allegro5=disabled',
+])
+dearimgui_dep = dearimgui_sp.get_variable('imgui_dep')
 
 if ['windows', 'mingw'].contains(host_machine.system())
   subdir('modules/minhook')

--- a/subprojects/imgui.wrap
+++ b/subprojects/imgui.wrap
@@ -1,7 +1,11 @@
-[wrap-git]
-directory = imgui
-url = https://github.com/ocornut/imgui.git
-revision = 22ace4438c86b3137567c69346a3836d26ebf95c
-patch_url = https://flightlessmango.com/wraps/imgui.zip
-patch_filename = imgui.zip
-patch_hash = 55e9f31b3edfe725e7271bd0dd06434ba2a3b6fdce476314947907a43e36b641
+[wrap-file]
+directory = imgui-1.80
+source_url = https://github.com/ocornut/imgui/archive/v1.80.tar.gz
+source_filename = imgui-1.80.tar.gz
+source_hash = d7e4e1c7233409018437a646680316040e6977b9a635c02da93d172baad94ce9
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/imgui/1.80/1/get_zip
+patch_filename = imgui-1.80-1-wrap.zip
+patch_hash = 9b86a584968d3c4b0b0c0cd648013eb5b81aeb6789babe3c1097727a134efc7f
+
+[provide]
+imgui = imgui_dep


### PR DESCRIPTION
Reworked for dear imgui wrap. The script is a bit longer than before, but it offloads the hard to Meson again.

Currently this doesn't work, I suspect due to some weird wrap-git error in Meson. Once https://github.com/mesonbuild/imgui/tree/1.79 is done for 1.80, it should work though.