### PR TITLE
Build mangoapp and mangohudctl for any CPU architecture

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -238,14 +238,15 @@ imgui_options = [
 sizeof_ptr = cc.sizeof('void*')
 if sizeof_ptr == 8
   pre_args += '-DMANGOHUD_ARCH="64bit"'
-  if get_option('mangoapp')
-    imgui_options += [
-      'opengl=enabled',
-      'glfw=enabled',
-    ]
-  endif
 elif sizeof_ptr == 4
   pre_args += '-DMANGOHUD_ARCH="32bit"'
+endif
+
+if get_option('mangoapp')
+  imgui_options += [
+    'opengl=enabled',
+    'glfw=enabled',
+  ]
 endif
 
 dearimgui_sp = subproject('imgui', default_options: imgui_options)

--- a/src/meson.build
+++ b/src/meson.build
@@ -215,7 +215,7 @@ if is_unixy
   )
 endif
 
-if get_option('mangoapp') and sizeof_ptr == 8
+if get_option('mangoapp')
   pre_args += '-DIMGUI_IMPL_OPENGL_LOADER_GLEW'
   pre_args += '-DMANGOAPP'
   mangoapp = executable(
@@ -254,7 +254,7 @@ if get_option('mangoapp') and sizeof_ptr == 8
   )
 endif
 
-if get_option('mangohudctl') and sizeof_ptr == 8
+if get_option('mangohudctl')
 mangoapp = executable(
   'mangohudctl',
   files('app/control.cpp'),


### PR DESCRIPTION
On 32-bit-only machines, building these for the 32-bit architecture makes sense. This is e.g. the case in Debian, where we have 32bit architectures.

Since the options to build them are off by default, I see is no reason to disable them explicitly.

Original patch by @smcv.
