### PR TITLE
Update Vulkan layer api version to 1.3.211

### DIFF
--- a/src/app/layer.json.in
+++ b/src/app/layer.json.in
@@ -3,7 +3,7 @@
     "layer" : {
       "name": "VK_LAYER_MANGOAPP_overlay",
       "type": "GLOBAL",
-      "api_version": "1.2.135",
+      "api_version": "1.3.211",
       "library_path": "@ld_libdir_mangohud@libMangoApp.so",
       "implementation_version": "1",
       "description": "Mangoapp Layer",

--- a/src/mangohud.json.in
+++ b/src/mangohud.json.in
@@ -3,7 +3,7 @@
     "layer" : {
       "name": "VK_LAYER_@PROJECT_NAME@_overlay",
       "type": "GLOBAL",
-      "api_version": "1.2.135",
+      "api_version": "1.3.211",
       "library_path": "@ld_libdir_mangohud@libMangoHud.so",
       "implementation_version": "1",
       "description": "Vulkan Hud Overlay",


### PR DESCRIPTION
Hi everyone! While trying to run a Vulkan 1.3 application with Mangohud, it does not initialise and no debug output is written to the screen. I fixed the issue by bumping up the Vulkan layer API version in my local configuration.

In the commit, I applied the same modifications I did to my local files.