### PR TITLE
Add "FPS limit method" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `font_size=`                       | Customizeable font size (default=24)                                                  |
 | `font_size_text=`                  | Customizeable font size for other text like media metadata (default=24)               |
 | `fps_limit`                        | Limit the apps framerate. Comma-separated list of one or more FPS values. `0` means unlimited. |
+| `fps_limit_method`                 | If FPS limiter should wait before or after presenting a frame. Choose `late` (default) for the lowest latency or `early` for the smoothest frametimes. |
 | `fps_only`                         | Show FPS only. ***Not meant to be used with other display params***                   |
 | `frame_count`                      | Display frame count                                                                   |
 | `frametime`                        | Display frametime next to FPS text                                                    |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -8,6 +8,9 @@
 ### Limit the application FPS. Comma-separated list of one or more FPS values (e.g. 0,30,60). 0 means unlimited (unless VSynced)
 # fps_limit=
 
+### early = wait before present, late = wait after present
+# fps_limit_method=
+
 ### VSync [0-3] 0 = adaptive; 1 = off; 2 = mailbox; 3 = on
 # vsync=
 

--- a/src/gl/inject_egl.cpp
+++ b/src/gl/inject_egl.cpp
@@ -61,14 +61,25 @@ EXPORT_C_(unsigned int) eglSwapBuffers( void* dpy, void* surf)
             imgui_render(width, height);
 
         using namespace std::chrono_literals;
-        if (fps_limit_stats.targetFrameTime > 0s){
+        if (fps_limit_stats.targetFrameTime > 0s && fps_limit_stats.method == FPS_LIMIT_METHOD_EARLY){
             fps_limit_stats.frameStart = Clock::now();
             FpsLimiter(fps_limit_stats);
             fps_limit_stats.frameEnd = Clock::now();
         }
     }
 
-    return pfn_eglSwapBuffers(dpy, surf);
+    int res = pfn_eglSwapBuffers(dpy, surf);
+
+    if (!is_blacklisted()) {
+        using namespace std::chrono_literals;
+        if (fps_limit_stats.targetFrameTime > 0s && fps_limit_stats.method == FPS_LIMIT_METHOD_LATE){
+            fps_limit_stats.frameStart = Clock::now();
+            FpsLimiter(fps_limit_stats);
+            fps_limit_stats.frameEnd = Clock::now();
+        }
+    }
+
+    return res;
 }
 
 struct func_ptr {

--- a/src/gl/inject_glx.cpp
+++ b/src/gl/inject_glx.cpp
@@ -155,12 +155,17 @@ EXPORT_C_(void) glXSwapBuffers(void* dpy, void* drawable) {
 
     do_imgui_swap(dpy, drawable);
     using namespace std::chrono_literals;
-    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0s){
+    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0s && fps_limit_stats.method == FPS_LIMIT_METHOD_EARLY){
         fps_limit_stats.frameStart = Clock::now();
         FpsLimiter(fps_limit_stats);
         fps_limit_stats.frameEnd = Clock::now();
     }
     glx.SwapBuffers(dpy, drawable);
+    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0s && fps_limit_stats.method == FPS_LIMIT_METHOD_LATE){
+        fps_limit_stats.frameStart = Clock::now();
+        FpsLimiter(fps_limit_stats);
+        fps_limit_stats.frameEnd = Clock::now();
+    }
 }
 
 EXPORT_C_(int64_t) glXSwapBuffersMscOML(void* dpy, void* drawable, int64_t target_msc, int64_t divisor, int64_t remainder)
@@ -171,12 +176,19 @@ EXPORT_C_(int64_t) glXSwapBuffersMscOML(void* dpy, void* drawable, int64_t targe
 
     do_imgui_swap(dpy, drawable);
     using namespace std::chrono_literals;
-    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0s){
+    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0s && fps_limit_stats.method == FPS_LIMIT_METHOD_EARLY){
         fps_limit_stats.frameStart = Clock::now();
         FpsLimiter(fps_limit_stats);
         fps_limit_stats.frameEnd = Clock::now();
     }
+
     int64_t ret = glx.SwapBuffersMscOML(dpy, drawable, target_msc, divisor, remainder);
