### PR TITLE
Various mangoapp fixes, et al

### DIFF
--- a/src/app/control.cpp
+++ b/src/app/control.cpp
@@ -3,7 +3,6 @@
 #include "mangoapp.h"
 
 void help_and_quit() {
-    // TODO! document attributes and values
     fprintf(stderr, "Usage: mangohudctl [set|toggle] attribute [value]\n");
     fprintf(stderr, "Attributes:\n");
     fprintf(stderr, "   no_display      hides or shows hud\n");
@@ -22,38 +21,10 @@ bool str_to_bool(const char *value)
         return true;
     else if (strcasecmp(value, "false") == 0 || strcmp(value, "0") == 0)
         return false;
-    
+
     /* invalid boolean, display a nice error message saying that */
     fprintf(stderr, "The value '%s' is not an accepted boolean. Use 0/1 or true/false\n", value);
     exit(1);
-}
-
-bool set_attribute(struct mangoapp_ctrl_msgid1_v1 *ctrl_msg,
-                   const char *attribute, const char* value)
-{
-    if (strcmp(attribute, "no_display") == 0) {
-        ctrl_msg->no_display = str_to_bool(value) ? 1 : 2;
-        return true;
-    } else if (strcmp(attribute, "log_session") == 0) {
-        ctrl_msg->log_session = str_to_bool(value) ? 1 : 2;
-        return true;
-    } 
-    
-    return false;
-}
-
-bool toggle_attribute(struct mangoapp_ctrl_msgid1_v1 *ctrl_msg,
-                      const char *attribute)
-{
-    if (strcmp(attribute, "no_display") == 0) {
-        ctrl_msg->no_display = 3;
-        return true;
-    } else if (strcmp(attribute, "log_session") == 0) {
-        ctrl_msg->log_session = 3;
-        return true;
-    } 
-    
-    return false;
 }
 
 int main(int argc, char *argv[])
@@ -66,24 +37,33 @@ int main(int argc, char *argv[])
     ctrl_msg.hdr.msg_type = 2;
     ctrl_msg.hdr.ctrl_msg_type = 1;
     ctrl_msg.hdr.version = 1;
-    
+    uint8_t value;
+
     if (argc <= 2)
         help_and_quit();
-    
+
     if (strcmp(argv[1], "set") == 0) {
         if (argc != 4)
             help_and_quit();
 
-        set_attribute(&ctrl_msg, argv[2], argv[3]);
+        value = str_to_bool(argv[3]) ? 1 : 2;
     } else if (strcmp(argv[1], "toggle") == 0) {
         if (argc != 3)
             help_and_quit();
 
-        toggle_attribute(&ctrl_msg, argv[2]);
-    } else
+        value = 3;
+    } else {
         help_and_quit();
-        
+    }
+
+    if (strcmp(argv[2], "no_display") == 0)
+        ctrl_msg.no_display = value;
+    else if (strcmp(argv[2], "log_session") == 0)
+        ctrl_msg.log_session = value;
+    else
+        help_and_quit();
+
     msgsnd(msgid, &ctrl_msg, sizeof(mangoapp_ctrl_msgid1_v1), IPC_NOWAIT);
-        
+
     return 0;
 }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -266,6 +266,7 @@ int main(int, char**)
     init_cpu_stats(*params);
     notifier.params = params;
     start_notifier(notifier);
