### PR TITLE
Fix Intel RAPL CPU power calculations

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <algorithm>
 #include <regex>
+#include <inttypes.h>
 #include "string_utils.h"
 
 #ifndef PROCDIR
@@ -307,15 +308,17 @@ static bool get_cpu_power_rapl(CPUPowerData* cpuPowerData, int& power) {
     rewind(powerData_rapl->energyCounterFile);
     fflush(powerData_rapl->energyCounterFile);
 
-    int energyCounterValue = 0;
-    if (fscanf(powerData_rapl->energyCounterFile, "%d", &energyCounterValue) != 1)
+    uint64_t energyCounterValue = 0;
+    if (fscanf(powerData_rapl->energyCounterFile, "%" SCNu64, &energyCounterValue) != 1)
         return false;
 
     Clock::time_point now = Clock::now();
     Clock::duration timeDiff = now - powerData_rapl->lastCounterValueTime;
-    int energyCounterDiff = energyCounterValue - powerData_rapl->lastCounterValue;
+    int64_t timeDiffMicro = std::chrono::duration_cast<std::chrono::microseconds>(timeDiff).count();
+    uint64_t energyCounterDiff = energyCounterValue - powerData_rapl->lastCounterValue;
 
-    power = (int)((float)energyCounterDiff / (float)timeDiff.count() * 1000);
+    if (powerData_rapl->lastCounterValue > 0 && energyCounterValue > powerData_rapl->lastCounterValue)
+        power = energyCounterDiff / timeDiffMicro;
 
     powerData_rapl->lastCounterValue = energyCounterValue;
     powerData_rapl->lastCounterValueTime = now;

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -93,6 +93,7 @@ struct CPUPowerData_zenpower : public CPUPowerData {
 struct CPUPowerData_rapl : public CPUPowerData {
    CPUPowerData_rapl() {
       this->source = CPU_POWER_RAPL;
+      this->lastCounterValue = 0;
       this->lastCounterValueTime = Clock::now();
    };
 
@@ -102,7 +103,7 @@ struct CPUPowerData_rapl : public CPUPowerData {
    };
 
    FILE* energyCounterFile {nullptr};
-   int lastCounterValue;
+   uint64_t lastCounterValue;
    Clock::time_point lastCounterValueTime;
 };
 


### PR DESCRIPTION
I ran into some problems while using the `cpu_power` option for the HUD. This PR fixes the following issues:

- [x] The `energy_uj` value read from RAPL is a 64-bit unsigned integer ([source](https://github.com/torvalds/linux/blob/e49d033bddf5b565044e2abe4241353959bc9120/drivers/powercap/intel_rapl_common.c#L156)), causing an overflow of the `energyCounterValue`.
- [x] The CPU power is evaluated on the first tick leading to a random power value because the `lastCounterValue` has not been set.
- [x] The power usage can become negative when the `energy_uj` value wraps around or resets.