### PR TITLE
meson.build: allow system nlohmann_json to satisfy dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -276,8 +276,7 @@ endif
 
 if get_option('mangoapp') or get_option('mangoapp_layer')
   glfw3_dep = dependency('glfw3')
-  json_sp = subproject('nlohmann_json')
-  json_dep = json_sp.get_variable('nlohmann_json_dep')
+  json_dep = dependency('nlohmann_json')
 endif
 
 subdir('src')


### PR DESCRIPTION
Meson can now automatically use wraps with `dependency` when a `[provide]` section is available (which is the case for all wraps from wrapdb).