### PR TITLE
Remove the Ubuntu PPA from the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,18 +174,6 @@ If you are using Solus, to install [MangoHud](https://dev.getsol.us/source/mango
 sudo eopkg it mangohud
 ```
 
-#### Ubuntu
-
-User of Ubuntu 20.04 or newer can install a NVML enabled version of MangoHud from the [MangoHud PPA](https://launchpad.net/~flexiondotorg/+archive/ubuntu/mangohud) maintained by [Martin Wimpress](https://github.com/flexiondotorg/mangohud-nvml-debian):
-
-````
-sudo add-apt-repository ppa:flexiondotorg/mangohud
-sudo apt update
-sudo apt install mangohud
-````
-
-**NOTE: Currently PPA has no 32-bit libraries**
-
 #### openSUSE
 
 If you run openSUSE Leap or Tumbleweed you can get Mangohud from the official repositories.


### PR DESCRIPTION
The Ubuntu PPA is extremely outdated, it's time to remove it.