### PR TITLE
Add missing and rearrange options in .conf

### DIFF
--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -23,7 +23,7 @@
 # custom_text_center=
 
 ### Display the current system time
-time
+# time
 
 ### Time formatting examples
 # time_format=%H:%M

--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -5,7 +5,7 @@
 
 ################ PERFORMANCE #################
 
-### Limit the application FPS. Comma-separated list of one or more FPS values (e.g. 0,30,60). 0 means unlimited (unless VSynced).
+### Limit the application FPS. Comma-separated list of one or more FPS values (e.g. 0,30,60). 0 means unlimited (unless VSynced)
 # fps_limit=
 
 ### VSync [0-3] 0 = adaptive; 1 = off; 2 = mailbox; 3 = on
@@ -16,104 +16,124 @@
 
 ################### VISUAL ###################
 
-### Custom text centered useful for a header
-# custom_text_center =
-
 ### Legacy layout
-# legacy_layout = false
+# legacy_layout=false
 
-### Display the current CPU information
-cpu_stats
-# cpu_temp
-# cpu_power
-# cpu_text = "CPU"
-# cpu_mhz
-# cpu_load_change
-# cpu_load_value
-# cpu_load_color
+### Display the current system time
+time
+
+### Time formatting examples
+# time_format=%H:%M
+# time_format=[ %T %F ]
+# time_format=%X # locally formatted time, because of limited glyph range, missing characters may show as '?' (e.g. Japanese)
+
+### Display MangoHud version
+# version
 
 ### Display the current GPU information
 gpu_stats
 # gpu_temp
 # gpu_core_clock
 # gpu_mem_clock
-# gpu_name
 # gpu_power
-# gpu_text = "GPU"
-# vulkan_driver
+# gpu_text="GPU"
 # gpu_load_change
-# gpu_load_value
-# gpu_load_color
+# gpu_load_value=60,90
+# gpu_load_color=39F900,FDFD09,B22222
+
+### Display the current CPU information
+cpu_stats
+# cpu_temp
+# cpu_power
+# cpu_text="CPU"
+# cpu_mhz
+# cpu_load_change
+# cpu_load_value=60,90
+# cpu_load_color=39F900,FDFD09,B22222
+
+### Display the current CPU load & frequency for each core
+# core_load
+# core_load_change
+
+### Display IO read and write for the app (not system)
+# io_stats
+# io_read
+# io_write
+
+### Display system vram / ram / swap space usage
+# vram
+# ram
+# swap
+
+### Display battery information
+# battery
+# battery_icon
 
 ### Display FPS and frametime
 fps
-# fps_sampling_period=
+# fps_sampling_period=500
+# fps_color_change
+# fps_value=30,60
+# fps_color=B22222,FDFD09,39F900
 frametime
+
+### Display miscellaneus information
+# engine_version
+# gpu_name
+# vulkan_driver
+# wine
 
 ### Display loaded MangoHud architecture
 # arch
 
 ### Display the frametime line graph
 frame_timing
-#histogram
+# histogram
 
-### Display the current system time
-# time
+### Display GameMode / vkBasalt running status
+# gamemode
+# vkbasalt
+
+### Display current FPS limit
+# show_fps_limit
 
 ### Display the current resolution
 # resolution
 
-### Show current fps limit
-#  show_fps_limit
-
 ### Display custom text
-# custom_text
+# custom_text=
+### Display output of Bash command in next column
+# exec=
 
-### Time formatting examples
-# time_format = %H:%M
-# time_format = [ %T %F ]
-# time_format = %X # locally formatted time, because of limited glyph range, missing characters may show as '?' (e.g. Japanese)
+### Display media player metadata
+# media_player
+# media_player_name=spotify
+# media_player_order=title,artist,album
 
-### Change the hud font size (default is 24)
-font_size=24
+### Change the hud font size
+# font_size=24
 # font_scale=1.0
 # font_size_text=24
-# font_scale_media_player = 0.55
+# font_scale_media_player=0.55
 # no_small_font
 
-### Change default font (set location to .TTF/.OTF file )
+### Change default font (set location to TTF/OTF file)
 ## Set font for the whole hud
 # font_file=
 
 ## Set font only for text like media player metadata
 # font_file_text=
 