+
+    if (!is_blacklisted() && fps_limit_stats.targetFrameTime > 0s && fps_limit_stats.method == FPS_LIMIT_METHOD_LATE){
+        fps_limit_stats.frameStart = Clock::now();
+        FpsLimiter(fps_limit_stats);
+        fps_limit_stats.frameEnd = Clock::now();
+    }
 
     return ret;
 }

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -665,7 +665,8 @@ void HudElements::show_fps_limit(){
             fps = 1000000000 / fps_limit_stats.targetFrameTime.count();
         ImGui::TableNextColumn();
         ImGui::PushFont(HUDElements.sw_stats->font1);
-        ImGui::TextColored(HUDElements.colors.engine, "%s","FPS limit");
+        const char* method = fps_limit_stats.method == FPS_LIMIT_METHOD_EARLY ? "early" : "late";
+        ImGui::TextColored(HUDElements.colors.engine, "%s (%s)","FPS limit",method);
         ImGuiTableSetColumnIndex(HUDElements.text_column);
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", fps);
         ImGui::PopFont();

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -61,6 +61,7 @@ struct fps_limit {
    Clock::duration targetFrameTime;
    Clock::duration frameOverhead;
    Clock::duration sleepTime;
+   enum fps_limit_method method;
 };
 
 struct benchmark_stats {

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -188,6 +188,16 @@ parse_fps_limit(const char *str)
    return fps_limit;
 }
 
+static enum fps_limit_method
+parse_fps_limit_method(const char *str)
+{
+   if (!strcmp(str, "early")) {
+      return FPS_LIMIT_METHOD_EARLY;
+   }
+
+   return FPS_LIMIT_METHOD_LATE;
+}
+
 static bool
 parse_no_display(const char *str)
 {
@@ -597,6 +607,7 @@ parse_overlay_config(struct overlay_params *params,
    params->height = 140;
    params->control = -1;
    params->fps_limit = { 0 };
+   params->fps_limit_method = FPS_LIMIT_METHOD_LATE;
    params->vsync = -1;
    params->gl_vsync = -2;
    params->offset_x = 0;
@@ -801,6 +812,8 @@ parse_overlay_config(struct overlay_params *params,
       fps_limit_stats.targetFrameTime = duration_cast<Clock::duration>(duration<double>(1) / params->fps_limit[0]);
    else
       fps_limit_stats.targetFrameTime = {};
+
+   fps_limit_stats.method = params->fps_limit_method;
 
 #ifdef HAVE_DBUS
    if (params->enabled[OVERLAY_PARAM_ENABLED_media_player]) {

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -108,6 +108,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(no_display)                  \
    OVERLAY_PARAM_CUSTOM(control)                     \
    OVERLAY_PARAM_CUSTOM(fps_limit)                   \
+   OVERLAY_PARAM_CUSTOM(fps_limit_method)            \
    OVERLAY_PARAM_CUSTOM(vsync)                       \
    OVERLAY_PARAM_CUSTOM(gl_vsync)                    \
    OVERLAY_PARAM_CUSTOM(gl_size_query)               \
@@ -200,6 +201,11 @@ enum gl_size_query {
    GL_SIZE_SCISSORBOX, // needed?
 };
 
+enum fps_limit_method {
+   FPS_LIMIT_METHOD_EARLY,
+   FPS_LIMIT_METHOD_LATE
+};
+
 enum overlay_param_enabled {
 #define OVERLAY_PARAM_BOOL(name) OVERLAY_PARAM_ENABLED_##name,
 #define OVERLAY_PARAM_CUSTOM(name)
@@ -215,6 +221,7 @@ struct overlay_params {
    int control;
    uint32_t fps_sampling_period; /* ns */
    std::vector<std::uint32_t> fps_limit;
+   enum fps_limit_method fps_limit_method;
    bool help;
    bool no_display;
    bool full;

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1576,7 +1576,7 @@ static VkResult overlay_QueuePresentKHR(
     const VkPresentInfoKHR*                     pPresentInfo)
 {
    using namespace std::chrono_literals;
-   if (fps_limit_stats.targetFrameTime > 0s){
+   if (fps_limit_stats.targetFrameTime > 0s && fps_limit_stats.method == FPS_LIMIT_METHOD_EARLY){
       fps_limit_stats.frameStart = Clock::now();
       FpsLimiter(fps_limit_stats);
       fps_limit_stats.frameEnd = Clock::now();
@@ -1622,6 +1622,12 @@ static VkResult overlay_QueuePresentKHR(
          pPresentInfo->pResults[i] = chain_result;
       if (chain_result != VK_SUCCESS && result == VK_SUCCESS)
          result = chain_result;
+   }
+
+   if (fps_limit_stats.targetFrameTime > 0s && fps_limit_stats.method == FPS_LIMIT_METHOD_LATE){
+      fps_limit_stats.frameStart = Clock::now();
+      FpsLimiter(fps_limit_stats);
+      fps_limit_stats.frameEnd = Clock::now();
    }
 
    return result;


### PR DESCRIPTION
This adds an option to select if the FPS limiter should wait before (`early`) or after (`late`) presenting a frame. The default is set to `late` which matches MangoHud 0.6.8, DXVK and libstrangle.

Waiting before present is required for 100% stable frametimes (since the limiter can know exactly how much time is left in every frame) but it adds latency (since the limiter adds a delay before sending the frame to the display). 

Fixes: #920