### PR TITLE
Install MangoHud.x86.json in pkgbuild/PKGBUILD

### DIFF
--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -76,4 +76,5 @@ package_lib32-mangohud() {
   DESTDIR="${pkgdir}" ninja -C build32 install
   rm -rf "$pkgdir/usr/bin"
   rm -rf "$pkgdir/usr/share"
+  install -m644 -Dt "$pkgdir/usr/share/vulkan/implicit_layer.d" "$srcdir/build32/src/MangoHud.x86.json"
 }


### PR DESCRIPTION
When packaging `lib32-mangohud`,  the path `/usr/share` is removed recursively.

Which also include file `/usr/share/vulkan/implicit_layer.d/MangoHud.x86.json`, cause mangohud fail to run on 32-bit application (for example borderlands 2).

This commit add back the file after removing `/usr/share`.