### PR TITLE
Fix for AMD Ryzen 7000 CPU when using the iGPU

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -89,16 +89,16 @@ void amdgpu_get_instant_metrics(struct amdgpu_common_metrics *metrics) {
 		metrics->average_gfx_power_w = amdgpu_metrics->average_gfx_power / 1000.f;
 
 		if( IS_VALID_METRIC(amdgpu_metrics->average_cpu_power) && IS_VALID_METRIC(amdgpu_metrics->average_soc_power) ) {
-			// Use 'cpu power' + 'soc power' similar to 'get_cpu_power_k10temp' in 'cpu.cpp'
-			metrics->average_cpu_power_w = amdgpu_metrics->average_cpu_power / 1000.f + amdgpu_metrics->average_soc_power / 1000.f;
+            // prefered method
+            metrics->average_cpu_power_w = amdgpu_metrics->average_cpu_power / 1000.f;
 		} else if( IS_VALID_METRIC(amdgpu_metrics->average_core_power[0]) ) {
 			// fallback 1: sum of core power
 			metrics->average_cpu_power_w = 0;
 			for (unsigned i = 0; i < cpuStats.GetCPUData().size() / 2; i++)
 				metrics->average_cpu_power_w = metrics->average_cpu_power_w + amdgpu_metrics->average_core_power[i];
 		} else if( IS_VALID_METRIC(amdgpu_metrics->average_socket_power) && IS_VALID_METRIC(amdgpu_metrics->average_gfx_power) ) {
-			// fallback 2: estimate cpu power from total socket power
-			metrics->average_cpu_power_w = amdgpu_metrics->average_socket_power / 1000.f - amdgpu_metrics->average_gfx_power / 1000.f;
+            // fallback 2: estimate cpu power from total socket power
+            metrics->average_cpu_power_w = amdgpu_metrics->average_socket_power / 1000.f - amdgpu_metrics->average_gfx_power / 1000.f;
 		} else if( IS_VALID_METRIC(amdgpu_metrics->average_cpu_power) ) {
 			// fallback 3: Ignore 'soc power' if not available
 			metrics->average_cpu_power_w = amdgpu_metrics->average_cpu_power / 1000.f;

--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -96,59 +96,6 @@ struct gpu_metrics_v1_3 {
 	uint64_t			indep_throttle_status;
 };
 
-struct gpu_metrics_v2_2 {
-	struct metrics_table_header	common_header;
-
-	/* Temperature */
-	uint16_t			temperature_gfx; // gfx temperature on APUs
-	uint16_t			temperature_soc; // soc temperature on APUs
-	uint16_t			temperature_core[8]; // CPU core temperature on APUs
-	uint16_t			temperature_l3[2];
-
-	/* Utilization */
-	uint16_t			average_gfx_activity;
-	uint16_t			average_mm_activity; // UVD or VCN
-
-	/* Driver attached timestamp (in ns) */
-	uint64_t			system_clock_counter;
-
-	/* Power/Energy */
-	uint16_t			average_socket_power; // dGPU + APU power on A + A platform
-	uint16_t			average_cpu_power;
-	uint16_t			average_soc_power;
-	uint16_t			average_gfx_power;
-	uint16_t			average_core_power[8]; // CPU core power on APUs
-
-	/* Average clocks */
-	uint16_t			average_gfxclk_frequency;
-	uint16_t			average_socclk_frequency;
-	uint16_t			average_uclk_frequency;
-	uint16_t			average_fclk_frequency;
-	uint16_t			average_vclk_frequency;
-	uint16_t			average_dclk_frequency;
-
-	/* Current clocks */
-	uint16_t			current_gfxclk;
-	uint16_t			current_socclk;
-	uint16_t			current_uclk;
-	uint16_t			current_fclk;
-	uint16_t			current_vclk;
-	uint16_t			current_dclk;
-	uint16_t			current_coreclk[8]; // CPU core clocks
-	uint16_t			current_l3clk[2];
-
-	/* Throttle status (ASIC dependent) */
-	uint32_t			throttle_status;
-
-	/* Fans */
-	uint16_t			fan_pwm;
-
-	uint16_t			padding[3];
-
-	/* Throttle status (ASIC independent) */
-	uint64_t			indep_throttle_status;
-};
-
 struct gpu_metrics_v2_3 {
 	struct metrics_table_header	common_header;
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -246,19 +246,26 @@ bool CPUStats::UpdateCoreMhz() {
     return true;
 }
 
+bool CPUStats::ReadcpuTempFile(int& temp) {
+	if (!m_cpuTempFile)
+		return false;
+
+	rewind(m_cpuTempFile);
+	fflush(m_cpuTempFile);
+	bool ret = (fscanf(m_cpuTempFile, "%d", &temp) == 1);
+	temp = temp / 1000;
+
+	return ret;
+}
+
 bool CPUStats::UpdateCpuTemp() {
-    if (cpu_type == "APU"){
+	if (cpu_type == "APU"){
         m_cpuDataTotal.temp = gpu_info.apu_cpu_temp;
         return true;
     } else {
-        if (!m_cpuTempFile)
-            return false;
-
         int temp = 0;
-        rewind(m_cpuTempFile);
-        fflush(m_cpuTempFile);
-        bool ret = (fscanf(m_cpuTempFile, "%d", &temp) == 1);
-        m_cpuDataTotal.temp = temp / 1000;
+		bool ret = ReadcpuTempFile(temp);
+		m_cpuDataTotal.temp = temp;
 
         return ret;
     }

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -135,6 +135,7 @@ public:
    bool UpdateCoreMhz();
    bool UpdateCpuTemp();
    bool UpdateCpuPower();
+   bool ReadcpuTempFile(int& temp);
    bool GetCpuFile();
    bool InitCpuPowerData();
    double GetCPUPeriod() { return m_cpuPeriod; }


### PR DESCRIPTION
partly fixes the issue: #868

This fixes the values reported by MangoHud for AMD Ryzen 7000 CPUs when using the iGPU, so without a dedicated/discrete GPU.

When using a dGPU, all values except for `cpu_power` should already report the correct value.

For the `cpu_power` when using a AMD Ryzen APU + AMD Radeon dGPU, we might be able to read this value from the `gpu_metrics` file of the APU but this would require us to read two separate `gpu_metrics` files. Code for this is not included in this PR.