### PR TITLE
Add support for it8603 sensor

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -442,6 +442,9 @@ bool CPUStats::GetCpuFile() {
         } else if (name == "atk0110") {
             find_temp_input(path, input, "CPU Temperature");
             break;
+        } else if (name == "it8603") {
+            find_temp_input(path, input, "temp1");
+            break;
         } else {
             path.clear();
         }


### PR DESCRIPTION
On some AMD CPUs (especially X4 860K) `k10temp` module gives wrong CPU tempetrature [(check chapter 7.60.1 on page 164 to learn why)](http://blog.foool.net/wp-content/uploads/linuxdocs/hwmon.pdf), however you can use `it87` kernel module to get the right temperature value. I've implemented it's support so now the CPU temperature readout works just fine.

Would like to see this merged, thanks!

![image](https://user-images.githubusercontent.com/32103950/189399777-82c6e4d9-a4dd-477d-95b4-735be5033ec3.png)
