### PR TITLE
imgui 1.81

### DIFF
--- a/subprojects/imgui.wrap
+++ b/subprojects/imgui.wrap
@@ -1,11 +1,11 @@
 [wrap-file]
-directory = imgui-1.80
-source_url = https://github.com/ocornut/imgui/archive/v1.80.tar.gz
-source_filename = imgui-1.80.tar.gz
-source_hash = d7e4e1c7233409018437a646680316040e6977b9a635c02da93d172baad94ce9
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/imgui/1.80/1/get_zip
-patch_filename = imgui-1.80-1-wrap.zip
-patch_hash = 9b86a584968d3c4b0b0c0cd648013eb5b81aeb6789babe3c1097727a134efc7f
+directory = imgui-1.81
+source_url = https://github.com/ocornut/imgui/archive/v1.81.tar.gz
+source_filename = imgui-1.81.tar.gz
+source_hash = f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/imgui/1.81/1/get_zip
+patch_filename = imgui-1.81-1-wrap.zip
+patch_hash = 6d00b442690b6a5c5d8f898311daafbce16d370cf64f53294c3b8c5c661e435f
 
 [provide]
 imgui = imgui_dep


### PR DESCRIPTION
I'm also looking into removing `src/gl/imgui_impl_opengl3.h` and `src/gl/imgui_impl_opengl3.cpp`, since they are provided in the Wrap. However, there are two problem at the moment: the Wrap doesn't allow for other GL loaders than GLEW, so that would need to be fixed, and in `src/gl/imgui_hud.cpp` `GetOpenGLVersion()` is called.