### PR TITLE
add missing vulkan-headers and it's patch to PKGBUILD

### DIFF
--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Simon Hallsten <flightlessmangoyt@gmail.com>
 
 pkgname=('mangohud' 'lib32-mangohud')
-pkgver=0.6.6.1.r178.g4341843
+pkgver=0.6.8.r140.g1b3f8b2
 pkgrel=1
 pkgdesc="Vulkan and OpenGL overlay to display performance information"
 arch=('x86_64')
@@ -9,21 +9,29 @@ makedepends=('dbus' 'gcc' 'meson' 'python-mako' 'libx11' 'lib32-libx11' 'git' 'p
 depends=('glslang' 'libglvnd' 'lib32-libglvnd' 'glew' 'glfw-x11')
 replaces=('vulkan-mesa-layer-mango')
 license=('MIT')
-source=("mangohud"::"git+https://github.com/flightlessmango/MangoHud.git#branch=master"
+source=(
+        "mangohud"::"git+https://github.com/flightlessmango/MangoHud.git#branch=master"
         "mangohud-minhook"::"git+https://github.com/flightlessmango/minhook.git"
         "imgui-v1.81.tar.gz::https://github.com/ocornut/imgui/archive/v1.81.tar.gz"
         "imgui-1.81-1-wrap.zip::https://wrapdb.mesonbuild.com/v1/projects/imgui/1.81/1/get_zip"
         "spdlog-1.8.5.tar.gz::https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz"
         "spdlog-1.8.5-1-wrap.zip::https://wrapdb.mesonbuild.com/v1/projects/spdlog/1.8.5/1/get_zip"
-        "nlohmann_json-3.10.5.zip::https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip")
+        "nlohmann_json-3.10.5.zip::https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip"
+        "vulkan-headers-1.2.158.tar.gz::https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.158.tar.gz"
+        "vulkan-headers-1.2.158-2-wrap.zip::https://wrapdb.mesonbuild.com/v2/vulkan-headers_1.2.158-2/get_patch"
+        )
 
-sha256sums=('SKIP'
+sha256sums=(
+            'SKIP'
             'SKIP'
             'f7c619e03a06c0f25e8f47262dbc32d61fd033d2c91796812bf0f8c94fca78fb'
             '6d00b442690b6a5c5d8f898311daafbce16d370cf64f53294c3b8c5c661e435f'
             '944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8'
             '3c38f275d5792b1286391102594329e98b17737924b344f98312ab09929b74be'
-            'b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e')
+            'b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e'
+            "53361271cfe274df8782e1e47bdc9e61b7af432ba30acbfe31723f9df2c257f3"
+            "860358cf5e73f458cd1e88f8c38116d123ab421d5ce2e4129ec38eaedd820e17"
+            )
 
 _build_args="-Dappend_libdir_mangohud=false -Dwith_xnvctrl=disabled -Dmangoapp_layer=true -Dtests=disabled"
 
@@ -46,6 +54,7 @@ prepare() {
   ln -sv "$srcdir/single_include" subprojects/nlohmann_json-3.10.5/
   ln -sv "$srcdir/LICENSE.MIT" subprojects/nlohmann_json-3.10.5/
   ln -sv "$srcdir/meson.build" subprojects/nlohmann_json-3.10.5/
+  ln -sv "$srcdir/Vulkan-Headers-1.2.158" subprojects
 }
 
 build() {


### PR DESCRIPTION
after commit bc282cf300ed5b6831177cf3e6753bc20f48e942, system's vulkan-header can no longer be used and need to be added as a subproject.

    mangohud/meson.build:168:0: ERROR: Automatic wrap-based subproject downloading is disabled
    
    A full log can be found at /tmp/makepkg/mangohud/src/build64/meson-logs/meson-log.txt
    ==> ERROR: A failure occurred in build().
        Aborting...

This add vulkan-headers and wrap patch to source, then link to subprojects directory..