### PR TITLE
meson: make libMangoHud.so append_libdir_mangohud aware

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -183,6 +183,7 @@ mangohud_shared_lib = shared_library(
   'MangoHud',
   objects: mangohud_static_lib.extract_all_objects(),
   link_with: mangohud_static_lib,
+  install_dir : libdir_mangohud,
   install: true
 )
 


### PR DESCRIPTION
The library does not honour the correct install location. Seems like it was broken for a while and I didn't catch it with my recent rework... Since all the scripts flip the default "true" to "false" :facepalm: