### PR TITLE
Add support for multi gpu device stats

### DIFF
--- a/src/gl/imgui_hud.cpp
+++ b/src/gl/imgui_hud.cpp
@@ -111,7 +111,7 @@ void imgui_create(void *ctx)
     } else {
         vendorID = 0x10de;
     }
-    init_gpu_stats(vendorID, params);
+    init_gpu_stats(vendorID, params,deviceID);
     get_device_name(vendorID, deviceID, sw_stats);
     // Setup Dear ImGui context
     IMGUI_CHECKVERSION();
@@ -177,8 +177,8 @@ void imgui_render(unsigned int width, unsigned int height)
     if (!state.imgui_ctx)
         return;
 
-    check_keybinds(sw_stats, params, vendorID);
-    update_hud_info(sw_stats, params, vendorID);
+    check_keybinds(sw_stats, params, vendorID,deviceID);
+    update_hud_info(sw_stats, params, vendorID,deviceID);
 
     ImGuiContext *saved_ctx = ImGui::GetCurrentContext();
     ImGui::SetCurrentContext(state.imgui_ctx);

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -5,9 +5,8 @@
 #include "nvidia_info.h"
 #endif
 
-struct gpuInfo gpu_info;
-amdgpu_files amdgpu {};
-
+std::unordered_map<int32_t, struct gpuInfo> gpu_info;
+std::unordered_map<int32_t, amdgpu_files> amdgpu= {};
 bool checkNvidia(const char *pci_dev){
     bool nvSuccess = false;
 #ifdef HAVE_NVML
@@ -24,30 +23,30 @@ bool checkNvidia(const char *pci_dev){
     return nvSuccess;
 }
 
-void getNvidiaGpuInfo(){
+void getNvidiaGpuInfo(int32_t deviceID){
 #ifdef HAVE_NVML
     if (nvmlSuccess){
         getNVMLInfo();
-        gpu_info.load = nvidiaUtilization.gpu;
-        gpu_info.temp = nvidiaTemp;
-        gpu_info.memoryUsed = nvidiaMemory.used / (1024.f * 1024.f * 1024.f);
-        gpu_info.CoreClock = nvidiaCoreClock;
-        gpu_info.MemClock = nvidiaMemClock;
-        gpu_info.powerUsage = nvidiaPowerUsage / 1000;
-        gpu_info.memoryTotal = nvidiaMemory.total / (1024.f * 1024.f * 1024.f);
+        gpu_info[deviceID].load = nvidiaUtilization.gpu;
+        gpu_info[deviceID].temp = nvidiaTemp;
+        gpu_info[deviceID].memoryUsed = nvidiaMemory.used / (1024.f * 1024.f * 1024.f);
+        gpu_info[deviceID].CoreClock = nvidiaCoreClock;
+        gpu_info[deviceID].MemClock = nvidiaMemClock;
+        gpu_info[deviceID].powerUsage = nvidiaPowerUsage / 1000;
+        gpu_info[deviceID].memoryTotal = nvidiaMemory.total / (1024.f * 1024.f * 1024.f);
         return;
     }
 #endif
 #ifdef HAVE_XNVCTRL
     if (nvctrlSuccess) {
         getNvctrlInfo();
-        gpu_info.load = nvctrl_info.load;
-        gpu_info.temp = nvctrl_info.temp;
-        gpu_info.memoryUsed = nvctrl_info.memoryUsed / (1024.f);
-        gpu_info.CoreClock = nvctrl_info.CoreClock;
-        gpu_info.MemClock = nvctrl_info.MemClock;
-        gpu_info.powerUsage = 0;
-        gpu_info.memoryTotal = nvctrl_info.memoryTotal;
+        gpu_info[deviceID].load = nvctrl_info.load;
+        gpu_info[deviceID].temp = nvctrl_info.temp;
+        gpu_info[deviceID].memoryUsed = nvctrl_info.memoryUsed / (1024.f);
+        gpu_info[deviceID].CoreClock = nvctrl_info.CoreClock;
+        gpu_info[deviceID].MemClock = nvctrl_info.MemClock;
+        gpu_info[deviceID].powerUsage = 0;
+        gpu_info[deviceID].memoryTotal = nvctrl_info.memoryTotal;
         return;
     }
 #endif
@@ -56,65 +55,65 @@ nvapi_util();
 #endif
 }
 
-void getAmdGpuInfo(){
+void getAmdGpuInfo(int32_t deviceID){
     int64_t value = 0;
 
-    if (amdgpu.busy) {
-        rewind(amdgpu.busy);
-        fflush(amdgpu.busy);
-        if (fscanf(amdgpu.busy, "%d", &gpu_info.load) != 1)
-            gpu_info.load = 0;
-        gpu_info.load = gpu_info.load;
+    if (amdgpu[deviceID].busy) {
+        rewind(amdgpu[deviceID].busy);
+        fflush(amdgpu[deviceID].busy);
+        if (fscanf(amdgpu[deviceID].busy, "%d", &gpu_info[deviceID].load) != 1)
+            gpu_info[deviceID].load = 0;
+        gpu_info[deviceID].load = gpu_info[deviceID].load;
     }
 
-    if (amdgpu.temp) {
-        rewind(amdgpu.temp);
-        fflush(amdgpu.temp);
-        if (fscanf(amdgpu.temp, "%d", &gpu_info.temp) != 1)
-            gpu_info.temp = 0;
-        gpu_info.temp /= 1000;
+    if (amdgpu[deviceID].temp) {
+        rewind(amdgpu[deviceID].temp);
+        fflush(amdgpu[deviceID].temp);
+        if (fscanf(amdgpu[deviceID].temp, "%d", &gpu_info[deviceID].temp) != 1)
+            gpu_info[deviceID].temp = 0;
+        gpu_info[deviceID].temp /= 1000;
     }
 
-    if (amdgpu.vram_total) {
-        rewind(amdgpu.vram_total);
-        fflush(amdgpu.vram_total);
-        if (fscanf(amdgpu.vram_total, "%" PRId64, &value) != 1)
+    if (amdgpu[deviceID].vram_total) {
+        rewind(amdgpu[deviceID].vram_total);
+        fflush(amdgpu[deviceID].vram_total);
+        if (fscanf(amdgpu[deviceID].vram_total, "%" PRId64, &value) != 1)
             value = 0;
-        gpu_info.memoryTotal = float(value) / (1024 * 1024 * 1024);
+        gpu_info[deviceID].memoryTotal = float(value) / (1024 * 1024 * 1024);
     }
 
-    if (amdgpu.vram_used) {
-        rewind(amdgpu.vram_used);
-        fflush(amdgpu.vram_used);
-        if (fscanf(amdgpu.vram_used, "%" PRId64, &value) != 1)
+    if (amdgpu[deviceID].vram_used) {
+        rewind(amdgpu[deviceID].vram_used);
+        fflush(amdgpu[deviceID].vram_used);
+        if (fscanf(amdgpu[deviceID].vram_used, "%" PRId64, &value) != 1)
             value = 0;
-        gpu_info.memoryUsed = float(value) / (1024 * 1024 * 1024);
+        gpu_info[deviceID].memoryUsed = float(value) / (1024 * 1024 * 1024);
     }
 
-    if (amdgpu.core_clock) {
-        rewind(amdgpu.core_clock);
-        fflush(amdgpu.core_clock);
-        if (fscanf(amdgpu.core_clock, "%" PRId64, &value) != 1)
-            value = 0;
-
-        gpu_info.CoreClock = value / 1000000;
-    }
-
-    if (amdgpu.memory_clock) {
-        rewind(amdgpu.memory_clock);
-        fflush(amdgpu.memory_clock);
-        if (fscanf(amdgpu.memory_clock, "%" PRId64, &value) != 1)
+    if (amdgpu[deviceID].core_clock) {
+        rewind(amdgpu[deviceID].core_clock);
+        fflush(amdgpu[deviceID].core_clock);
+        if (fscanf(amdgpu[deviceID].core_clock, "%" PRId64, &value) != 1)
             value = 0;
 
-        gpu_info.MemClock = value / 1000000;
+        gpu_info[deviceID].CoreClock = value / 1000000;
     }
 
-    if (amdgpu.power_usage) {
-        rewind(amdgpu.power_usage);
-        fflush(amdgpu.power_usage);
-        if (fscanf(amdgpu.power_usage, "%" PRId64, &value) != 1)
+    if (amdgpu[deviceID].memory_clock) {
+        rewind(amdgpu[deviceID].memory_clock);
+        fflush(amdgpu[deviceID].memory_clock);
+        if (fscanf(amdgpu[deviceID].memory_clock, "%" PRId64, &value) != 1)
             value = 0;
 
-        gpu_info.powerUsage = value / 1000000;
+        gpu_info[deviceID].MemClock = value / 1000000;
+    }
+
+    if (amdgpu[deviceID].power_usage) {
+        rewind(amdgpu[deviceID].power_usage);
+        fflush(amdgpu[deviceID].power_usage);
+        if (fscanf(amdgpu[deviceID].power_usage, "%" PRId64, &value) != 1)
+            value = 0;
+
+        gpu_info[deviceID].powerUsage = value / 1000000;
     }
 }

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -3,6 +3,8 @@
 #define MANGOHUD_GPU_H
 
 #include <stdio.h>
+#include <unordered_map>
+#include <cstdint>
 
 struct amdgpu_files
 {
@@ -15,9 +17,10 @@ struct amdgpu_files
     FILE *power_usage;
 };
 
-extern amdgpu_files amdgpu;
+extern std::unordered_map<int32_t, amdgpu_files> amdgpu;
 
 struct gpuInfo{
+    int32_t deviceID;
     int load;
     int temp;
     float memoryUsed;
@@ -27,10 +30,10 @@ struct gpuInfo{
     int powerUsage;
 };
 
-extern struct gpuInfo gpu_info;
+extern std::unordered_map<int32_t, struct gpuInfo> gpu_info;
 
-void getNvidiaGpuInfo(void);
-void getAmdGpuInfo(void);
+void getNvidiaGpuInfo(int32_t deviceID);
+void getAmdGpuInfo(int32_t deviceID);
 bool checkNvidia(const char *pci_dev);
 extern void nvapi_util();
 extern bool checkNVAPI();

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <unordered_map>
 #include <cstdint>
+#include <string>
 
 struct amdgpu_files
 {
@@ -20,7 +21,7 @@ struct amdgpu_files
 extern std::unordered_map<int32_t, amdgpu_files> amdgpu;
 
 struct gpuInfo{
-    int32_t deviceID;
+    std::string deviceName;
     int load;
     int temp;
     float memoryUsed;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -104,12 +104,14 @@ void HudElements::gpu_stats(){
     for(auto per_gpu_info: gpu_info){
          if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats]){
         ImGui::TableNextRow();
-        const char* gpu_text;
+        
+        std::string gpu_text;
         if (HUDElements.params->gpu_text.empty())
-            gpu_text = "GPU";
+            gpu_text = "GPU " + per_gpu_info.second.deviceName;
         else
             gpu_text = HUDElements.params->gpu_text.c_str();
-        ImGui::TextColored(HUDElements.colors.gpu, "%s", gpu_text);
+        ImGui::TextColored(HUDElements.colors.gpu, "%s", gpu_text.c_str());
+        ImGui::TableNextRow();
         ImGui::TableNextCell();
         auto text_color = HUDElements.colors.text;
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_load_change]){
@@ -285,7 +287,8 @@ void HudElements::vram(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vram]){
         for(auto per_gpu_info : gpu_info){
             ImGui::TableNextRow();
-        ImGui::TextColored(HUDElements.colors.vram, "VRAM" );
+        ImGui::TextColored(HUDElements.colors.vram, "VRAM %s",per_gpu_info.second.deviceName.c_str() );
+        ImGui::TableNextRow();
         ImGui::TableNextCell();
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", per_gpu_info.second.memoryUsed);
         ImGui::SameLine(0,1.0f);

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -548,9 +548,11 @@ void HudElements::graphs(){
             arr.erase(arr.begin());
         }
 
-        HUDElements.max = gpu_info[0].memoryTotal;
+        for(auto per_gpu_info: gpu_info){
+            HUDElements.max = per_gpu_info.second.memoryTotal;
         HUDElements.min = 0;
         ImGui::TextColored(HUDElements.colors.engine, "%s", "VRAM");
+        }
     }
 
     if (value == "ram"){

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -101,7 +101,8 @@ void HudElements::version(){
 }
 
 void HudElements::gpu_stats(){
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats]){
+    for(auto per_gpu_info: gpu_info){
+         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats]){
         ImGui::TableNextRow();
         const char* gpu_text;
         if (HUDElements.params->gpu_text.empty())
@@ -119,14 +120,15 @@ void HudElements::gpu_stats(){
                 HUDElements.params->gpu_load_value[0],
                 HUDElements.params->gpu_load_value[1]
             };
+            
 
-            auto load_color = change_on_load_temp(gpu_data, gpu_info.load);
-            right_aligned_text(load_color, HUDElements.ralign_width, "%i", gpu_info.load);
+            auto load_color = change_on_load_temp(gpu_data, per_gpu_info.second.load);
+            right_aligned_text(load_color, HUDElements.ralign_width, "%i", per_gpu_info.second.load);
             ImGui::SameLine(0, 1.0f);
             ImGui::TextColored(load_color,"%%");
         }
         else {
-            right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.load);
+            right_aligned_text(text_color, HUDElements.ralign_width, "%i", per_gpu_info.second.load);
             ImGui::SameLine(0, 1.0f);
             ImGui::TextColored(text_color,"%%");
             // ImGui::SameLine(150);
@@ -134,7 +136,7 @@ void HudElements::gpu_stats(){
         }
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp]){
             ImGui::TableNextCell();
-            right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.temp);
+            right_aligned_text(text_color, HUDElements.ralign_width, "%i", per_gpu_info.second.temp);
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("°C");
         }
@@ -142,7 +144,7 @@ void HudElements::gpu_stats(){
             ImGui::TableNextRow();
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock]){
             ImGui::TableNextCell();
-            right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.CoreClock);
+            right_aligned_text(text_color, HUDElements.ralign_width, "%i", per_gpu_info.second.CoreClock);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(HUDElements.sw_stats->font1);
             ImGui::Text("MHz");
@@ -150,12 +152,15 @@ void HudElements::gpu_stats(){
         }
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_power]) {
             ImGui::TableNextCell();
-            right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.powerUsage);
+            right_aligned_text(text_color, HUDElements.ralign_width, "%i", per_gpu_info.second.powerUsage);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(HUDElements.sw_stats->font1);
             ImGui::Text("W");
             ImGui::PopFont();
         }
+       
+        
+    }
     }
 }
 
@@ -278,22 +283,26 @@ void HudElements::io_stats(){
 
 void HudElements::vram(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vram]){
-        ImGui::TableNextRow();
-        ImGui::TextColored(HUDElements.colors.vram, "VRAM");
+        for(auto per_gpu_info : gpu_info){
+            ImGui::TableNextRow();
+        ImGui::TextColored(HUDElements.colors.vram, "VRAM" );
         ImGui::TableNextCell();
-        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", gpu_info.memoryUsed);
+            right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", per_gpu_info.second.memoryUsed);
         ImGui::SameLine(0,1.0f);
         ImGui::PushFont(HUDElements.sw_stats->font1);
         ImGui::Text("GiB");
         ImGui::PopFont();
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_mem_clock]){
             ImGui::TableNextCell();
-            right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", gpu_info.MemClock);
+            right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", per_gpu_info.second.MemClock);
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(HUDElements.sw_stats->font1);
             ImGui::Text("MHz");
             ImGui::PopFont();
         }
+
+        }
+        
     }
 }
 void HudElements::ram(){
@@ -536,7 +545,7 @@ void HudElements::graphs(){
             arr.erase(arr.begin());
         }
 
-        HUDElements.max = gpu_info.memoryTotal;
+        HUDElements.max = gpu_info[0].memoryTotal;
         HUDElements.min = 0;
         ImGui::TextColored(HUDElements.colors.engine, "%s", "VRAM");
     }

