### PR TITLE
Fix crash when no frames were recorded

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -77,7 +77,7 @@ void writeSummary(string filename){
       out << fixed << setprecision(1) << result << ",";
     }
     // 97th percentile
-    result = sorted[floor(0.97 * (sorted.size() - 1))].fps;
+    result = sorted.empty() ? 0.0f : sorted[floor(0.97 * (sorted.size() - 1))].fps;
     out << fixed << setprecision(1) << result << ",";
     // avg
     total = 0;
@@ -251,7 +251,7 @@ void Logger::calculate_benchmark_data(){
         // the percentiles are already validated when they're parsed from the config.
         float fraction = parse_float(percentile) / 100;
 
-        result = sorted[(fraction * sorted.size()) - 1];
+        result = sorted.empty() ? 0.0f : sorted[(fraction * sorted.size()) - 1];
         percentile += "%";
       }
 

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -431,7 +431,7 @@ void render_benchmark(swapchain_stats& data, struct overlay_params& params, ImVe
       ImGui::TextColored(ImVec4(1.0, 1.0, 1.0, alpha / params.background_alpha), "%s %.1f", data_.first.c_str(), data_.second);
    }
 
-   float max = *max_element(benchmark.fps_data.begin(), benchmark.fps_data.end());
+   float max = benchmark.fps_data.empty() ? 0.0f : *max_element(benchmark.fps_data.begin(), benchmark.fps_data.end());
    ImVec4 plotColor = HUDElements.colors.frametime;
    plotColor.w = alpha / params.background_alpha;
    ImGui::PushStyleColor(ImGuiCol_PlotLines, plotColor);


### PR DESCRIPTION
This can happen with MangoApp + the Steam Deck UI as it doesn't commit when there is nothing going on