### PR TITLE
Drop most libdir options, simplify and make it work everywhere (tm)

### DIFF
--- a/bin/mangohud-setup.sh
+++ b/bin/mangohud-setup.sh
@@ -65,7 +65,8 @@ mangohud_install() {
     /usr/bin/install -Dvm644 ./usr/lib/mangohud/lib64/libMangoHud_dlsym.so /usr/lib/mangohud/lib64/libMangoHud_dlsym.so
     /usr/bin/install -Dvm644 ./usr/lib/mangohud/lib32/libMangoHud.so /usr/lib/mangohud/lib32/libMangoHud.so
     /usr/bin/install -Dvm644 ./usr/lib/mangohud/lib32/libMangoHud_dlsym.so /usr/lib/mangohud/lib32/libMangoHud_dlsym.so
-    /usr/bin/install -Dvm644 ./usr/share/vulkan/implicit_layer.d/MangoHud.json /usr/share/vulkan/implicit_layer.d/MangoHud.json
+    /usr/bin/install -Dvm644 ./usr/share/vulkan/implicit_layer.d/MangoHud.x86_64.json /usr/share/vulkan/implicit_layer.d/MangoHud.x86_64.json
+    /usr/bin/install -Dvm644 ./usr/share/vulkan/implicit_layer.d/MangoHud.x86.json /usr/share/vulkan/implicit_layer.d/MangoHud.x86.json
     /usr/bin/install -Dvm644 ./usr/share/man/man1/mangohud.1 /usr/share/man/man1/mangohud.1
     /usr/bin/install -Dvm644 ./usr/share/doc/mangohud/MangoHud.conf.example /usr/share/doc/mangohud/MangoHud.conf.example
     /usr/bin/install -vm755  ./usr/bin/mangohud /usr/bin/mangohud

--- a/bin/mangohud.in
+++ b/bin/mangohud.in
@@ -13,16 +13,14 @@ if [ "$1" = "--dlsym" ]; then
 	shift
 fi
 
-MANGOHUD_LIB_NAME="@ld_libdir_mangohud_abs@libMangoHud.so"
+MANGOHUD_LIB_NAME="@ld_libdir_mangohud@libMangoHud.so"
 
 if [ "$MANGOHUD_DLSYM" = "1" ]; then
-	MANGOHUD_LIB_NAME="@ld_libdir_mangohud_abs@libMangoHud_dlsym.so:${MANGOHUD_LIB_NAME}"
+	MANGOHUD_LIB_NAME="@ld_libdir_mangohud@libMangoHud_dlsym.so:${MANGOHUD_LIB_NAME}"
 fi
 
 # Preload using the plain filenames of the libs, the dynamic linker will
-# figure out whether the 32 or 64 bit version should be used, and will search
-# for it in the correct directory
+# figure out whether the 32 or 64 bit version should be used
 LD_PRELOAD="${LD_PRELOAD}${LD_PRELOAD:+:}${MANGOHUD_LIB_NAME}"
-LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}@ld_libdir_mangohud@"
 
-exec env MANGOHUD=1 LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" LD_PRELOAD="${LD_PRELOAD}" "$@"
+exec env MANGOHUD=1 LD_PRELOAD="${LD_PRELOAD}" "$@"

--- a/bin/mangohud.in
+++ b/bin/mangohud.in
@@ -8,19 +8,16 @@ if [ "$#" -eq 0 ]; then
 	exit 1
 fi
 
-if [ "$1" = "--dlsym" ]; then
-	MANGOHUD_DLSYM=1
-	shift
-fi
-
 MANGOHUD_LIB_NAME="@ld_libdir_mangohud@libMangoHud.so"
 
-if [ "$MANGOHUD_DLSYM" = "1" ]; then
+if [ "$1" = "--dlsym" ]; then
+	MANGOHUD_DLSYM=1
 	MANGOHUD_LIB_NAME="@ld_libdir_mangohud@libMangoHud_dlsym.so:${MANGOHUD_LIB_NAME}"
+	shift
 fi
 
 # Preload using the plain filenames of the libs, the dynamic linker will
 # figure out whether the 32 or 64 bit version should be used
-LD_PRELOAD="${LD_PRELOAD}${LD_PRELOAD:+:}${MANGOHUD_LIB_NAME}"
+LD_PRELOAD="${LD_PRELOAD:+$LD_PRELOAD:}${MANGOHUD_LIB_NAME}"
 
 exec env MANGOHUD=1 LD_PRELOAD="${LD_PRELOAD}" "$@"