--- a/src/keybinds.cpp
+++ b/src/keybinds.cpp
@@ -3,7 +3,7 @@
 #include "logging.h"
 #include "keybinds.h"
 
-void check_keybinds(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID){
+void check_keybinds(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID,int32_t deviceID){
    using namespace std::chrono_literals;
    bool pressed = false; // FIXME just a placeholder until wayland support
    auto now = Clock::now(); /* us */
@@ -28,7 +28,7 @@ void check_keybinds(struct swapchain_stats& sw_stats, struct overlay_params& par
        } else {
          logger->start_logging();
          std::thread(update_hw_info, std::ref(sw_stats), std::ref(params),
-                     vendorID)
+                     vendorID,deviceID)
              .detach();
          benchmark.fps_data.clear();
        }

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -19,7 +19,7 @@ struct fps_limit fps_limit_stats {};
 ImVec2 real_font_size;
 std::vector<logData> graph_data;
 
-void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID)
+void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID,int32_t deviceID)
 {
    if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_stats] || logger->is_active()) {
       cpuStats.UpdateCPUData();
@@ -35,10 +35,10 @@ void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& par
    }
    if (params.enabled[OVERLAY_PARAM_ENABLED_gpu_stats] || logger->is_active()) {
       if (vendorID == 0x1002)
-         getAmdGpuInfo();
+         getAmdGpuInfo(deviceID);
 
       if (vendorID == 0x10de)
-         getNvidiaGpuInfo();
+         getNvidiaGpuInfo(deviceID);
    }
 
    // get ram usage/max
