### PR TITLE
changing Logger class from struct pointer to 3 variables

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -144,7 +144,9 @@ string get_log_suffix(){
 }
 
 Logger::Logger(const overlay_params* in_params)
-  : m_params(in_params),
+  : output_folder(in_params->output_folder),
+	log_interval(in_params->log_interval),
+	log_duration(in_params->log_duration),
     m_logging_on(false),
     m_values_valid(false)
 {
@@ -157,7 +159,7 @@ void Logger::start_logging() {
   m_values_valid = false;
   m_logging_on = true;
   m_log_start = Clock::now();
-  if(m_params->log_interval != 0){
+  if(log_interval != 0){
     std::thread(&Logger::logging, this).detach();
   }
 }
@@ -169,12 +171,11 @@ void Logger::stop_logging() {
 
   calculate_benchmark_data();
 
-  if(!m_params->output_folder.empty()) {
+  if(!output_folder.empty()) {
     std::string program = get_wine_exe_name();
     if (program.empty())
         program = get_program_name();
-
-    m_log_files.emplace_back(HUDElements.params->output_folder + "/" + program + "_" + get_log_suffix());
+    m_log_files.emplace_back(output_folder + "/" + program + "_" + get_log_suffix());
     std::thread writefile (writeFile, m_log_files.back());
     std::thread writesummary (writeSummary, m_log_files.back());
     writefile.join();
@@ -194,7 +195,7 @@ void Logger::logging(){
   wait_until_data_valid();
   while (is_active()){
       try_log();
-      this_thread::sleep_for(chrono::milliseconds(m_params->log_interval));
+      this_thread::sleep_for(std::chrono::milliseconds(log_interval));
   }
 }
 
@@ -209,7 +210,7 @@ void Logger::try_log() {
   currentLogData.frametime = frametime;
   m_log_array.push_back(currentLogData);
 
-  if(m_params->log_duration && (elapsedLog >= std::chrono::seconds(m_params->log_duration))){
+  if(log_duration && (elapsedLog >= std::chrono::seconds(log_duration))){
     stop_logging();
   }
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -53,7 +53,9 @@ public:
   void upload_last_log();
   void upload_last_logs();
   void calculate_benchmark_data();
-  const overlay_params* m_params;
+  const std::string output_folder;
+  const int64_t log_interval;
+  const int64_t log_duration;
 
 private:
   std::vector<logData> m_log_array;

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -835,7 +835,6 @@ parse_overlay_config(struct overlay_params *params,
    else
       HUDElements.text_column = 1;
 
-   if(logger && logger->m_params == nullptr) logger.reset();
    if(!logger) logger = std::make_unique<Logger>(HUDElements.params);
    if(params->autostart_log && !logger->is_active())
       std::thread(autostart_log, params->autostart_log).detach();

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -217,7 +217,7 @@ struct overlay_params {
    int gl_bind_framebuffer {-1};
    enum gl_size_query gl_size_query {GL_SIZE_DRAWABLE};
    bool gl_dont_flip {false};
-   uint64_t log_duration;
+   int64_t log_duration, log_interval;
    unsigned cpu_color, gpu_color, vram_color, ram_color, engine_color, io_color, frametime_color, background_color, text_color, wine_color, battery_color;
    std::vector<unsigned> gpu_load_color;
    std::vector<unsigned> cpu_load_color;
@@ -244,7 +244,7 @@ struct overlay_params {
    std::string media_player_name;
    std::string cpu_text, gpu_text;
    std::vector<std::string> blacklist;
-   unsigned log_interval, autostart_log;
+   unsigned autostart_log;
    std::vector<std::string> media_player_format;
    std::vector<std::string> benchmark_percentiles;
    std::string font_file, font_file_text;


### PR DESCRIPTION
On my PC after compiling mangohud, logging with keys showed random behaviour.
Sometimes NaN values, sometimes no output file. sometimes same values for all percentiles and average, but then only one line in output file.

Tracking down the issue, it seemed that on my machine, at least running Gothic1 with mods (32 bit), that the pointer to the overlay param struct given to the logger class does not seem to keep its values during the whole runtime.
Probably due to the struct behind it losing its scope.

Thus instead of passing the pointer to the whole struct I changed passing the 3 necessary values only and storing them directly instead of just a pointer to the struct.