### PR TITLE
meson: Add vulkan_datadir option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,10 @@ else
 endif
 
 if dep_vulkan.found()
-  datadir = get_option('datadir')
+  datadir = get_option('vulkan_datadir')
+  if datadir == ''
+    datadir = get_option('datadir')
+  endif
   if not datadir.startswith('/')
     datadir = get_option('prefix') / datadir
   endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('glibcxx_asserts', type : 'boolean', value : false)
 option('use_system_vulkan', type : 'feature', value : 'disabled', description: 'Use system vulkan headers instead of the provided ones')
+option('vulkan_datadir', type : 'string', value : '', description: 'Path to the system vulkan headers data directory if different from MangoHud\'s datadir')
 option('append_libdir_mangohud', type : 'boolean', value : true, description: 'Append "mangohud" to libdir path or not.')
 option('ld_libdir_prefix', type : 'boolean', value : false, description: 'Set ld libdir to "$prefix/lib/mangohud/\$LIB"')
 option('ld_libdir_abs', type : 'boolean', value : false, description: 'Use absolute path in LD_PRELOAD')


### PR DESCRIPTION
This option enables using system Vulkan headers when it doesn't share the same datadir as MangoHud. This is specifically an issue in NixOS where packages are built into their own isolated directories in `/nix/store`.

For example:
`/nix/store/9g28nz6zh484144mzw670bx82y1ka49a-vulkan-headers-1.2.162.0/share/vulkan/registry/vk.xml`

This is currently worked around in the Nix package, by symlinking the `vulkan-headers` into MangoHud's install directory:

https://github.com/NixOS/nixpkgs/blob/5debc5776042e6eda5f87e02308a4b3998258940/pkgs/tools/graphics/mangohud/default.nix#L66-L70

Although, this workaround causes the `vulkan-headers` to be included as a runtime dependency when they're only needed at build time.

I tried to figure out a way to resolve the datadir automatically, but found that just adding a new option is probably the best solution for the following reasons:

- The `vulkan.pc` file used to resolve `dep_vulkan` doesn't contain any information about the datadir.

- The share directory could be resolved relative to the vulkan include directory and that would solve the specific issue for Nix, but the datadir could be installed anywhere and that wouldn't be a general solution.

- I couldn't find a way to resolve the data dir using the XDG Base Directory Specification because meson doesn't provide a way to access the necessary environment variables. https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html