### PR TITLE
meson: explicitly annotate version.h as dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,8 @@ mangohud_version = vcs_tag(
   input:  'version.h.in',
   output: 'version.h')
 
+mangohud_version_dep = declare_dependency(sources : mangohud_version)
+
 pre_args = [
   '-D__STDC_CONSTANT_MACROS',
   '-D__STDC_FORMAT_MACROS',

--- a/src/meson.build
+++ b/src/meson.build
@@ -178,6 +178,7 @@ mangohud_static_lib = static_library(
     ],
   gnu_symbol_visibility : 'hidden',
   dependencies : [
+    mangohud_version_dep,
     vulkan_wsi_deps,
     dearimgui_dep,
     spdlog_dep,


### PR DESCRIPTION
Currently we list the custom_target (aka vcs_tag() as part of the sources. Although since it's not an explicit dependency meson/ninja are free to compile the C/C++ files, before the file is generated.

Closes: https://github.com/flightlessmango/MangoHud/issues/862

@sl1pkn07 can you give this a try? Don't have a 48 thread system to test and I doubt you're willing to ship me one :stuck_out_tongue_winking_eye: 