### PR TITLE
vulkan: fix implicit instantiation of 'std::basic_stringstream<char>'

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -34,6 +34,7 @@
 #include <list>
 #include <array>
 #include <iomanip>
+#include <sstream>
 #include <inttypes.h>
 #include <spdlog/spdlog.h>
 #include <imgui.h>


### PR DESCRIPTION
Add a missing include to fix the following build error seen with clang 15.0.7:

```
../MangoHud-0.6.8/src/vulkan.cpp:1523:22: error: implicit instantiation of undefined template 'std::basic_stringstream<char>'
   std::stringstream ss;
                     ^
/usr/include/c++/v1/iosfwd:146:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_stringstream;
```