### PR TITLE
build-source: exclude spdlog

### DIFF
--- a/build-source.sh
+++ b/build-source.sh
@@ -26,6 +26,8 @@ rm ${NAME}/include/nvml.h
 rm -r ${NAME}/modules/minhook
 # vulkan headers from system
 rm -r ${NAME}/subprojects/Vulkan-Headers-*
+# spdlog from system
+rm -r ${NAME}/subprojects/spdlog-*
 # remove some dear imgui clutter
 rm -rf ${NAME}/subprojects/imgui-*/examples ${NAME}/subprojects/imgui-*/misc
 # compress new sources


### PR DESCRIPTION
spdlog is available on most distros: https://repology.org/project/spdlog/versions

Thus, as with Vulkan headers, it would be appreciated if it could be removed from the DFSG tarball.