--- a/build-srt.sh
+++ b/build-srt.sh
@@ -69,13 +69,13 @@ configure() {
     if [[ ! -f "build-srt/meson64/build.ninja" ]]; then
         export CC="${LOCAL_CC}"
         export CXX="${LOCAL_CXX}"
-        meson build-srt/meson64 --libdir lib/mangohud/lib --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_prefix=true $@ ${CONFIGURE_OPTS}
+        meson build-srt/meson64 --libdir lib/mangohud/lib --prefix /usr -Dappend_libdir_mangohud=false $@ ${CONFIGURE_OPTS}
     fi
     if [[ ! -f "build-srt/meson32/build.ninja" ]]; then
         export CC="${LOCAL_CC} -m32"
         export CXX="${LOCAL_CXX} -m32"
         export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig:${PKG_CONFIG_PATH_32}"
-        meson build-srt/meson32 --libdir lib/mangohud/lib32 --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_prefix=true $@ ${CONFIGURE_OPTS}
+        meson build-srt/meson32 --libdir lib/mangohud/lib32 --prefix /usr -Dappend_libdir_mangohud=false $@ ${CONFIGURE_OPTS}
     fi
 }
 

--- a/build.sh
+++ b/build.sh
@@ -7,11 +7,7 @@ source ./build_deps.sh
 OS_RELEASE_FILES=("/etc/os-release" "/usr/lib/os-release")
 XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
 XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
-DATA_DIR="$XDG_DATA_HOME/MangoHud"
 CONFIG_DIR="$XDG_CONFIG_HOME/MangoHud"
