### PR TITLE
cpu: remove k10temp power reporting

### DIFF
--- a/src/cpu.h
+++ b/src/cpu.h
@@ -43,35 +43,12 @@ typedef struct CPUData_ {
 } CPUData;
 
 enum {
-   CPU_POWER_K10TEMP,
    CPU_POWER_ZENPOWER,
    CPU_POWER_RAPL
 };
 
 struct CPUPowerData {
    int source;
-};
-
-struct CPUPowerData_k10temp : public CPUPowerData {
-   CPUPowerData_k10temp() {
-      this->source = CPU_POWER_K10TEMP;
-   };
-
-   ~CPUPowerData_k10temp() {
-      if(this->coreVoltageFile)
-         fclose(this->coreVoltageFile);
-      if(this->coreCurrentFile)
-         fclose(this->coreCurrentFile);
-      if(this->socVoltageFile)
-         fclose(this->socVoltageFile);
-      if(this->socCurrentFile)
-         fclose(this->socCurrentFile);
-   };
-
-   FILE* coreVoltageFile {nullptr};
-   FILE* coreCurrentFile {nullptr};
-   FILE* socVoltageFile {nullptr};
-   FILE* socCurrentFile {nullptr};
 };
 
 struct CPUPowerData_zenpower : public CPUPowerData {


### PR DESCRIPTION
the k10temp driver no longer reports voltage / current
 since kernel 5.11

support was initially added for 5.6 so the window where people
 will miss this information isn't too large
 (ubuntu 20.10 by the looks of it)

https://github.com/torvalds/linux/commit/0a4e668

Signed-off-by: Theo Anderson <telans@posteo.de>