### PR TITLE
Lower the minimum required version of meson to v0.54.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('MangoHud',
   ['c', 'cpp'],
-  version : 'v0.6.8',
+  version : 'v0.54.0',
   license : 'MIT',
   meson_version: '>=0.60.0',
   default_options : ['buildtype=release', 'c_std=c99', 'cpp_std=c++14', 'warning_level=2']


### PR DESCRIPTION
Unless strictly necessary, the minimum required version of meson should always be set to the oldest version possible. This is done to ensure compatibility with systems where upgrading meson is not possible.

For example, on specific branches of Flatpak SDKs: https://github.com/flathub/org.freedesktop.Platform.VulkanLayer.MangoHud/pull/19#issuecomment-1291596497