### PR TITLE
Add missing include to tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -302,7 +302,8 @@ if get_option('tests').enabled()
       cmocka_dep,
       spdlog_dep,
       dearimgui_dep
-    ])
+    ],
+    include_directories: inc_common)
 
   test('test amdgpu', e, workdir : meson.project_source_root() + '/tests')
 


### PR DESCRIPTION
Mangohud build failed when tests feature is enabled due to missing filesystem.h

    FAILED: amdgpu.p/src_file_utils.cpp.o 
    c++ -Iamdgpu.p -I. -I.. -Isubprojects/cmocka -I../subprojects/cmocka -I../subprojects/cmocka/include -I../subprojects/spdlog-1.8.5/include -Isubprojects/imgui-1.81 -I../subprojects/imgui-1.81 -I../subprojects/imgui-1.81/backends -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++14 -O3 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS '-DPACKAGE_VERSION="v0.6.8"' -DNDEBUG -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -D_GNU_SOURCE -DHAVE_PTHREAD -DUSE_GCC_ATOMIC_BUILTINS -DHAVE_TIMESPEC_GET -DHAVE___BUILTIN_BSWAP32 -DHAVE___BUILTIN_BSWAP64 -DHAVE___BUILTIN_CLZ -DHAVE___BUILTIN_CLZLL -DHAVE___BUILTIN_CTZ -DHAVE___BUILTIN_EXPECT -DHAVE___BUILTIN_FFS -DHAVE___BUILTIN_FFSLL -DHAVE___BUILTIN_POPCOUNT -DHAVE___BUILTIN_POPCOUNTLL -DHAVE___BUILTIN_UNREACHABLE -Werror=return-type -Wno-unused-parameter -fno-math-errno -fno-trapping-math -Wno-non-virtual-dtor -Wno-missing-field-initializers -Wno-format-truncation -pthread -DSPDLOG_COMPILED_LIB -MD -MQ amdgpu.p/src_file_utils.cpp.o -MF amdgpu.p/src_file_utils.cpp.o.d -o amdgpu.p/src_file_utils.cpp.o -c ../src/file_utils.cpp
    ../src/file_utils.cpp:12:10: fatal error: filesystem.h: No such file or directory
        12 | #include <filesystem.h>
          |          ^~~~~~~~~~~~~~
    compilation terminated.

This commit add include directory when building executable amdgpu.