### PR TITLE
Add new margin configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `no_small_font`                    | Use primary font size for smaller text like units                                     |
 | `width=`<br>`height=`              | Customizeable hud dimensions (in pixels)                                              |
 | `position=`                        | Location of the hud: `top-left` (default), `top-right`, `middle-left`, `middle-right`, `bottom-left`, `bottom-right`, `top-center` |
+| `margin`                           | Hud margin, in pixels (default=10)                                                    |
 | `offset_x` `offset_y`              | Hud position offsets                                                                  |
 | `no_display`                       | Hide the hud by default                                                               |
 | `toggle_hud=`<br>`toggle_logging=` | Modifiable toggle hotkeys. Default are `Shift_R+F12` and `Shift_L+F2`, respectively.      |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -153,6 +153,9 @@ frame_timing
 ### Disable / hide the hud by default
 # no_display
 
+### Hud margin
+# margin=10
+
 ### Hud position offset
 # offset_x=
 # offset_y=

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -324,39 +324,36 @@ void position_layer(struct swapchain_stats& data, const struct overlay_params& p
 {
    unsigned width = ImGui::GetIO().DisplaySize.x;
    unsigned height = ImGui::GetIO().DisplaySize.y;
-   float margin = 10.0f;
-   if (params.offset_x > 0 || params.offset_y > 0 || params.enabled[OVERLAY_PARAM_ENABLED_hud_no_margin])
-      margin = 0.0f;
 
    ImGui::SetNextWindowBgAlpha(params.background_alpha);
    ImGui::SetNextWindowSize(window_size, ImGuiCond_Always);
    switch (params.position) {
    case LAYER_POSITION_TOP_LEFT:
-      data.main_window_pos = ImVec2(margin + params.offset_x, margin + params.offset_y);
+      data.main_window_pos = ImVec2(params.margin + params.offset_x, params.margin + params.offset_y);
       ImGui::SetNextWindowPos(data.main_window_pos, ImGuiCond_Always);
       break;
    case LAYER_POSITION_TOP_RIGHT:
-      data.main_window_pos = ImVec2(width - window_size.x - margin + params.offset_x, margin + params.offset_y);
+      data.main_window_pos = ImVec2(width - window_size.x - params.margin + params.offset_x, params.margin + params.offset_y);
       ImGui::SetNextWindowPos(data.main_window_pos, ImGuiCond_Always);
       break;
    case LAYER_POSITION_MIDDLE_LEFT:
-      data.main_window_pos = ImVec2(margin + params.offset_x, height / 2 - window_size.y / 2 - margin + params.offset_y);
+      data.main_window_pos = ImVec2(params.margin + params.offset_x, height / 2 - window_size.y / 2 - params.margin + params.offset_y);
       ImGui::SetNextWindowPos(data.main_window_pos, ImGuiCond_Always);
       break;
    case LAYER_POSITION_MIDDLE_RIGHT:
-      data.main_window_pos = ImVec2(width - window_size.x - margin + params.offset_x, height / 2 - window_size.y / 2 - margin + params.offset_y);
+      data.main_window_pos = ImVec2(width - window_size.x - params.margin + params.offset_x, height / 2 - window_size.y / 2 - params.margin + params.offset_y);
       ImGui::SetNextWindowPos(data.main_window_pos, ImGuiCond_Always);
       break;
    case LAYER_POSITION_BOTTOM_LEFT:
-      data.main_window_pos = ImVec2(margin + params.offset_x, height - window_size.y - margin + params.offset_y);
+      data.main_window_pos = ImVec2(params.margin + params.offset_x, height - window_size.y - params.margin + params.offset_y);
       ImGui::SetNextWindowPos(data.main_window_pos, ImGuiCond_Always);
       break;
    case LAYER_POSITION_BOTTOM_RIGHT:
-      data.main_window_pos = ImVec2(width - window_size.x - margin + params.offset_x, height - window_size.y - margin + params.offset_y);
+      data.main_window_pos = ImVec2(width - window_size.x - params.margin + params.offset_x, height - window_size.y - params.margin + params.offset_y);
       ImGui::SetNextWindowPos(data.main_window_pos, ImGuiCond_Always);
       break;
    case LAYER_POSITION_TOP_CENTER:
-      data.main_window_pos = ImVec2((width / 2) - (window_size.x / 2), margin + params.offset_y);
+      data.main_window_pos = ImVec2((width / 2) - (window_size.x / 2), params.margin + params.offset_y);
       ImGui::SetNextWindowPos(data.main_window_pos, ImGuiCond_Always);
       break;
    case LAYER_POSITION_COUNT:

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -381,8 +381,9 @@ parse_gl_size_query(const char *str)
 #define parse_height(s) parse_unsigned(s)
 #define parse_vsync(s) parse_unsigned(s)
 #define parse_gl_vsync(s) parse_signed(s)
-#define parse_offset_x(s) parse_unsigned(s)
-#define parse_offset_y(s) parse_unsigned(s)
+#define parse_margin(s) parse_unsigned(s)
+#define parse_offset_x(s) parse_signed(s)
+#define parse_offset_y(s) parse_signed(s)
 #define parse_log_duration(s) parse_unsigned(s)
 #define parse_time_format(s) parse_str(s)
 #define parse_output_folder(s) parse_path(s)
@@ -539,7 +540,6 @@ parse_overlay_env(struct overlay_params *params,
          params->enabled[OVERLAY_PARAM_ENABLED_read_cfg] = read_cfg;
          params->enabled[OVERLAY_PARAM_ENABLED_fcat] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_horizontal] = 0;
-         params->enabled[OVERLAY_PARAM_ENABLED_hud_no_margin] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_log_versioning] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_hud_compact] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_exec_name] = 0;
@@ -602,6 +602,7 @@ parse_overlay_config(struct overlay_params *params,
    params->fps_limit = { 0 };
    params->vsync = -1;
    params->gl_vsync = -2;
+   params->margin = 10;
    params->offset_x = 0;
    params->offset_y = 0;
    params->background_alpha = 0.5;
@@ -691,7 +692,6 @@ parse_overlay_config(struct overlay_params *params,
          params->enabled[OVERLAY_PARAM_ENABLED_throttling_status] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_fcat] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_horizontal] = 0;
