### PR TITLE
Updated Arch-based distributions download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you do not wish to compile anything, simply download the file under [Releases
 
 #### Arch-based distributions
 
-If you are using an Arch-based distribution, install [`mangohud`](https://aur.archlinux.org/packages/mangohud/) and [`lib32-mangohud`](https://aur.archlinux.org/packages/lib32-mangohud/) with your favourite AUR helper. [`mangohud-git`](https://aur.archlinux.org/packages/mangohud-git/) and [`lib32-mangohud-git`](https://aur.archlinux.org/packages/lib32-mangohud-git/) are also available on the AUR if you want the up-to-date version of MangoHud.
+If you are using an Arch-based distribution, install [`mangohud-x11`](https://aur.archlinux.org/packages/mangohud-x11) and [`lib32-mangohud-x11`](https://aur.archlinux.org/packages/lib32-mangohud-x11) with your favourite AUR helper. [`mangohud-git`](https://aur.archlinux.org/packages/mangohud-git/) and [`lib32-mangohud-git`](https://aur.archlinux.org/packages/lib32-mangohud-git/) are also available on the AUR if you want the up-to-date version of MangoHud.
 
 If you are building it by yourself, you need to enable multilib repository, by editing pacman config:
 


### PR DESCRIPTION
The AUR packages [`mangohud`](https://aur.archlinux.org/packages/mangohud) and [`lib32-mangohud`](https://aur.archlinux.org/packages/lib32-mangohud)  do no exist anymore.

Instead there are several different packages now e.g.: [`mangohud-x11`](https://aur.archlinux.org/packages/mangohud-x11), [`mangohud-common-x11`](https://aur.archlinux.org/packages/mangohud-common-x11) and [`lib32-mangohud-x11`](https://aur.archlinux.org/packages/lib32-mangohud-x11).

I linked to the `mangohud-x11` package since it's the most popular and probably the most commonly needed one.

But there are [several different versions in the AUR](https://aur.archlinux.org/packages?O=0&SeB=nd&K=mangohud&outdated=&SB=p&SO=d&PP=50&submit=Go) like [`mangohud-wayland`](https://aur.archlinux.org/packages/mangohud-wayland) which could also be mentioned in the `README.md` _Arch-based distributions_ section.


