### PR TITLE
fix: Look for NAVI in device name for AMD GPUs

### DIFF
--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -131,7 +131,8 @@ void imgui_create(void *ctx)
     SPDLOG_DEBUG("deviceName: {}", deviceName);
     sw_stats.deviceName = deviceName;
     if (deviceName.find("Radeon") != std::string::npos
-    || deviceName.find("AMD") != std::string::npos){
+    || deviceName.find("AMD") != std::string::npos
+    || deviceName.find("NAVI") != std::string::npos) {
         vendorID = 0x1002;
     } else {
         vendorID = 0x10de;


### PR DESCRIPTION
## Why

Starting with Mesa 22.2, AMD NAVI GPUs (like the AMD RX 6700, which I own), have started reporting their device name as `NAVI{VERSION}`, without the string AMD or Radeon. Here's my output of `glxinfo`:

```sh
~ glxinfo | grep "OpenGL"
OpenGL vendor string: AMD
OpenGL renderer string: NAVI22 (navi22, LLVM 14.0.6, DRM 3.48, 6.0.1-arch2-1)
OpenGL core profile version string: 4.6 (Core Profile) Mesa 22.2.1
OpenGL core profile shading language version string: 4.60
OpenGL core profile context flags: (none)
OpenGL core profile profile mask: core profile
OpenGL core profile extensions:
OpenGL version string: 4.6 (Compatibility Profile) Mesa 22.2.1
OpenGL shading language version string: 4.60
OpenGL context flags: (none)
OpenGL profile mask: compatibility profile
OpenGL extensions:
OpenGL ES profile version string: OpenGL ES 3.2 Mesa 22.2.1
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.20
OpenGL ES profile extensions:
```

This causes these cards to be assumed, internally, as Nvidia vendor cards, which breaks GPU stats for OpenGL applications (see screenshot below).

![2022-10-14-220832_screenshot](https://user-images.githubusercontent.com/8539174/195997487-5f32d261-1db5-4926-8b66-c19a9357fe1b.png)

## Solution

I've added a check for `NAVI` in the OpenGL renderer string. This makes MangoHud able to recognize NAVI cards as AMD, and GPU stats work again. (see proof below)

![2022-10-15-172934_screenshot](https://user-images.githubusercontent.com/8539174/195997617-19de0194-9eaa-4190-b612-4c0940b40b8c.png)

I'm not sure why we're checking for specific strings in `OpenGL renderer string` to figure out the vendor, instead of using `OpenGL vendor string`, so I'm fixing it with another check instead of re-writing to use the vendor string directly, as it's possible that would break some scenarios.