### PR TITLE
blacklist: add SteamVR's vrcompositor

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -28,6 +28,7 @@ static  std::vector<std::string> blacklist {
     "OriginThinSetupInternal.exe",
     "steam",
     "steamwebhelper",
+    "vrcompositor",
     "gldriverquery",
     "vulkandriverquery",
     "Steam.exe",


### PR DESCRIPTION
Limiting frame rate in vrcompositor has catastrohpic consequences and it's not something the user will ever see the HUD on. Every SteamVR user with a global frame rate limit has to explicitly blacklist vrcompositor, so it's better to have this upstream.