### PR TITLE
Divide IO stats by time difference since last update

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -269,7 +269,6 @@ void HudElements::core_load(){
 }
 void HudElements::io_stats(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read] || HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write]){
-        auto sampling = HUDElements.params->fps_sampling_period;
         ImGui::TableNextRow(); ImGui::TableNextColumn();
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write])
             ImGui::TextColored(HUDElements.colors.io, "IO RD");
@@ -280,7 +279,7 @@ void HudElements::io_stats(){
 
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_read]){
             ImGui::TableNextColumn();
-            float val = HUDElements.sw_stats->io.diff.read * 1000000 / sampling;
+            float val = HUDElements.sw_stats->io.per_second.read;
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, val < 100 ? "%.1f" : "%.f", val);
             ImGui::SameLine(0,1.0f);
             ImGui::PushFont(HUDElements.sw_stats->font1);
@@ -289,7 +288,7 @@ void HudElements::io_stats(){
         }
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_io_write]){
             ImGui::TableNextColumn();
-            float val = HUDElements.sw_stats->io.diff.write * 1000000 / sampling;
+            float val = HUDElements.sw_stats->io.per_second.write;
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, val < 100 ? "%.1f" : "%.f", val);
             ImGui::SameLine(0,1.0f);
             ImGui::PushFont(HUDElements.sw_stats->font1);

--- a/src/iostats.cpp
+++ b/src/iostats.cpp
@@ -1,10 +1,17 @@
 #include "iostats.h"
 #include "string_utils.h"
+#include "timing.hpp"
 #include <fstream>
+
+Clock::time_point lastUpdate = Clock::now(); /* ns */
 
 void getIoStats(void *args) {
     iostats *io = reinterpret_cast<iostats *>(args);
     if (io) {
+        Clock::time_point now = Clock::now(); /* ns */
+        Clock::duration timeDiff = now - lastUpdate;
+        float timeDiffSecs = (float)timeDiff.count() / (float)1000000000; // Time diff in seconds
+
         io->prev.read_bytes  = io->curr.read_bytes;
         io->prev.write_bytes = io->curr.write_bytes;
 
@@ -18,7 +25,13 @@ void getIoStats(void *args) {
                 try_stoull(io->curr.write_bytes, line.substr(13));
             }
         }
+
         io->diff.read  = (io->curr.read_bytes  - io->prev.read_bytes) / (1024.f * 1024.f);
         io->diff.write = (io->curr.write_bytes - io->prev.write_bytes) / (1024.f * 1024.f);
+
+        io->per_second.read = io->diff.read / timeDiffSecs;
+        io->per_second.write = io->diff.write / timeDiffSecs;
+
+        lastUpdate = now;
     }
 }

--- a/src/iostats.h
+++ b/src/iostats.h
@@ -17,6 +17,10 @@ struct iostats {
       float read;
       float write;
     } diff;
+    struct {
+      float read;
+      float write;
+    } per_second;
 };
 
 void getIoStats(void *args);


### PR DESCRIPTION
This should prevent IO stats reaching high numbers when application stops responding resulting into MangoHud not updating.