+    window_size = ImVec2(params->width, params->height);
         deviceName = (char*)glGetString(GL_RENDERER);
     sw_stats.deviceName = deviceName;
     if (deviceName.find("Radeon") != std::string::npos

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -69,7 +69,7 @@ static unsigned int get_prop(const char* propName){
     return 0;
 }
 
-void ctrl_thread(){
+static void ctrl_thread(){
     while (1){
         const struct mangoapp_ctrl_msgid1_v1 *mangoapp_ctrl_v1 = (const struct mangoapp_ctrl_msgid1_v1*) raw_msg;
         memset(raw_msg, 0, sizeof(raw_msg));
@@ -107,7 +107,7 @@ void ctrl_thread(){
 
 bool new_frame = false;
 
-void gamescope_frametime(uint64_t app_frametime_ns, uint64_t latency_ns){
+static void gamescope_frametime(uint64_t app_frametime_ns, uint64_t latency_ns){
     float app_frametime_ms = app_frametime_ns / 1000000.f;
     gamescope_debug_app.push_back(app_frametime_ms);
     if (gamescope_debug_app.size() > 200)
@@ -121,7 +121,7 @@ void gamescope_frametime(uint64_t app_frametime_ns, uint64_t latency_ns){
         gamescope_debug_latency.erase(gamescope_debug_latency.begin());
 }
 
-void msg_read_thread(){
+static void msg_read_thread(){
     for (size_t i = 0; i < 200; i++){
         gamescope_debug_app.push_back(0);
         gamescope_debug_latency.push_back(0);
@@ -180,7 +180,7 @@ void msg_read_thread(){
 
 static const char *GamescopeOverlayProperty = "GAMESCOPE_EXTERNAL_OVERLAY";
 
-GLFWwindow* init(const char* glsl_version){
+static GLFWwindow* init(const char* glsl_version){
     GLFWwindow *window = glfwCreateWindow(1280, 720, "mangoapp overlay window", NULL, NULL);
     Display *x11_display = glfwGetX11Display();
     Window x11_window = glfwGetX11Window(window);
@@ -203,14 +203,14 @@ GLFWwindow* init(const char* glsl_version){
     return window;
 }
 
-void shutdown(GLFWwindow* window){
+static void shutdown(GLFWwindow* window){
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplGlfw_Shutdown();
     ImGui::DestroyContext();
     glfwDestroyWindow(window);
 }
 
-bool render(GLFWwindow* window) {
+static bool render(GLFWwindow* window) {
     ImVec2 last_window_size = window_size;
     ImGui_ImplGlfw_NewFrame();
     ImGui_ImplOpenGL3_NewFrame();

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -75,6 +75,9 @@ static void ctrl_thread(){
         memset(raw_msg, 0, sizeof(raw_msg));
         msgrcv(msgid, (void *) raw_msg, sizeof(raw_msg), 2, 0);
         switch (mangoapp_ctrl_v1->log_session) {
+            case 0:
+                // Keep as-is
+                break;
             case 1:
                 if (!logger->is_active())
                     logger->start_logging();
@@ -90,6 +93,9 @@ static void ctrl_thread(){
         {
             std::lock_guard<std::mutex> lk(mangoapp_m);
             switch (mangoapp_ctrl_v1->no_display){
+                case 0:
+                    // Keep as-is
+                    break;
                 case 1:
                     params->no_display = 1;
                     break;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -284,9 +284,7 @@ int main(int, char**)
     while (!glfwWindowShouldClose(window)){
         if (!params->no_display){
             if (mangoapp_paused){
-                window = init(glsl_version);
-                create_fonts(*params, sw_stats.font1, sw_stats.font_text);
-                HUDElements.convert_colors(*params);
+                glfwRestoreWindow(window);
                 mangoapp_paused = false;
             }
             {
@@ -322,7 +320,7 @@ int main(int, char**)
 
             glfwSwapBuffers(window);
         } else if (!mangoapp_paused) {
-            shutdown(window);
+            glfwIconifyWindow(window);
             mangoapp_paused = true;
             std::unique_lock<std::mutex> lk(mangoapp_m);
             mangoapp_cv.wait(lk, []{return !params->no_display;});

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -223,7 +223,7 @@ bool render(GLFWwindow* window) {
 }
 
 int main(int, char**)
-{   
+{
     // Setup window
     glfwSetErrorCallback(glfw_error_callback);
     if (!glfwInit())
@@ -306,8 +306,8 @@ int main(int, char**)
             }
             // Rendering
             ImGui::Render();
-            glEnable(GL_DEPTH_TEST);        
-            glEnable(GL_BLEND);             
+            glEnable(GL_DEPTH_TEST);
+            glEnable(GL_BLEND);
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
             glClearColor(0, 0, 0, 0);
             glClear(GL_COLOR_BUFFER_BIT);

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -25,14 +25,15 @@ static void glfw_error_callback(int error, const char* description)
 {
     fprintf(stderr, "Glfw Error %d: %s\n", error, description);
 }
+
 swapchain_stats sw_stats {};
 overlay_params *params;
 static ImVec2 window_size;
 static uint32_t vendorID;
 static std::string deviceName;
 static notify_thread notifier;
-int msgid;
-bool mangoapp_paused = false;
+static int msgid;
+static bool mangoapp_paused = false;
 std::mutex mangoapp_m;
 std::condition_variable mangoapp_cv;
 static uint8_t raw_msg[1024] = {0};

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -330,11 +330,8 @@ int main(int, char**)
     }
 
     // Cleanup
-    ImGui_ImplOpenGL3_Shutdown();
-    ImGui_ImplGlfw_Shutdown();
-    ImGui::DestroyContext();
+    shutdown(window);
 
-    glfwDestroyWindow(window);
     glfwTerminate();
 
     return 0;

--- a/src/app/mangoapp.h
+++ b/src/app/mangoapp.h
@@ -7,7 +7,6 @@
 #include <condition_variable>
 #include <vector>
 
-extern int ctrl_msgid;
 extern int msgid;
 extern bool mangoapp_paused;
 extern std::mutex mangoapp_m;

--- a/src/app/mangoapp.h
+++ b/src/app/mangoapp.h
@@ -7,8 +7,6 @@
 #include <condition_variable>
 #include <vector>
 
-extern int msgid;
-extern bool mangoapp_paused;
 extern std::mutex mangoapp_m;
 extern std::condition_variable mangoapp_cv;
 struct mangoapp_msg_header {

--- a/src/app/mangoapp.h
+++ b/src/app/mangoapp.h
@@ -19,7 +19,7 @@ struct mangoapp_msg_header {
 
 struct mangoapp_msg_v1 {
     struct mangoapp_msg_header hdr;
-    
+
     uint32_t pid;
     uint64_t visible_frametime_ns;
     uint8_t fsrUpscale;
@@ -38,12 +38,12 @@ struct mangoapp_ctrl_header {
 
 struct mangoapp_ctrl_msgid1_v1 {
     struct mangoapp_ctrl_header hdr;
-    
+
     // When a field is set to 0, it should always mean "ignore" or "no changes"
     uint8_t no_display;      // 0x0 = ignore; 0x1 = disable; 0x2 = enable; 0x3 = toggle
     uint8_t log_session;     // 0x0 = ignore; 0x1 = start a session; 0x2 = stop the current session; 0x3 = toggle logging
     char log_session_name[64]; // if byte 0 is NULL, ignore. Needs to be set when starting/toggling a session if we want to override the default name
-    
+
     // WARNING: Always ADD fields, never remove or repurpose fields
 } __attribute__((packed));
 

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -73,7 +73,7 @@ R format_units(T value, const char*& unit)
     return out_value;
 }
 
-void HudElements::convert_colors(struct overlay_params& params)
+void HudElements::convert_colors(const struct overlay_params& params)
 {
     HUDElements.colors.update = false;
     auto convert = [](unsigned color) -> ImVec4 {
@@ -114,7 +114,7 @@ void HudElements::convert_colors(struct overlay_params& params)
     style.WindowRounding = params.round_corners;
 }
 
-void HudElements::convert_colors(bool do_conv, struct overlay_params& params)
+void HudElements::convert_colors(bool do_conv, const struct overlay_params& params)
 {
     HUDElements.colors.convert = do_conv;
     convert_colors(params);
@@ -188,7 +188,7 @@ void HudElements::gpu_stats(){
 #ifdef MANGOAPP
             right_aligned_text(text_color, HUDElements.ralign_width, "%.1f", gpu_info.powerUsage);
 #else
-    right_aligned_text(text_color, HUDElements.ralign_width, "%.0f", gpu_info.powerUsage);
+            right_aligned_text(text_color, HUDElements.ralign_width, "%.0f", gpu_info.powerUsage);
 #endif
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(HUDElements.sw_stats->font1);

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -937,7 +937,8 @@ void HudElements::graphs(){
         for (auto& it : graph_data){
             arr.push_back(float(it.cpu_load));
         }
-        HUDElements.max = 100; HUDElements.min = 0;
+        HUDElements.max = 100;
+        HUDElements.min = 0;
         ImGui::TextColored(HUDElements.colors.engine, "%s", "CPU Load");
     }
 
@@ -945,7 +946,8 @@ void HudElements::graphs(){
         for (auto& it : graph_data){
             arr.push_back(float(it.gpu_load));
         }
-        HUDElements.max = 100; HUDElements.min = 0;
+        HUDElements.max = 100;
+        HUDElements.min = 0;
         ImGui::TextColored(HUDElements.colors.engine, "%s", "GPU Load");
     }
 

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -64,8 +64,8 @@ class HudElements{
         static void gamepad_battery();
         static void framecount();
 
-        void convert_colors(struct overlay_params& params);
-        void convert_colors(bool do_conv, struct overlay_params& params);
+        void convert_colors(const struct overlay_params& params);
+        void convert_colors(bool do_conv, const struct overlay_params& params);
         struct hud_colors {
             bool convert, update;
             ImVec4 cpu,

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -141,7 +141,7 @@ string get_log_suffix(){
   return log_name;
 }
 
-Logger::Logger(overlay_params* in_params)
+Logger::Logger(const overlay_params* in_params)
   : m_params(in_params),
     m_logging_on(false),
     m_values_valid(false)

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -155,9 +155,6 @@ void Logger::start_logging() {
   m_values_valid = false;
   m_logging_on = true;
   m_log_start = Clock::now();
-#ifdef MANGOAPP
-  HUDElements.params->log_interval = 0;
-#endif
   if((!m_params->output_folder.empty()) && (m_params->log_interval != 0)){
     std::thread(&Logger::logging, this).detach();
   }

--- a/src/logging.h
+++ b/src/logging.h
@@ -32,7 +32,7 @@ struct logData{
 
 class Logger {
 public:
-  Logger(overlay_params* in_params);
+  Logger(const overlay_params* in_params);
 
   void start_logging();
   void stop_logging();
@@ -54,7 +54,7 @@ public:
   void upload_last_log();
   void upload_last_logs();
   void calculate_benchmark_data();
-  overlay_params* m_params;
+  const overlay_params* m_params;
 
 private:
   std::vector<logData> m_log_array;

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -84,7 +84,7 @@ void FpsLimiter(struct fps_limit& stats){
    }
 }
 
-void update_hw_info(struct overlay_params& params, uint32_t vendorID)
+void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
 {
    if (params.enabled[OVERLAY_PARAM_ENABLED_cpu_stats] || logger->is_active()) {
       cpuStats.UpdateCPUData();
@@ -144,7 +144,7 @@ struct hw_info_updater
 {
    bool quit = false;
    std::thread thread {};
-   struct overlay_params* params = nullptr;
+   const struct overlay_params* params = nullptr;
    uint32_t vendorID;
    bool update_hw_info_thread = false;
 
@@ -164,7 +164,7 @@ struct hw_info_updater
          thread.join();
    }
 
-   void update(struct overlay_params* params_, uint32_t vendorID_)
+   void update(const struct overlay_params* params_, uint32_t vendorID_)
    {
       std::unique_lock<std::mutex> lk_hw_updating(m_hw_updating, std::try_to_lock);
       if (lk_hw_updating.owns_lock())
@@ -200,7 +200,7 @@ void stop_hw_updater()
       hw_update_thread.reset();
 }
 
-void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID, uint64_t frametime_ns){
+void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, const struct overlay_params& params, uint32_t vendorID, uint64_t frametime_ns){
    uint32_t f_idx = sw_stats.n_frames % ARRAY_SIZE(sw_stats.frames_stats);
    uint64_t now = os_time_get_nano(); /* ns */
    auto elapsed = now - sw_stats.last_fps_update; /* ns */
@@ -255,7 +255,7 @@ void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, struct ove
    sw_stats.n_frames_since_update++;
 }
 
-void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID){
+void update_hud_info(struct swapchain_stats& sw_stats, const struct overlay_params& params, uint32_t vendorID){
    uint64_t now = os_time_get_nano(); /* ns */
    uint64_t frametime_ns = now - sw_stats.last_present_time;
    update_hud_info_with_frametime(sw_stats, params, vendorID, frametime_ns);
@@ -275,7 +275,7 @@ float get_time_stat(void *_data, int _idx)
    return data->frames_stats[idx].stats[data->stat_selector] / data->time_dividor;
 }
 
-void position_layer(struct swapchain_stats& data, struct overlay_params& params, const ImVec2& window_size)
+void position_layer(struct swapchain_stats& data, const struct overlay_params& params, const ImVec2& window_size)
 {
    unsigned width = ImGui::GetIO().DisplaySize.x;
    unsigned height = ImGui::GetIO().DisplaySize.y;
@@ -363,7 +363,7 @@ float get_ticker_limited_pos(float pos, float tw, float& left_limit, float& righ
 }
 
 #ifdef HAVE_DBUS
-void render_mpris_metadata(struct overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing)
+void render_mpris_metadata(const struct overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing)
 {
    if (meta.meta.valid) {
       auto color = ImGui::ColorConvertU32ToFloat4(params.media_player_color);
@@ -426,7 +426,7 @@ void render_mpris_metadata(struct overlay_params& params, mutexed_metadata& meta
 }
 #endif
 
-static void render_benchmark(swapchain_stats& data, struct overlay_params& params, const ImVec2& window_size, unsigned height, Clock::time_point now){
+static void render_benchmark(swapchain_stats& data, const struct overlay_params& params, const ImVec2& window_size, unsigned height, Clock::time_point now){
    // TODO, FIX LOG_DURATION FOR BENCHMARK
    int benchHeight = (2 + benchmark.percentile_data.size()) * real_font_size.x + 10.0f + 58;
    ImGui::SetNextWindowSize(ImVec2(window_size.x, benchHeight), ImGuiCond_Always);

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -519,7 +519,7 @@ ImVec4 change_on_load_temp(LOAD_DATA& data, unsigned current)
 
 void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, bool is_vulkan)
 {
-   HUDElements.sw_stats = &data; HUDElements.params = &params;
+   HUDElements.sw_stats = &data;
    HUDElements.is_vulkan = is_vulkan;
    ImGui::GetIO().FontGlobalScale = params.font_scale;
    static float ralign_width = 0, old_scale = 0;

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -426,7 +426,7 @@ void render_mpris_metadata(struct overlay_params& params, mutexed_metadata& meta
 }
 #endif
 
-void render_benchmark(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, unsigned height, Clock::time_point now){
+static void render_benchmark(swapchain_stats& data, struct overlay_params& params, const ImVec2& window_size, unsigned height, Clock::time_point now){
    // TODO, FIX LOG_DURATION FOR BENCHMARK
    int benchHeight = (2 + benchmark.percentile_data.size()) * real_font_size.x + 10.0f + 58;
    ImGui::SetNextWindowSize(ImVec2(window_size.x, benchHeight), ImGuiCond_Always);

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -275,7 +275,7 @@ float get_time_stat(void *_data, int _idx)
    return data->frames_stats[idx].stats[data->stat_selector] / data->time_dividor;
 }
 
-void position_layer(struct swapchain_stats& data, struct overlay_params& params, ImVec2 window_size)
+void position_layer(struct swapchain_stats& data, struct overlay_params& params, const ImVec2& window_size)
 {
    unsigned width = ImGui::GetIO().DisplaySize.x;
    unsigned height = ImGui::GetIO().DisplaySize.y;

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -162,7 +162,6 @@ void check_keybinds(overlay_params& params, uint32_t vendorID);
 void init_system_info(void);
 void FpsLimiter(struct fps_limit& stats);
 std::string get_device_name(int32_t vendorID, int32_t deviceID);
-void calculate_benchmark_data(overlay_params* params);
 void create_fonts(const overlay_params& params, ImFont*& small_font, ImFont*& text_font);
 void right_aligned_text(ImVec4& col, float off_x, const char *fmt, ...);
 void center_text(const std::string& text);

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -151,11 +151,11 @@ extern double min_frametime, max_frametime;
 extern bool steam_focused;
 
 void init_spdlog();
-void position_layer(struct swapchain_stats& data, struct overlay_params& params, const ImVec2& window_size);
+void position_layer(struct swapchain_stats& data, const struct overlay_params& params, const ImVec2& window_size);
 void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, bool is_vulkan);
-void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID);
-void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID, uint64_t frametime_ns);
-void update_hw_info(struct overlay_params& params, uint32_t vendorID);
+void update_hud_info(struct swapchain_stats& sw_stats, const struct overlay_params& params, uint32_t vendorID);
+void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, const struct overlay_params& params, uint32_t vendorID, uint64_t frametime_ns);
+void update_hw_info(const struct overlay_params& params, uint32_t vendorID);
 void init_gpu_stats(uint32_t& vendorID, uint32_t reported_deviceID, overlay_params& params);
 void init_cpu_stats(overlay_params& params);
 void check_keybinds(overlay_params& params, uint32_t vendorID);
@@ -170,9 +170,9 @@ float get_time_stat(void *_data, int _idx);
 void stop_hw_updater();
 extern void control_client_check(struct device_data *device_data);
 extern void process_control_socket(struct instance_data *instance_data);
-   #ifdef HAVE_DBUS
-   void render_mpris_metadata(overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing);
-   #endif
+#ifdef HAVE_DBUS
+void render_mpris_metadata(const overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing);
 #endif
+#endif //MANGOAPP_LAYER
 
 #endif //MANGOHUD_OVERLAY_H

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -151,7 +151,7 @@ extern double min_frametime, max_frametime;
 extern bool steam_focused;
 
 void init_spdlog();
-void position_layer(struct swapchain_stats& data, struct overlay_params& params, ImVec2 window_size);
+void position_layer(struct swapchain_stats& data, struct overlay_params& params, const ImVec2& window_size);
 void render_imgui(swapchain_stats& data, struct overlay_params& params, ImVec2& window_size, bool is_vulkan);
 void update_hud_info(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID);
 void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, struct overlay_params& params, uint32_t vendorID, uint64_t frametime_ns);

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -499,7 +499,7 @@ const char *overlay_param_names[] = {
 #undef OVERLAY_PARAM_CUSTOM
 };
 
-void
+static void
 parse_overlay_env(struct overlay_params *params,
                   const char *env)
 {

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -794,6 +794,9 @@ parse_overlay_config(struct overlay_params *params,
 
    auto real_size = params->font_size * params->font_scale;
    real_font_size = ImVec2(real_size, real_size / 2);
+#ifdef MANGOAPP
+   params->log_interval = 0;
+#endif
    HUDElements.params = params;
    if (params->enabled[OVERLAY_PARAM_ENABLED_legacy_layout]){
         HUDElements.legacy_elements();

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -256,8 +256,6 @@ struct overlay_params {
 
 const extern char *overlay_param_names[];
 
-void parse_overlay_env(struct overlay_params *params,
-                       const char *env);
 void parse_overlay_config(struct overlay_params *params,
                        const char *env);
 


### PR DESCRIPTION
While playing around with the mangoapp I've noticed a couple of serious quirks:
 - we destroy the glfw window, while checking the destroyed object - it's a miracle we don't crash
 - to prevent visual glitches on window resizes, we render 3x times

The former was trivial to resolve - just iconify/restore the window.

Fixing the resize/render was not so straight-forward, since we seemingly leak/duplicate a lot of state across components and modify it in fairly convoluted manner.
So this is not resolved, yet things should be tad easier to reason - with API cleaned up and immutable state annotated as such.

The series build on top of my earlier MR - https://github.com/flightlessmango/MangoHud/pull/703