### PR TITLE
Logging: Switch to a different sleep function

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -254,7 +254,8 @@ void Logger::upload_last_logs() {
 }
 
 void autostart_log(int sleep) {
-  os_time_sleep(sleep * 1000000);
+  // os_time_sleep() causes freezes with zink + autologging :frog_donut:
+  this_thread::sleep_for(chrono::seconds(sleep));
   logger->start_logging();
 }
 


### PR DESCRIPTION
This fixes a freeze with zink when automatic logging is enabled

I didn't test this on Windows, so please report any issues there