### PR TITLE
Show fan RPM for (AMD) GPUs

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -66,6 +66,15 @@ void getAmdGpuInfo(){
         gpu_info.load = value;
     }
 
+    if (amdgpu.fan) {
+        rewind(amdgpu.fan);
+        fflush(amdgpu.fan);
+        int value = 0;
+        if (fscanf(amdgpu.fan, "%d" PRId64, &value) != 1)
+            value = 0;
+        gpu_info.fan = value;
+    }
+
     if (amdgpu.temp) {
         rewind(amdgpu.temp);
         fflush(amdgpu.temp);

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -13,6 +13,7 @@ struct amdgpu_files
     FILE *core_clock;
     FILE *memory_clock;
     FILE *power_usage;
+    FILE *fan;
 };
 
 extern amdgpu_files amdgpu;
@@ -25,6 +26,7 @@ struct gpuInfo{
     int MemClock;
     int CoreClock;
     int powerUsage;
+    int fan;
 };
 
 extern struct gpuInfo gpu_info;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -144,6 +144,15 @@ void HudElements::gpu_stats(){
             ImGui::SameLine(0, 1.0f);
             ImGui::Text("°C");
         }
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_fan]){
+            // ImGui::TableNextRow();
+            // ImGui::TableNextColumn();
+            right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu_info.fan);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::Text("RPM");
+            ImGui::PopFont();
+        }
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock] || HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_power]){
             ImGui::TableNextRow(); ImGui::TableNextColumn();
         }

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -27,7 +27,7 @@ class HudElements{
         int min, max, gpu_core_max, gpu_mem_max, cpu_temp_max, gpu_temp_max;
         std::vector<std::string> permitted_params = {
             "gpu_load", "cpu_load", "gpu_core_clock", "gpu_mem_clock",
-            "vram", "ram", "cpu_temp", "gpu_temp"
+            "vram", "ram", "cpu_temp", "gpu_temp", "gpu_fan"
         };
         std::vector<exec_list> exec_list;
         void sort_elements(std::pair<std::string, std::string> option);

--- a/src/logging.h
+++ b/src/logging.h
@@ -24,6 +24,7 @@ struct logData{
   int gpu_core_clock;
   int gpu_mem_clock;
   int gpu_power;
+  int gpu_fan;
   float gpu_vram_used;
   float ram_used;
 

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -61,6 +61,7 @@ void update_hw_info(struct swapchain_stats& sw_stats, struct overlay_params& par
    currentLogData.gpu_mem_clock = gpu_info.MemClock;
    currentLogData.gpu_vram_used = gpu_info.memoryUsed;
    currentLogData.gpu_power = gpu_info.powerUsage;
+   currentLogData.gpu_fan = gpu_info.fan;
 #ifdef __gnu_linux__
    currentLogData.ram_used = memused;
 #endif

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -565,6 +565,7 @@ parse_overlay_config(struct overlay_params *params,
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_power] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_gpu_fan] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_ram] = false;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -45,6 +45,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(gpu_mem_clock)                 \
    OVERLAY_PARAM_BOOL(gpu_core_clock)                \
    OVERLAY_PARAM_BOOL(gpu_power)                     \
+   OVERLAY_PARAM_BOOL(gpu_fan)                       \
    OVERLAY_PARAM_BOOL(arch)                          \
    OVERLAY_PARAM_BOOL(media_player)                  \
    OVERLAY_PARAM_BOOL(version)                       \

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -583,6 +583,9 @@ void init_gpu_stats(uint32_t& vendorID, overlay_params& params)
                amdgpu.temp = fopen((path + tempFolder + "/temp1_input").c_str(), "r");
             if (!amdgpu.power_usage)
                amdgpu.power_usage = fopen((path + tempFolder + "/power1_average").c_str(), "r");
+            // check for more fan inputs?
+            if (!amdgpu.fan)
+               amdgpu.fan = fopen((path + tempFolder + "/fan1_input").c_str(), "r");
 
             vendorID = 0x1002;
             break;


### PR DESCRIPTION
This PR, based on https://github.com/flightlessmango/MangoHud/commit/e42002c57bd41235e14f155a45453223861e26d6 (master), adds the rpm value of the GPU as reported by the amdgpu driver.

What remains to be done:

- Add a check for whether the GPU fan is actually available/readable (e.g. CPUs with integrated graphics, or passively cooled GPUs)?
- Check whether there's a different sys file if fan1_input is unavailable?
- Beautify layout?
- Do the same for Nvidia GPUs