### PR TITLE
add functions to check if a process is running

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -83,6 +83,7 @@ if is_unixy
     'battery.cpp',
     'control.cpp',
     'gamepad.cpp',
+    'process.cpp',
   )
 
   opengl_files = files(

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <string.h>
+#include "process.h"
+
+bool process_running(const char *process_name) {
+	return process_id(process_name) != -1;
+}
+
+int process_id(const char *process_name) {
+	int pid = -1;
+
+	DIR *proc_dir = opendir("/proc");
+	if (proc_dir == NULL)
+		return pid;
+
+	struct dirent *files;
+	while ((files = readdir(proc_dir)) != NULL) {
+		char process_filename[128];
+		char process_cmd[256];
+
+		snprintf(process_filename, 127, "/proc/%s/cmdline", files->d_name);
+		FILE *process_file = fopen(process_filename, "r");
+		if (process_file == NULL)
+			continue;
+
+		fgets(process_cmd, 255, process_file);
+		fclose(process_file);
+		if (strcasestr(process_cmd, process_name) != NULL) {
+			pid = atoi(files->d_name);
+			break;
+		}
+	}
+
+	return pid;
+}

--- a/src/process.h
+++ b/src/process.h
@@ -1,0 +1,21 @@
+#pragma once
+#ifndef MANGOHUD_PROCESS_H
+#define MANGOHUD_PROCESS_H
+
+/**
+ * Checks if a process whose command string contains process_name is running
+ * 
+ * @param process_name Name of the process
+ * @return true if process is running, otherwise false
+ */
+bool process_running(const char *process_name);
+
+/**
+ * Returns the PID of the first process whose command string contains process_name
+ * 
+ * @param process_name Name of the process
+ * @return PID of the process or -1 if not found
+ */
+int process_id(const char *process_name);
+
+#endif // MANGOHUD_PROCESS_H


### PR DESCRIPTION
Now `bool process_running(const char *process_name)` and `int process_id(const char *process_name)` can be used to check if a process containing a certain string in the process' command is running.
This could for example be used to determine if OBS is running and show the user an indicator.

Please not that I am not accustomed to using meson, therefore I might have added the file's name to the wrong place. It still builds and works however.