@@ -50,11 +50,11 @@ void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& par
       getIoStats(&sw_stats.io);
 #endif
 
-   currentLogData.gpu_load = gpu_info.load;
-   currentLogData.gpu_temp = gpu_info.temp;
-   currentLogData.gpu_core_clock = gpu_info.CoreClock;
-   currentLogData.gpu_mem_clock = gpu_info.MemClock;
-   currentLogData.gpu_vram_used = gpu_info.memoryUsed;
+  currentLogData.gpu_load = gpu_info[deviceID].load;
+   currentLogData.gpu_temp = gpu_info[deviceID].temp;
+   currentLogData.gpu_core_clock = gpu_info[deviceID].CoreClock;
+   currentLogData.gpu_mem_clock = gpu_info[deviceID].MemClock;
+   currentLogData.gpu_vram_used = gpu_info[deviceID].memoryUsed;
 #ifdef __gnu_linux__
    currentLogData.ram_used = memused;
 #endif
@@ -64,12 +64,12 @@ void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& par
    // Save data for graphs
    if (graph_data.size() > 50)
       graph_data.erase(graph_data.begin());
-   graph_data.push_back({0, 0, cpuStats.GetCPUDataTotal().percent, gpu_info.load, cpuStats.GetCPUDataTotal().temp,
-                        gpu_info.temp, gpu_info.CoreClock, gpu_info.MemClock, gpu_info.memoryUsed, memused});
+   graph_data.push_back({0, 0, cpuStats.GetCPUDataTotal().percent, gpu_info[deviceID].load, cpuStats.GetCPUDataTotal().temp,
+                        gpu_info[deviceID].temp, gpu_info[deviceID].CoreClock, gpu_info[deviceID].MemClock, gpu_info[deviceID].memoryUsed, memused});
    logger->notify_data_valid();
 }
 
