### PR TITLE
Disable lsof warnings explicitly

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -670,11 +670,11 @@ void init_system_info(){
          printf("MANGOHUD: lsof is missing, can't check for gamemode and vkbasalt");
       } else {
          auto pid = getpid();
-         string command = "lsof -lnPX -L -p " + to_string(pid) + " | grep gamemode";
+         string command = "lsof -w -lnPX -L -p " + to_string(pid) + " | grep gamemode";
          string ret = exec(command);
          if (!ret.empty())
             HUDElements.gamemode_bol = true;
-         command = "lsof -lnPX -L -p " + to_string(pid) + " | grep vkbasalt";
+         command = "lsof -w -lnPX -L -p " + to_string(pid) + " | grep vkbasalt";
          ret = exec(command);
          if (!ret.empty())
             HUDElements.vkbasalt_bol = true;


### PR DESCRIPTION
On most system lsof is compiled with warnings enabled.

This causes spam multiple times per one mangohud invocation (up to about 10 times even), like this:

```
lsof: WARNING: can't stat() tracefs file system /sys/kernel/debug/tracing
      Output information may be incomplete.
```

Disable warnings explicitly.