### PR TITLE
Blacklist GOG Galaxy 2.0

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -40,6 +40,7 @@ static  std::vector<std::string> blacklist {
     "EALauncher.exe",
     "StarCitizen_Launcher.exe",
     "InsurgencyEAC.exe",
+    "GalaxyClient.exe",
 };
 
 


### PR DESCRIPTION
FPS counter appears in the client, it probably shouldn't.
![Screenshot_20230113_152020](https://user-images.githubusercontent.com/65789901/212436281-256f4fa0-a0e5-49cc-b308-4df9e80c4150.png)
