### PR TITLE
Explicitly test for the mako python module

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project('MangoHud',
 
 cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
-prog_python = import('python').find_installation('python3')
+prog_python = import('python').find_installation('python3', modules: ['mako'])
 null_dep = dependency('', required : false)
 
 mangohud_version = vcs_tag(


### PR DESCRIPTION
Some distros (Gentoo) support multiple versions of python3 and mako may
not be built for all of the implementations. Testing for the module
early will make sure meson bails out if the module cannot be
found.