### PR TITLE
Always use bundled/subproject vulkan headers/xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Install necessary development packages.
 - meson >=0.54
 - ninja (ninja-build)
 - glslang
-- vulkan headers if using `-Duse_system_vulkan=enabled` option with `meson`
 - libGL/libEGL (libglvnd, mesa-common-dev, mesa-libGL-devel etc)
 - X11 (libx11-dev)
 - XNVCtrl (libxnvctrl-dev), optional, use `-Dwith_xnvctrl=disabled` option with `meson` to disable

--- a/build-source.sh
+++ b/build-source.sh
@@ -24,8 +24,6 @@ tar -xf ${TAR_NAME} --strip 1 -C ${NAME}
 rm ${NAME}/include/nvml.h
 # minhook not needed
 rm -r ${NAME}/modules/minhook
-# vulkan headers from system
-rm -r ${NAME}/subprojects/Vulkan-Headers-*
 # spdlog from system
 rm -r ${NAME}/subprojects/spdlog-*
 # remove some dear imgui clutter

--- a/meson.build
+++ b/meson.build
@@ -165,21 +165,9 @@ else
   dep_rt = null_dep
 endif
 
-dep_vulkan = dependency('vulkan', required: get_option('use_system_vulkan'))
-if dep_vulkan.found() and not get_option('use_system_vulkan').disabled()
-  datadir = get_option('vulkan_datadir')
-  if datadir == ''
-    datadir = get_option('datadir')
-  endif
-  if not datadir.startswith('/')
-    datadir = get_option('prefix') / datadir
-  endif
-  vk_api_xml = files(datadir / 'vulkan/registry/vk.xml')
-else
-  vkh_sp = subproject('vulkan-headers')
-  vk_api_xml = vkh_sp.get_variable('vulkan_api_xml')
-  dep_vulkan = vkh_sp.get_variable('vulkan_headers_dep')
-endif
+vkh_sp = subproject('vulkan-headers')
+vk_api_xml = vkh_sp.get_variable('vulkan_api_xml')
+dep_vulkan = vkh_sp.get_variable('vulkan_headers_dep')
 
 vk_enum_to_str = custom_target(
   'vk_enum_to_str',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,5 @@
 option('glibcxx_asserts', type : 'boolean', value : false)
-option('use_system_vulkan', type : 'feature', value : 'disabled', description: 'Use system vulkan headers instead of the provided ones')
 option('use_system_spdlog', type : 'feature', value : 'disabled', description: 'Use system spdlog library')
-option('vulkan_datadir', type : 'string', value : '', description: 'Path to the system vulkan headers data directory if different from MangoHud\'s datadir')
 option('append_libdir_mangohud', type : 'boolean', value : true, description: 'Append "mangohud" to libdir path or not.')
 option('include_doc', type : 'boolean', value : true, description: 'Include the example config, man pages, appstream files etc.')
 option('with_nvml', type : 'combo', value : 'enabled', choices: ['enabled', 'system', 'disabled'], description: 'Enable NVML support')

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -25,7 +25,7 @@ sha256sums=('SKIP'
             '3c38f275d5792b1286391102594329e98b17737924b344f98312ab09929b74be'
             'b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e')
 
-_build_args="-Dappend_libdir_mangohud=false -Dwith_xnvctrl=disabled -Duse_system_vulkan=enabled -Dmangoapp_layer=true -Dtests=disabled"
+_build_args="-Dappend_libdir_mangohud=false -Dwith_xnvctrl=disabled -Dmangoapp_layer=true -Dtests=disabled"
 
 pkgver() {
   cd "$srcdir/mangohud"


### PR DESCRIPTION
Newer versions of the XML and headers don't play nice. In particular the
VK_LAYER_EXPORT macro was removed and the XML was reworked quite
significantly, so our generator no longer works.

I was able to port newer version of the generator scripts from Mesa
(where these were copied from originally), although these new scripts
don't work with the old XML.

Just drop the meson knobs and always use the subproject version. In
practical terms this is identical to what Mesa also does... So Debian
DFSG should not be _too_ upset.

Closes: https://github.com/flightlessmango/MangoHud/issues/927