-void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID){
+void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID,int32_t deviceID){
    uint32_t f_idx = sw_stats.n_frames % ARRAY_SIZE(sw_stats.frames_stats);
    uint64_t now = os_time_get(); /* us */
    double elapsed = (double)(now - sw_stats.last_fps_update); /* us */
@@ -84,7 +84,7 @@ void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& pa
 
    frametime = now - sw_stats.last_present_time;
    if (elapsed >= params.fps_sampling_period) {
-      std::thread(update_hw_info, std::ref(sw_stats), std::ref(params), vendorID).detach();
+      std::thread(update_hw_info, std::ref(sw_stats), std::ref(params), vendorID,deviceID).detach();
       sw_stats.fps = fps;
 
       if (params.enabled[OVERLAY_PARAM_ENABLED_time]) {

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -88,11 +88,11 @@ extern std::vector<logData> graph_data;
 
 void position_layer(struct swapchain_stats& data, struct overlay_params& params, ImVec2 window_size);
 void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, bool is_vulkan);
-void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID);
-void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID);
-void init_gpu_stats(uint32_t& vendorID, overlay_params& params);
+void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID,int32_t deviceID);
+void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID,int32_t deviceID);
+void init_gpu_stats(uint32_t& vendorID, overlay_params& params, int32_t deviceID);
 void init_cpu_stats(overlay_params& params);
-void check_keybinds(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID);
+void check_keybinds(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID,int32_t deviceID);
 void init_system_info(void);
 void FpsLimiter(struct fps_limit& stats);
 void get_device_name(int32_t vendorID, int32_t deviceID, struct swapchain_stats& sw_stats);

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1754,6 +1754,7 @@ void get_device_name(int32_t vendorID, int32_t deviceID, struct swapchain_stats&
       for (char c: chars)
          desc.erase(remove(desc.begin(), desc.end(), c), desc.end());
    }
+   gpu_info[deviceID].deviceName = desc;
    sw_stats.gpuName = desc;
    trim(sw_stats.gpuName);
 #endif


### PR DESCRIPTION
This allows setups with more than one GPU to see statistics from both GPUs. This is still pretty rough and has been tested only on Vulkan and not OpenGL or Direct3D. 
I am still pretty new to Vulkan programming and I thought this would be a good way to explore Vulkan device groups and Vulkan explicit Multi GPU (Whenever they become a thing)