-         params->enabled[OVERLAY_PARAM_ENABLED_hud_no_margin] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_log_versioning] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_hud_compact] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_exec_name] = 0;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -86,7 +86,6 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(fcat)                          \
    OVERLAY_PARAM_BOOL(log_versioning)                \
    OVERLAY_PARAM_BOOL(horizontal)                    \
-   OVERLAY_PARAM_BOOL(hud_no_margin)                 \
    OVERLAY_PARAM_BOOL(hud_compact)                   \
    OVERLAY_PARAM_BOOL(exec_name)                     \
    OVERLAY_PARAM_CUSTOM(fps_sampling_period)         \
@@ -118,6 +117,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(reload_cfg)                  \
    OVERLAY_PARAM_CUSTOM(upload_log)                  \
    OVERLAY_PARAM_CUSTOM(upload_logs)                 \
+   OVERLAY_PARAM_CUSTOM(margin)                      \
    OVERLAY_PARAM_CUSTOM(offset_x)                    \
    OVERLAY_PARAM_CUSTOM(offset_y)                    \
    OVERLAY_PARAM_CUSTOM(background_alpha)            \
@@ -218,7 +218,7 @@ struct overlay_params {
    bool io_read, io_write, io_stats;
    unsigned width;
    unsigned height;
-   int offset_x, offset_y;
+   int margin, offset_x, offset_y;
    float round_corners;
    unsigned vsync;
    int gl_vsync;


### PR DESCRIPTION
Add a new configuration option to easily set the margin of the hud, instead of having to use negative values for `offset_x` and `offset_y` options.
Also fixes #888.