-LAYER="build/release/usr/share/vulkan/implicit_layer.d/mangohud.json"
-INSTALL_DIR="build/package/"
-IMPLICIT_LAYER_DIR="$XDG_DATA_HOME/vulkan/implicit_layer.d"
 VERSION=$(git describe --long --tags --always | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//')
 SU_CMD=$(command -v sudo || command -v doas || echo)
 MACHINE=$(uname -m || echo)
@@ -152,7 +148,6 @@ configure() {
         export CC="gcc -m32"
         export CXX="g++ -m32"
         export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig:${PKG_CONFIG_PATH_32}"
-        export LLVM_CONFIG="/usr/bin/llvm-config32"
         meson build/meson32 --libdir lib/mangohud/lib32 --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_prefix=true -Dld_libdir_abs=true $@ ${CONFIGURE_OPTS}
     fi
 }

--- a/build.sh
+++ b/build.sh
@@ -228,8 +228,8 @@ install() {
       /usr/bin/install -Dvm644 ./build/release/usr/lib/mangohud/lib32/libMangoHud_dlsym.so /usr/lib/mangohud/lib32/libMangoHud_dlsym.so
     fi
 
-    /usr/bin/install -Dvm644 ./build/release/usr/share/vulkan/implicit_layer.d/MangoHud.json /usr/share/vulkan/implicit_layer.d/MangoHud.json
-    /usr/bin/install -Dvm644 ./build/release/usr/share/vulkan/implicit_layer.d/MangoHud.json /usr/share/vulkan/implicit_layer.d/MangoHud.json
+    /usr/bin/install -Dvm644 ./build/release/usr/share/vulkan/implicit_layer.d/MangoHud.x86_64.json /usr/share/vulkan/implicit_layer.d/MangoHud.x86_64.json
+    /usr/bin/install -Dvm644 ./build/release/usr/share/vulkan/implicit_layer.d/MangoHud.x86.json /usr/share/vulkan/implicit_layer.d/MangoHud.x86.json
     /usr/bin/install -Dvm644 ./build/release/usr/share/man/man1/mangohud.1 /usr/share/man/man1/mangohud.1
     /usr/bin/install -Dvm644 ./build/release/usr/share/doc/mangohud/MangoHud.conf.example /usr/share/doc/mangohud/MangoHud.conf.example
     /usr/bin/install -vm755  ./build/release/usr/bin/mangohud /usr/bin/mangohud

--- a/build.sh
+++ b/build.sh
@@ -142,13 +142,13 @@ configure() {
     git submodule update --init --depth 50
     CONFIGURE_OPTS="-Dwerror=true"
     if [[ ! -f "build/meson64/build.ninja" ]]; then
-        meson build/meson64 --libdir lib/mangohud/lib64 --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_prefix=true -Dld_libdir_abs=true $@ ${CONFIGURE_OPTS}
+        meson build/meson64 --libdir lib/mangohud/lib64 --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_abs=true $@ ${CONFIGURE_OPTS}
     fi
     if [[ ! -f "build/meson32/build.ninja" && "$MACHINE" = "x86_64" ]]; then
         export CC="gcc -m32"
         export CXX="g++ -m32"
         export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig:${PKG_CONFIG_PATH_32}"
-        meson build/meson32 --libdir lib/mangohud/lib32 --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_prefix=true -Dld_libdir_abs=true $@ ${CONFIGURE_OPTS}
+        meson build/meson32 --libdir lib/mangohud/lib32 --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_abs=true $@ ${CONFIGURE_OPTS}
     fi
 }
 

--- a/build.sh
+++ b/build.sh
@@ -142,13 +142,13 @@ configure() {
     git submodule update --init --depth 50
     CONFIGURE_OPTS="-Dwerror=true"
     if [[ ! -f "build/meson64/build.ninja" ]]; then
-        meson build/meson64 --libdir lib/mangohud/lib64 --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_abs=true $@ ${CONFIGURE_OPTS}
+        meson build/meson64 --libdir lib/mangohud/lib64 --prefix /usr -Dappend_libdir_mangohud=false $@ ${CONFIGURE_OPTS}
     fi
     if [[ ! -f "build/meson32/build.ninja" && "$MACHINE" = "x86_64" ]]; then
         export CC="gcc -m32"
         export CXX="g++ -m32"
         export PKG_CONFIG_PATH="/usr/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig:/usr/lib/pkgconfig:${PKG_CONFIG_PATH_32}"
-        meson build/meson32 --libdir lib/mangohud/lib32 --prefix /usr -Dappend_libdir_mangohud=false -Dld_libdir_abs=true $@ ${CONFIGURE_OPTS}
+        meson build/meson32 --libdir lib/mangohud/lib32 --prefix /usr -Dappend_libdir_mangohud=false $@ ${CONFIGURE_OPTS}
     fi
 }
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,7 +3,6 @@ option('use_system_vulkan', type : 'feature', value : 'disabled', description: '
 option('use_system_spdlog', type : 'feature', value : 'disabled', description: 'Use system spdlog library')
 option('vulkan_datadir', type : 'string', value : '', description: 'Path to the system vulkan headers data directory if different from MangoHud\'s datadir')
 option('append_libdir_mangohud', type : 'boolean', value : true, description: 'Append "mangohud" to libdir path or not.')
-option('ld_libdir_prefix', type : 'boolean', value : false, description: 'Set ld libdir to "$prefix/lib/mangohud/\$LIB"')
 option('ld_libdir_abs', type : 'boolean', value : false, description: 'Use absolute path in LD_PRELOAD')
 option('prepend_libdir_vk', type : 'boolean', value : true, description: 'Prepend libdir to library path in vulkan manifest')
 option('include_doc', type : 'boolean', value : true, description: 'Include the example config, man pages, appstream files etc.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,7 +4,6 @@ option('use_system_spdlog', type : 'feature', value : 'disabled', description: '
 option('vulkan_datadir', type : 'string', value : '', description: 'Path to the system vulkan headers data directory if different from MangoHud\'s datadir')
 option('append_libdir_mangohud', type : 'boolean', value : true, description: 'Append "mangohud" to libdir path or not.')
 option('ld_libdir_abs', type : 'boolean', value : false, description: 'Use absolute path in LD_PRELOAD')
-option('prepend_libdir_vk', type : 'boolean', value : true, description: 'Prepend libdir to library path in vulkan manifest')
 option('include_doc', type : 'boolean', value : true, description: 'Include the example config, man pages, appstream files etc.')
 option('with_nvml', type : 'combo', value : 'enabled', choices: ['enabled', 'system', 'disabled'], description: 'Enable NVML support')
 option('with_xnvctrl', type : 'feature', value : 'enabled', description: 'Enable XNVCtrl support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,7 +3,6 @@ option('use_system_vulkan', type : 'feature', value : 'disabled', description: '
 option('use_system_spdlog', type : 'feature', value : 'disabled', description: 'Use system spdlog library')
 option('vulkan_datadir', type : 'string', value : '', description: 'Path to the system vulkan headers data directory if different from MangoHud\'s datadir')
 option('append_libdir_mangohud', type : 'boolean', value : true, description: 'Append "mangohud" to libdir path or not.')
-option('ld_libdir_abs', type : 'boolean', value : false, description: 'Use absolute path in LD_PRELOAD')
 option('include_doc', type : 'boolean', value : true, description: 'Include the example config, man pages, appstream files etc.')
 option('with_nvml', type : 'combo', value : 'enabled', choices: ['enabled', 'system', 'disabled'], description: 'Enable NVML support')
 option('with_xnvctrl', type : 'feature', value : 'enabled', description: 'Enable XNVCtrl support')

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('SKIP'
             '3c38f275d5792b1286391102594329e98b17737924b344f98312ab09929b74be'
             'b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e')
 
-_build_args="-Dappend_libdir_mangohud=false -Dwith_xnvctrl=disabled -Duse_system_vulkan=enabled -Dmangoapp_layer=true -Dprepend_libdir_vk=false"
+_build_args="-Dappend_libdir_mangohud=false -Dwith_xnvctrl=disabled -Duse_system_vulkan=enabled -Dmangoapp_layer=true"
 
 pkgver() {
   cd "$srcdir/mangohud"

--- a/src/app/layer.json.in
+++ b/src/app/layer.json.in
@@ -4,7 +4,7 @@
       "name": "VK_LAYER_MANGOAPP_overlay",
       "type": "GLOBAL",
       "api_version": "1.3.0",
-      "library_path": "@ld_libdir_mangohud@libMangoApp.so",
+      "library_path": "@ld_libdir_mangohud_abs@/libMangoApp.so",
       "implementation_version": "1",
       "description": "Mangoapp Layer",
       "functions": {

--- a/src/mangohud.json.in
+++ b/src/mangohud.json.in
@@ -4,7 +4,7 @@
       "name": "VK_LAYER_MANGOHUD_overlay",
       "type": "GLOBAL",
       "api_version": "1.3.0",
-      "library_path": "@ld_libdir_mangohud@libMangoHud.so",
+      "library_path": "@ld_libdir_mangohud_abs@/libMangoHud.so",
       "implementation_version": "1",
       "description": "Vulkan Hud Overlay",
       "functions": {

--- a/src/mangohud.json.in
+++ b/src/mangohud.json.in
@@ -1,7 +1,7 @@
 {
     "file_format_version" : "1.0.0",
     "layer" : {
-      "name": "VK_LAYER_@PROJECT_NAME@_overlay",
+      "name": "VK_LAYER_MANGOHUD_overlay",
       "type": "GLOBAL",
       "api_version": "1.3.0",
       "library_path": "@ld_libdir_mangohud@libMangoHud.so",

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,22 +2,17 @@ glslang = find_program('glslangValidator')
 
 # Needs prefix for configure_file()
 if get_option('append_libdir_mangohud')
-  libdir_mangohud = join_paths(get_option('libdir'), 'mangohud')
+  libdir_mangohud = join_paths(get_option('prefix'), get_option('libdir'), 'mangohud')
   ld_libdir_mangohud = get_option('prefix') + '/\$LIB/mangohud/'
 else
-  libdir_mangohud = get_option('libdir')
+  libdir_mangohud = join_paths(get_option('prefix'), get_option('libdir'))
   ld_libdir_mangohud = get_option('prefix') + '/\$LIB/'
 endif
 
 conf_data = configuration_data()
 
-if get_option('ld_libdir_abs')
-  conf_data.set('ld_libdir_mangohud_abs', ld_libdir_mangohud)
-  conf_data.set('ld_libdir_mangohud', '')
-else
-  conf_data.set('ld_libdir_mangohud_abs', '')
-  conf_data.set('ld_libdir_mangohud', ld_libdir_mangohud)
-endif
+conf_data.set('ld_libdir_mangohud_abs', libdir_mangohud)
+conf_data.set('ld_libdir_mangohud', ld_libdir_mangohud)
 
 overlay_shaders = [
   'overlay.frag',
@@ -284,7 +279,7 @@ endif
 
 configure_file(input : 'mangohud.json.in',
   output : '@0@.@1@.json'.format(meson.project_name(), host_machine.cpu_family()),
-  configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud.replace('\$', '$')},
+  configuration : conf_data,
   install : true,
   install_dir : join_paths(get_option('datadir'), 'vulkan', 'implicit_layer.d'),
   install_tag : 'runtime',
@@ -300,7 +295,7 @@ configure_file(input : '../bin/mangohud.in',
 if get_option('mangoapp_layer')
   configure_file(input : 'app/layer.json.in',
     output : 'libMangoApp.@0@.json'.format(host_machine.cpu_family()),
-    configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud.replace('\$', '$')},
+    configuration : conf_data,
     install : true,
     install_dir : join_paths(get_option('datadir'), 'vulkan', 'implicit_layer.d'),
     install_tag : 'mangoapp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -288,7 +288,7 @@ if get_option('mangoapp_layer')
 endif
 
 configure_file(input : 'mangohud.json.in',
-  output : '@0@.json'.format(meson.project_name()),
+  output : '@0@.@1@.json'.format(meson.project_name(), host_machine.cpu_family()),
   configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud_vk.replace('\$', '$')},
   install : true,
   install_dir : join_paths(get_option('datadir'), 'vulkan', 'implicit_layer.d'),
@@ -304,7 +304,7 @@ configure_file(input : '../bin/mangohud.in',
 
 if get_option('mangoapp_layer')
   configure_file(input : 'app/layer.json.in',
-    output : 'libMangoApp.json',
+    output : 'libMangoApp.@0@.json'.format(host_machine.cpu_family()),
     configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud_vk.replace('\$', '$')},
     install : true,
     install_dir : join_paths(get_option('datadir'), 'vulkan', 'implicit_layer.d'),

--- a/src/meson.build
+++ b/src/meson.build
@@ -289,8 +289,7 @@ endif
 
 configure_file(input : 'mangohud.json.in',
   output : '@0@.json'.format(meson.project_name()),
-  configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud_vk.replace('\$', '$'),
-                  'PROJECT_NAME' : meson.project_name().to_upper()},
+  configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud_vk.replace('\$', '$')},
   install : true,
   install_dir : join_paths(get_option('datadir'), 'vulkan', 'implicit_layer.d'),
   install_tag : 'runtime',

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,11 +19,6 @@ else
   conf_data.set('ld_libdir_mangohud', ld_libdir_mangohud)
 endif
 
-ld_libdir_mangohud_vk = ''
-if get_option('prepend_libdir_vk')
-  ld_libdir_mangohud_vk = ld_libdir_mangohud
-endif
-
 overlay_shaders = [
   'overlay.frag',
   'overlay.vert',
@@ -289,7 +284,7 @@ endif
 
 configure_file(input : 'mangohud.json.in',
   output : '@0@.@1@.json'.format(meson.project_name(), host_machine.cpu_family()),
-  configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud_vk.replace('\$', '$')},
+  configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud.replace('\$', '$')},
   install : true,
   install_dir : join_paths(get_option('datadir'), 'vulkan', 'implicit_layer.d'),
   install_tag : 'runtime',
@@ -305,7 +300,7 @@ configure_file(input : '../bin/mangohud.in',
 if get_option('mangoapp_layer')
   configure_file(input : 'app/layer.json.in',
     output : 'libMangoApp.@0@.json'.format(host_machine.cpu_family()),
-    configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud_vk.replace('\$', '$')},
+    configuration : {'ld_libdir_mangohud' : ld_libdir_mangohud.replace('\$', '$')},
     install : true,
     install_dir : join_paths(get_option('datadir'), 'vulkan', 'implicit_layer.d'),
     install_tag : 'mangoapp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,12 +9,6 @@ else
   ld_libdir_mangohud = get_option('prefix') + '/\$LIB/'
 endif
 
-# For build.sh
-if get_option('ld_libdir_prefix')
-  # FIXME derive from libdir
-  ld_libdir_mangohud = get_option('prefix') + '/lib/mangohud/\$LIB/'
-endif
-
 conf_data = configuration_data()
 
 if get_option('ld_libdir_abs')


### PR DESCRIPTION
Currently we have an absolute maze of libdir options and in practical terms, orchestrating between them is fairly fragile and error prone.

This PR, removes most of them - `ld_libdir_prefix`, `ld_libdir_abs` and `prepend_libdir_vk`, simplifies the related code and ensures that:
  - LD_LIBRARY_PATH is untouched - otherwise java and friends are broken
  - LD_PRELOAD always uses the DSO with the `$LIB` based path
  - separate json files are produced, each with the full absolute path within - using `$LIB` in there is asking for trouble

Closes: https://github.com/flightlessmango/MangoHud/issues/468
Closes: https://github.com/flightlessmango/MangoHud/issues/906