### PR TITLE
meson: restrict most libMangoHud.so symbols

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -183,6 +183,7 @@ mangohud_shared_lib = shared_library(
   'MangoHud',
   objects: mangohud_static_lib.extract_all_objects(),
   link_with: mangohud_static_lib,
+  link_args : link_args,
   install_dir : libdir_mangohud,
   install: true
 )


### PR DESCRIPTION
With the introduction of the static library, we forgot the version script. As a result we were spilling all the internal symbols.

Fixes: d4aa74c ("Create static and shared libs separately")
Closes: https://github.com/flightlessmango/MangoHud/issues/933