### PR TITLE
Load multiple config files

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -101,13 +101,13 @@ void parseConfigFile(overlay_params& params) {
     std::vector<std::string> paths;
     const char *cfg_file = getenv("MANGOHUD_CONFIGFILE");
 
+    enumerate_config_files(paths);
+
     if (cfg_file)
         paths.push_back(cfg_file);
-    else
-        enumerate_config_files(paths);
 
     std::string line;
-    for (auto p = paths.rbegin(); p != paths.rend(); p++) {
+    for (auto p = paths.begin(); p != paths.end(); p++) {
         std::ifstream stream(*p);
         if (!stream.good()) {
             // printing just so user has an idea of possible configs
@@ -122,6 +122,5 @@ void parseConfigFile(overlay_params& params) {
             parseConfigLine(line, params.options);
         }
         params.config_file_path = *p;
-        return;
     }
 }


### PR DESCRIPTION
Closes #594
Supersedes #429

This PR adds a simple way to enable all HUD elements specified by all found configs.

There are some things to be solved first:
- There's no way to disable HUD element (could be solved with configs allowing for example `!cpu_temp` which would disable CPU temp HUD element)
- With `legacy_layout=false` the order of HUD elements isn't possible to be changed(?)
- Only last config file is watched for changes for auto-reload