### PR TITLE
Updated PKGBUILD to honor the user set compiler using CC and CXX environment variables.

### DIFF
--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -53,8 +53,8 @@ build() {
     ${_build_args} -Dmangoapp=true -Dmangohudctl=true
 
   ninja -C build64
-  export CC="gcc -m32"
-  export CXX="g++ -m32"
+  export CC="${CC:-gcc} -m32"
+  export CXX="${CXX:-g++} -m32"
   export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig:${PKG_CONFIG_PATH_32}"
   export LLVM_CONFIG="/usr/bin/llvm-config32"
 


### PR DESCRIPTION
Update the PKGBUILD file to check CC and CXX variables.

Then add "-m32" to variables if those are set, and fallback to GCC as the compiler if not.