-## Set font glyph ranges. Defaults to latin-only. Don't forget to set font_file/text_font_file to font that supports these.
-## Probably don't enable all at once because of memory usage and hardware limits concerns.
-## If you experience crashes or text is just squares, reduce glyph range or reduce font size.
-# font_glyph_ranges=korean, chinese, chinese_simplified, japanese, cyrillic, thai, vietnamese, latin_ext_a, latin_ext_b
+## Set font glyph ranges. Defaults to Latin-only. Don't forget to set font_file/font_file_text to font that supports these
+## Probably don't enable all at once because of memory usage and hardware limits concerns
+## If you experience crashes or text is just squares, reduce glyph range or reduce font size
+# font_glyph_ranges=korean,chinese,chinese_simplified,japanese,cyrillic,thai,vietnamese,latin_ext_a,latin_ext_b
 
-### Change the hud position (default is top-left)
-position=top-left
+### Change the hud position
+# position=top-left
 
-### Display the current CPU load & frequency for each core
-# core_load
-# core_load_change
-
-### IO read and write for the app (not system)
-# io_read
-# io_write
-# io_stats
-
-### Display system ram / swap space / vram usage
-# ram
-# swap
-# vram
-
-### Display MangoHud, engine or Wine version
-# version
-# engine_version
-# wine
+### Change the corner roundness
+# round_corners=
 
 ### Disable / hide the hud by default
 # no_display
@@ -129,7 +149,7 @@ position=top-left
 # cellpadding_y=
 
 ### Hud transparency / alpha
-background_alpha=0.5
+# background_alpha=0.5
 # alpha=
 
 ### Color customization
@@ -143,32 +163,28 @@ background_alpha=0.5
 # frametime_color=00FF00
 # background_color=020202
 # media_player_color=FFFFFF
-# wine_color=732010
+# wine_color=EB5B5B
+# battery_color=FF9078
 
-### Show media player metadata
-# media_player
-# media_player_name = spotify
-# media_player_order = title,artist,album
-
-### Specify gpu with pci bus id for amdgpu and NVML stats.
+### Specify GPU with PCI bus ID for AMDGPU and NVML stats
 ### Set to 'domain:bus:slot.function'
-# pci_dev = 0:0a:0.0
+# pci_dev=0:0a:0.0
 
 ### Blacklist
-# blacklist =
+# blacklist=
 
-################## WORKAROUNDS #################
-### Options starting with "gl_*" are for OpenGL.
-### Specify what to use for getting display size. Options are "viewport", "scissorbox" or disabled. Defaults to using glXQueryDrawable.
-# gl_size_query = viewport
+################ WORKAROUNDS #################
+### Options starting with "gl_*" are for OpenGL
+### Specify what to use for getting display size. Options are "viewport", "scissorbox" or disabled. Defaults to using glXQueryDrawable
+# gl_size_query=viewport
 
-### (Re)bind given framebuffer before MangoHud gets drawn. Helps with Crusader Kings III.
-# gl_bind_framebuffer = 0
+### (Re)bind given framebuffer before MangoHud gets drawn. Helps with Crusader Kings III
+# gl_bind_framebuffer=0
 
-### Don't swap origin if using GL_UPPER_LEFT. Helps with Ryujinx.
-# gl_dont_flip = 1
+### Don't swap origin if using GL_UPPER_LEFT. Helps with Ryujinx
+# gl_dont_flip=1
 
-################## INTERACTION #################
+################ INTERACTION #################
 
 ### Change toggle keybinds for the hud & logging
 # toggle_hud=Shift_R+F12
@@ -177,15 +193,17 @@ background_alpha=0.5
 # reload_cfg=Shift_L+F4
 # upload_log=Shift_L+F3
 
-################## LOG #################
+#################### LOG #####################
 ### Automatically start the log after X seconds
-# autostart_log = 1
+# autostart_log=1
 ### Set amount of time in seconds that the logging will run for
-# log_duration
+# log_duration=
+### Change the default log interval, 100 is default
+# log_interval=100
 ### Set location of the output files (required for logging)
-# output_folder = /home/<USERNAME>/mangologs
+# output_folder=/home/<USERNAME>/mangologs
 ### Permit uploading logs directly to FlightlessMango.com
 # permit_upload=1
-### Define a '+'-separated list of percentiles shown in the benchmark results.
+### Define a '+'-separated list of percentiles shown in the benchmark results
 ### Use "AVG" to get a mean average. Default percentiles are 97+AVG+1+0.1
-# benchmark_percentiles=
+# benchmark_percentiles=97,AVG,1,0.1

--- a/bin/MangoHud.conf
+++ b/bin/MangoHud.conf
@@ -19,6 +19,9 @@
 ### Legacy layout
 # legacy_layout=false
 
+### Display custom centered text, useful for a header
+# custom_text_center=
+
 ### Display the current system time
 time
 


### PR DESCRIPTION
Added missing options and rearranged the way they appear under legacy layout plus minor fixes:
* Added some default values after `=`
* Commented out options with default values
* Unified style