### PR TITLE
Don't build 32bit version of mangoapp and mangoctl in pkgbuild/PKGBUILD

### DIFF
--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -60,6 +60,8 @@ build() {
 
   arch-meson mangohud build32 \
     --libdir=lib32 \
+    -Dmangoapp=false \
+    -Dmangohudctl=false \
     ${_build_args}
 
   ninja -C build32


### PR DESCRIPTION
Those executable is not included in the package anyway.