### PR TITLE
Fix var typo in unrecognized command argument feedback

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -250,7 +250,7 @@ clean() {
 
 usage() {
     if test -z $1; then
-        echo "Unrecognized command argument: $a"
+        echo "Unrecognized command argument: $arg"
     else
         echo "$0 requires one argument"
     fi


### PR DESCRIPTION
Behavior with original code:

```console
$ ./build.sh asdf                                                                           
Command: asdf                                                                                                                      
Unrecognized command argument:                                                                                                     
                                                                                                                                   
Usage: ./build.sh <command>
…
```

Behavior with PR code:
```console
$ ./build.sh asdf                                                                         
Command: asdf                                                                                                                      
Unrecognized command argument: asdf                                                                                                
                                                                                                                                   
Usage: ./build.sh <command>
…
```