### PR TITLE
Enable no_overlay by default with mangoapp

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -91,7 +91,7 @@ static void enumerate_config_files(std::vector<std::string>& paths) {
      }
 }
 
-void parseConfigFile(overlay_params& params) {
+bool parseConfigFile(overlay_params& params) {
     HUDElements.options.clear();
     params.options.clear();
     std::vector<std::string> paths;
@@ -120,6 +120,8 @@ void parseConfigFile(overlay_params& params) {
             parseConfigLine(line, params.options);
         }
         params.config_file_path = *p;
-        return;
+        return true;
     }
+
+    return false;
 }

--- a/src/config.h
+++ b/src/config.h
@@ -5,7 +5,7 @@
 #include "overlay_params.h"
 #include <string>
 
-void parseConfigFile(overlay_params& p);
+bool parseConfigFile(overlay_params& p);
 std::string get_program_name();
 
 #endif //MANGOHUD_CONFIG_H

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -658,7 +658,14 @@ parse_overlay_config(struct overlay_params *params,
    if (!env || read_cfg) {
 
       // Get config options
-      parseConfigFile(*params);
+      bool has_config_file = parseConfigFile(*params);
+#ifdef MANGOAPP
+      // Enable no_display if we have no config at all
+      // so we don't start randomly showing mangoapp if
+      // things went wrong somewhere.
+      if (!has_config_file)
+         params->no_display = true;
+#endif
       if (params->options.find("full") != params->options.end() && params->options.find("full")->second != "0") {
 #define OVERLAY_PARAM_BOOL(name) \
             params->enabled[OVERLAY_PARAM_ENABLED_##name] = 1;


### PR DESCRIPTION
Don't want this displaying unless explicitly requested.