### PR TITLE
add logging for when the OpenGL context fails to initialize

### DIFF
--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -120,7 +120,8 @@ void imgui_create(void *ctx)
     imgui_init();
     inited = true;
 
-    gladLoadGL();
+    if (!gladLoadGL())
+        spdlog::error("Failed to initialize OpenGL context, crash incoming");
 
     GetOpenGLVersion(sw_stats.version_gl.major,
         sw_stats.version_gl.minor,


### PR DESCRIPTION
I just had to do a whole lot of asm debugging to figure out why MangoHud was segfaulting when invoking it on Wezterm on NixOS (it was because the OpenGL context wasn't initializing). This should hopefully save others some pain when dealing with similar issues.