### PR TITLE
Drop unused warnings, add new one, parallelise

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,13 +151,6 @@ foreach a : ['non-virtual-dtor', 'missing-field-initializers', 'format-truncatio
   endif
 endforeach
 
-no_override_init_args = []
-foreach a : ['override-init', 'initializer-overrides']
-  if cc.has_argument('-W' + a)
-    no_override_init_args += '-Wno-' + a
-  endif
-endforeach
-
 foreach a : pre_args
   add_project_arguments(a, language : ['c', 'cpp'])
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -114,51 +114,34 @@ inc_common = [
 dep_vulkan = dependency('vulkan', required: get_option('use_system_vulkan'))
 dep_pthread = dependency('threads')
 
-# Check for generic C arguments
-c_args = []
-foreach a : ['-Werror=implicit-function-declaration',
-             '-Werror=missing-prototypes', '-Werror=return-type',
-             '-Werror=incompatible-pointer-types',
-             '-Wno-unused-parameter', '-Qunused-arguments',
-             '-fno-math-errno', '-fno-trapping-math']
-  if cc.has_argument(a)
-    c_args += a
-  endif
-endforeach
+add_project_arguments(
+  cc.get_supported_arguments([
+    '-Werror=implicit-function-declaration',
+    '-Werror=missing-prototypes',
+    '-Werror=return-type',
+    '-Werror=incompatible-pointer-types',
+    '-Wno-unused-parameter',
+    '-Qunused-arguments',
+    '-fno-math-errno',
+    '-fno-trapping-math',
+    '-Wno-missing-field-initializers',
+  ]), language : ['c'],
+)
 
-foreach a : ['missing-field-initializers']
-  if cc.has_argument('-W' + a)
-    c_args += '-Wno-' + a
-  endif
-endforeach
-
-# Check for generic C++ arguments
-cpp_args = []
-foreach a : ['-Werror=return-type',
-             '-Wno-unused-parameter', '-Qunused-arguments',
-             '-fno-math-errno', '-fno-trapping-math']
-  if cpp.has_argument(a)
-    cpp_args += a
-  endif
-endforeach
-
-# For some reason, the test for -Wno-foo always succeeds with gcc, even if the
-# option is not supported. Hence, check for -Wfoo instead.
-
-foreach a : ['non-virtual-dtor', 'missing-field-initializers',]
-  if cpp.has_argument('-W' + a)
-    cpp_args += '-Wno-' + a
-  endif
-endforeach
+add_project_arguments(
+  cpp.get_supported_arguments([
+    '-Werror=return-type',
+    '-Wno-unused-parameter',
+    '-Qunused-arguments',
+    '-fno-math-errno',
+    '-fno-trapping-math',
+    '-Wno-non-virtual-dtor',
+    '-Wno-missing-field-initializers',
+  ]), language : ['cpp'],
+)
 
 foreach a : pre_args
   add_project_arguments(a, language : ['c', 'cpp'])
-endforeach
-foreach a : c_args
-  add_project_arguments(a, language : ['c'])
-endforeach
-foreach a : cpp_args
-  add_project_arguments(a, language : ['cpp'])
 endforeach
 
 # check for dl support

--- a/meson.build
+++ b/meson.build
@@ -187,11 +187,6 @@ vk_enum_to_str = custom_target(
   ],
 )
 
-util_files = files(
-  'src/mesa/util/os_socket.c',
-  'src/mesa/util/os_time.c',
-)
-
 imgui_options = [
   'default_library=static',
   'werror=false',

--- a/meson.build
+++ b/meson.build
@@ -117,6 +117,7 @@ dep_pthread = dependency('threads')
 add_project_arguments(
   cc.get_supported_arguments([
     '-Werror=implicit-function-declaration',
+    '-Werror=missing-declarations',
     '-Werror=missing-prototypes',
     '-Werror=return-type',
     '-Werror=incompatible-pointer-types',
@@ -130,6 +131,7 @@ add_project_arguments(
 
 add_project_arguments(
   cpp.get_supported_arguments([
+    '-Werror=missing-declarations',
     '-Werror=return-type',
     '-Wno-unused-parameter',
     '-Qunused-arguments',

--- a/meson.build
+++ b/meson.build
@@ -126,7 +126,7 @@ foreach a : ['-Werror=implicit-function-declaration',
   endif
 endforeach
 
-foreach a : ['missing-field-initializers', 'format-truncation']
+foreach a : ['missing-field-initializers']
   if cc.has_argument('-W' + a)
     c_args += '-Wno-' + a
   endif
@@ -145,7 +145,7 @@ endforeach
 # For some reason, the test for -Wno-foo always succeeds with gcc, even if the
 # option is not supported. Hence, check for -Wfoo instead.
 
-foreach a : ['non-virtual-dtor', 'missing-field-initializers', 'format-truncation']
+foreach a : ['non-virtual-dtor', 'missing-field-initializers',]
   if cpp.has_argument('-W' + a)
     cpp_args += '-Wno-' + a
   endif

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -27,7 +27,7 @@
 
 #include "file_utils.h"
 
-void calculateCPUData(CPUData& cpuData,
+static void calculateCPUData(CPUData& cpuData,
     unsigned long long int usertime,
     unsigned long long int nicetime,
     unsigned long long int systemtime,
@@ -480,7 +480,7 @@ static bool find_input(const std::string& path, const char* input_prefix, std::s
     return false;
 }
 
-CPUPowerData_k10temp* init_cpu_power_data_k10temp(const std::string path) {
+static CPUPowerData_k10temp* init_cpu_power_data_k10temp(const std::string path) {
     auto powerData = std::make_unique<CPUPowerData_k10temp>();
 
     std::string coreVoltageInput, coreCurrentInput;
@@ -504,7 +504,7 @@ CPUPowerData_k10temp* init_cpu_power_data_k10temp(const std::string path) {
     return powerData.release();
 }
 
-CPUPowerData_zenpower* init_cpu_power_data_zenpower(const std::string path) {
+static CPUPowerData_zenpower* init_cpu_power_data_zenpower(const std::string path) {
     auto powerData = std::make_unique<CPUPowerData_zenpower>();
 
     std::string corePowerInput, socPowerInput;
@@ -521,7 +521,7 @@ CPUPowerData_zenpower* init_cpu_power_data_zenpower(const std::string path) {
     return powerData.release();
 }
 
-CPUPowerData_rapl* init_cpu_power_data_rapl(const std::string path) {
+static CPUPowerData_rapl* init_cpu_power_data_rapl(const std::string path) {
     auto powerData = std::make_unique<CPUPowerData_rapl>();
 
     std::string energyCounterPath = path + "/energy_uj";

--- a/src/dbus.cpp
+++ b/src/dbus.cpp
@@ -45,14 +45,14 @@ static void assign_metadata_value(metadata& meta, const std::string& key,
     }
 }
 
-std::string format_signal(const dbusmgr::DBusSignal& s) {
+static std::string format_signal(const dbusmgr::DBusSignal& s) {
     std::stringstream ss;
     ss << "type='signal',interface='" << s.intf << "'";
     ss << ",member='" << s.signal << "'";
     return ss.str();
 }
 
-void parse_song_data(DBusMessageIter_wrap iter, metadata& meta){
+static void parse_song_data(DBusMessageIter_wrap iter, metadata& meta){
     iter.string_map_for_each([&meta](const std::string& key,
                                        DBusMessageIter_wrap it) {
         std::string val;
@@ -100,7 +100,7 @@ static void parse_mpris_properties(libdbus_loader& dbus, DBusMessage* msg,
     meta.valid = (meta.artists.size() || !meta.title.empty());
 }
 
-bool dbus_get_name_owner(dbusmgr::dbus_manager& dbus_mgr,
+static bool dbus_get_name_owner(dbusmgr::dbus_manager& dbus_mgr,
                          std::string& name_owner, const char* name) {
     auto reply =
         DBusMessage_wrap::new_method_call(
@@ -116,7 +116,7 @@ bool dbus_get_name_owner(dbusmgr::dbus_manager& dbus_mgr,
     return true;
 }
 
-bool dbus_get_player_property(dbusmgr::dbus_manager& dbus_mgr, metadata& meta,
+static bool dbus_get_player_property(dbusmgr::dbus_manager& dbus_mgr, metadata& meta,
                               const char* dest, const char* prop) {
     auto reply =
         DBusMessage_wrap::new_method_call(dest, "/org/mpris/MediaPlayer2",

--- a/src/elfhacks.cpp
+++ b/src/elfhacks.cpp
@@ -44,6 +44,7 @@ int eh_set_rel_plt(eh_obj_t *obj, int p, const char *sym, void *val);
 
 int eh_iterate_rela_plt(eh_obj_t *obj, int p, eh_iterate_rel_callback_func callback, void *arg);
 int eh_iterate_rel_plt(eh_obj_t *obj, int p, eh_iterate_rel_callback_func callback, void *arg);
+int eh_iterate_callback(struct dl_phdr_info *info, size_t size, void *argptr);
 
 int eh_find_sym_hash(eh_obj_t *obj, const char *name, eh_sym_t *sym);
 int eh_find_sym_gnu_hash(eh_obj_t *obj, const char *name, eh_sym_t *sym);

--- a/src/gamepad.cpp
+++ b/src/gamepad.cpp
@@ -17,7 +17,7 @@ int switch_count = 0;
 int bitdo_count = 0;
 std::string  xbox_paths [2]{"gip","xpadneo"};
 
-bool operator<(const gamepad& a, const gamepad& b)
+static bool operator<(const gamepad& a, const gamepad& b)
 {
     return a.name < b.name;
 }

--- a/src/gl/inject_egl.cpp
+++ b/src/gl/inject_egl.cpp
@@ -15,7 +15,7 @@ using namespace MangoHud::GL;
 
 EXPORT_C_(void *) eglGetProcAddress(const char* procName);
 
-void* get_egl_proc_address(const char* name) {
+static void* get_egl_proc_address(const char* name) {
 
     void *func = nullptr;
     static void *(*pfn_eglGetProcAddress)(const char*) = nullptr;
@@ -41,6 +41,7 @@ void* get_egl_proc_address(const char* name) {
     return func;
 }
 
+EXPORT_C_(unsigned int) eglSwapBuffers( void* dpy, void* surf);
 EXPORT_C_(unsigned int) eglSwapBuffers( void* dpy, void* surf)
 {
     static int (*pfn_eglSwapBuffers)(void*, void*) = nullptr;
@@ -82,6 +83,7 @@ static std::array<const func_ptr, 2> name_to_funcptr_map = {{
 #undef ADD_HOOK
 }};
 
+EXPORT_C_(void *) mangohud_find_egl_ptr(const char *name);
 EXPORT_C_(void *) mangohud_find_egl_ptr(const char *name)
 {
   if (is_blacklisted())

--- a/src/gl/inject_egl.cpp
+++ b/src/gl/inject_egl.cpp
@@ -41,13 +41,6 @@ void* get_egl_proc_address(const char* name) {
     return func;
 }
 
-//EGLBoolean eglMakeCurrent(EGLDisplay dpy, EGLSurface draw, EGLSurface read, EGLContext ctx);
-EXPORT_C_(int) eglMakeCurrent_OFF(void *dpy, void *draw, void *read,void *ctx) {
-    SPDLOG_TRACE("{}: draw: {}, ctx: {}", __func__, draw, ctx);
-    int ret = 0;
-    return ret;
-}
-
 EXPORT_C_(unsigned int) eglSwapBuffers( void* dpy, void* surf)
 {
     static int (*pfn_eglSwapBuffers)(void*, void*) = nullptr;

--- a/src/gl/inject_glx.cpp
+++ b/src/gl/inject_glx.cpp
@@ -22,9 +22,6 @@
 
 using namespace MangoHud::GL;
 
-EXPORT_C_(void *) glXGetProcAddress(const unsigned char* procName);
-EXPORT_C_(void *) glXGetProcAddressARB(const unsigned char* procName);
-
 #ifndef GLX_WIDTH
 #define GLX_WIDTH   0x801D
 #define GLX_HEIGHT  0x801E

--- a/src/gl/inject_glx.cpp
+++ b/src/gl/inject_glx.cpp
@@ -31,7 +31,7 @@ static glx_loader glx;
 
 static std::atomic<int> refcnt (0);
 
-void* get_glx_proc_address(const char* name) {
+static void* get_glx_proc_address(const char* name) {
     glx.Load();
 
     void *func = nullptr;
@@ -61,6 +61,7 @@ EXPORT_C_(void *) glXCreateContext(void *dpy, void *vis, void *shareList, int di
     return ctx;
 }
 
+EXPORT_C_(void *) glXCreateContextAttribs(void *dpy, void *config,void *share_context, int direct, const int *attrib_list);
 EXPORT_C_(void *) glXCreateContextAttribs(void *dpy, void *config,void *share_context, int direct, const int *attrib_list)
 {
     glx.Load();
@@ -263,6 +264,7 @@ static std::array<const func_ptr, 13> name_to_funcptr_map = {{
 #undef ADD_HOOK
 }};
 
+EXPORT_C_(void *) mangohud_find_glx_ptr(const char *name);
 EXPORT_C_(void *) mangohud_find_glx_ptr(const char *name)
 {
   if (is_blacklisted())

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -35,29 +35,11 @@ float SRGBToLinear(float in)
         return powf((in + 0.055f) / 1.055f, 2.4f);
 }
 
-float LinearToSRGB(float in)
-{
-    if (in <= 0.0031308f)
-        return in * 12.92f;
-    else
-        return 1.055f * powf(in, 1.0f / 2.4f) - 0.055f;
-}
-
 ImVec4 SRGBToLinear(ImVec4 col)
 {
     col.x = SRGBToLinear(col.x);
     col.y = SRGBToLinear(col.y);
     col.z = SRGBToLinear(col.z);
-    // Alpha component is already linear
-
-    return col;
-}
-
-ImVec4 LinearToSRGB(ImVec4 col)
-{
-    col.x = LinearToSRGB(col.x);
-    col.y = LinearToSRGB(col.y);
-    col.z = LinearToSRGB(col.z);
     // Alpha component is already linear
 
     return col;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -27,7 +27,7 @@ using namespace std;
 
 // Cut from https://github.com/ocornut/imgui/pull/2943
 // Probably move to ImGui
-float SRGBToLinear(float in)
+static float SRGBToLinear(float in)
 {
     if (in <= 0.04045f)
         return in / 12.92f;
@@ -35,7 +35,7 @@ float SRGBToLinear(float in)
         return powf((in + 0.055f) / 1.055f, 2.4f);
 }
 
-ImVec4 SRGBToLinear(ImVec4 col)
+static ImVec4 SRGBToLinear(ImVec4 col)
 {
     col.x = SRGBToLinear(col.x);
     col.y = SRGBToLinear(col.y);
@@ -109,7 +109,7 @@ void HudElements::convert_colors(bool do_conv, const struct overlay_params& para
 /**
 * Go to next column or second column on new row
 */
-void ImguiNextColumnOrNewRow(int column = -1)
+static void ImguiNextColumnOrNewRow(int column = -1)
 {
     if (column > -1 && column < ImGui::TableGetColumnCount())
         ImGui::TableSetColumnIndex(column);
@@ -121,7 +121,7 @@ void ImguiNextColumnOrNewRow(int column = -1)
     }
 }
 
-void ImGuiTableSetColumnIndex(int column)
+static void ImGuiTableSetColumnIndex(int column)
 {
     ImGui::TableSetColumnIndex(std::max(0, std::min(column, ImGui::TableGetColumnCount() - 1)));
 }
@@ -767,13 +767,13 @@ void HudElements::battery(){
                         ImGuiTableSetColumnIndex(2);
                         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%02.0f:%02.0f", hours, minutes);
                     }
-                } else { 
+                } else {
                     ImguiNextColumnOrNewRow();
                     right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", ICON_FK_PLUG);
                 }
             }
         }
-        
+
     }
 #endif
 }

--- a/src/intel.cpp
+++ b/src/intel.cpp
@@ -8,7 +8,7 @@ using json = nlohmann::json;
 static bool init_intel = false;
 struct gpuInfo gpu_info_intel {};
 
-void intelGpuThread(){
+static void intelGpuThread(){
     init_intel = true;
     static char stdout_buffer[1024];
     FILE* intel_gpu_top = popen("intel_gpu_top -J -s 500", "r");
@@ -56,7 +56,7 @@ void intelGpuThread(){
 
         if (exitcode == 1)
         SPDLOG_INFO("Missing permissions for '{}'", "intel_gpu_top");
-        
+
         SPDLOG_INFO("Disabling gpu_stats");
         _params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] = false;
     }

--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -14,7 +14,7 @@ typedef unsigned long KeySym;
 Clock::time_point last_f2_press, toggle_fps_limit_press , last_f12_press, reload_cfg_press, last_upload_press;
 
 #if defined(HAVE_X11)
-bool keys_are_pressed(const std::vector<KeySym>& keys) {
+static inline bool keys_are_pressed(const std::vector<KeySym>& keys) {
 
     if (!init_x11())
         return false;
@@ -41,7 +41,7 @@ bool keys_are_pressed(const std::vector<KeySym>& keys) {
 }
 #elif defined(_WIN32)
 #include <windows.h>
-bool keys_are_pressed(const std::vector<KeySym>& keys) {
+static inline bool keys_are_pressed(const std::vector<KeySym>& keys) {
     size_t pressed = 0;
 
     for (KeySym ks : keys) {
@@ -56,7 +56,7 @@ bool keys_are_pressed(const std::vector<KeySym>& keys) {
     return false;
 }
 #else // XXX: Add wayland support
-bool keys_are_pressed(const std::vector<KeySym>& keys) {
+static inline bool keys_are_pressed(const std::vector<KeySym>& keys) {
     return false;
 }
 #endif

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -36,7 +36,7 @@ string exec(string command) {
     return result;
 }
 
-void upload_file(std::string logFile){
+static void upload_file(std::string logFile){
   std::string command = "curl --include --request POST https://flightlessmango.com/logs -F 'log[game_id]=26506' -F 'log[user_id]=176' -F 'attachment=true' -A 'mangohud' ";
   command += " -F 'log[uploads][]=@" + logFile + "'";
 
@@ -45,7 +45,7 @@ void upload_file(std::string logFile){
   exec("xdg-open " + url);
 }
 
-void upload_files(const std::vector<std::string>& logFiles){
+static void upload_files(const std::vector<std::string>& logFiles){
   std::string command = "curl --include --request POST https://flightlessmango.com/logs -F 'log[game_id]=26506' -F 'log[user_id]=176' -F 'attachment=true' -A 'mangohud' ";
   for (auto& file : logFiles)
     command += " -F 'log[uploads][]=@" + file + "'";
@@ -55,12 +55,12 @@ void upload_files(const std::vector<std::string>& logFiles){
   exec("xdg-open " + url);
 }
 
-bool compareByFps(const logData &a, const logData &b)
+static bool compareByFps(const logData &a, const logData &b)
 {
     return a.fps < b.fps;
 }
 
-void writeSummary(string filename){
+static void writeSummary(string filename){
   auto& logArray = logger->get_log_data();
   filename = filename.substr(0, filename.size() - 4);
   filename += "_summary.csv";
@@ -109,7 +109,7 @@ void writeSummary(string filename){
   out.close();
 }
 
-void writeFileHeaders(ofstream& out){
+static void writeFileHeaders(ofstream& out){
       if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_log_versioning]){
       printf("log versioning");
       out << "v1" << endl;
@@ -152,7 +152,7 @@ void Logger::writeToFile(){
   }
 }
 
-string get_log_suffix(){
+static string get_log_suffix(){
   time_t now_log = time(0);
   tm *log_time = localtime(&now_log);
   std::ostringstream buffer;

--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,11 @@ foreach s : ['overlay.frag', 'overlay.vert']
     command : [glslang, '-V', '-x', '-o', '@OUTPUT@', '@INPUT@'])
 endforeach
 
+util_files = files(
+  'mesa/util/os_socket.c',
+  'mesa/util/os_time.c',
+)
+
 vklayer_files = files(
   'hud_elements.cpp',
   'overlay.cpp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -169,7 +169,6 @@ mangohud_static_lib = static_library(
   overlay_spv,
   c_args : [
     pre_args,
-    no_override_init_args,
     vulkan_wsi_args
     ],
   cpp_args : [
@@ -211,7 +210,6 @@ if is_unixy
     ),
     c_args : [
       pre_args,
-      no_override_init_args,
       ],
     cpp_args : [
       pre_args,
@@ -236,7 +234,6 @@ if sizeof_ptr != 4 or get_option('mangoapp_32bit')
       ),
       c_args : [
         pre_args,
-        no_override_init_args,
         vulkan_wsi_args
         ],
       cpp_args : [
@@ -281,7 +278,6 @@ if get_option('mangoapp_layer')
     ),
     c_args : [
       pre_args,
-      no_override_init_args,
       ],
     cpp_args : [
       pre_args,

--- a/src/nvctrl.cpp
+++ b/src/nvctrl.cpp
@@ -89,7 +89,7 @@ static void parse_token(std::string token, string_map& options) {
         options[param] = value;
 }
 
-char* get_attr_target_string(libnvctrl_loader& nvctrl, int attr, int target_type, int target_id) {
+static char* get_attr_target_string(libnvctrl_loader& nvctrl, int attr, int target_type, int target_id) {
     char* c = nullptr;
     if (!nvctrl.XNVCTRLQueryTargetStringAttribute(display.get(), target_type, target_id, 0, attr, &c)) {
         SPDLOG_ERROR("Failed to query attribute '{}'", attr);

--- a/src/nvctrl.h
+++ b/src/nvctrl.h
@@ -15,6 +15,5 @@ extern struct nvctrlInfo nvctrl_info;
 extern bool nvctrlSuccess;
 bool checkXNVCtrl(void);
 void getNvctrlInfo(void);
-char *get_attr_target_string(int attr, int target_type, int target_id);
 
 #endif //MANGOHUD_NVCTRL_H

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -389,7 +389,7 @@ void center_text(const std::string& text)
    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2 )- (ImGui::CalcTextSize(text.c_str()).x / 2));
 }
 
-float get_ticker_limited_pos(float pos, float tw, float& left_limit, float& right_limit)
+static float get_ticker_limited_pos(float pos, float tw, float& left_limit, float& right_limit)
 {
    //float cw = ImGui::GetContentRegionAvailWidth() * 3; // only table cell worth of width
    float cw = ImGui::GetWindowContentRegionMax().x - ImGui::GetStyle().WindowPadding.x;

--- a/src/pci_ids.cpp
+++ b/src/pci_ids.cpp
@@ -9,7 +9,7 @@
 
 std::map<uint32_t /*vendor id*/, std::pair<std::string /*vendor desc*/, std::map<uint32_t /*device id*/, device>>> pci_ids;
 
-std::istream& get_uncommented_line(std::istream& is, std::string &line)
+static std::istream& get_uncommented_line(std::istream& is, std::string &line)
 {
     while (std::getline(is, line)) {
         auto c = line.find("#");

--- a/src/real_dlsym.cpp
+++ b/src/real_dlsym.cpp
@@ -15,7 +15,7 @@ void *(*__dlsym)(void *, const char *) = nullptr;
 static bool print_dlopen = getenv("MANGOHUD_DEBUG_DLOPEN") != nullptr;
 static bool print_dlsym = getenv("MANGOHUD_DEBUG_DLSYM") != nullptr;
 
-void get_real_functions()
+static void get_real_functions()
 {
     eh_obj_t libdl;
     int ret;

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -401,7 +401,7 @@ static void destroy_swapchain_data(struct swapchain_data *data)
    delete data;
 }
 
-struct overlay_draw *get_overlay_draw(struct swapchain_data *data)
+static struct overlay_draw *get_overlay_draw(struct swapchain_data *data)
 {
    struct device_data *device_data = data->device;
    struct overlay_draw *draw = data->draws.empty() ?


### PR DESCRIPTION
This PR drops a few no longer relevant warnings - `Wno-format-truncation` and the no-override ones. Adds a new one - `missing-declarations` - which kindly enough prompts about some dead code, which was removed.

Last by not least the meson `get_supported-arguments()` is used, which allows meson to do the checks in parallel, plus is aware of the `-Wno` trick and uses it as applicable.