### PR TITLE
Install MangoApp layer into libdir_mangohud

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -282,6 +282,7 @@ if get_option('mangoapp_layer')
     gnu_symbol_visibility : 'hidden',
     include_directories : [inc_common],
     link_args : link_args,
+    install_dir : libdir_mangohud,
     install : true
   )
 endif


### PR DESCRIPTION
This makes the installation path adapt correctly to the value of
the append_libdir_mangohud option, which defaults to putting it in a
subdirectory ${libdir}/mangohud. Without this, the path in the JSON
manifest (which does respect append_libdir_mangohud) is inconsistent
with the actual location of the library.

Resolves: https://github.com/flightlessmango/MangoHud/issues/795

---

Patch from @stephanlachnit, via the Debian packaging; commit message added by @smcv.