### PR TITLE
Add preset to MangoHud.conf and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `permit_upload`                    | Allow uploading of logs to Flightlessmango.com                                        |
 | `picmip`                           | Mip-map LoD bias. Negative values will increase texture sharpness (and aliasing). Positive values will increase texture blurriness `-16`-`16` |
 | `position=`                        | Location of the HUD: `top-left` (default), `top-right`, `middle-left`, `middle-right`, `bottom-left`, `bottom-right`, `top-center`, `bottom-center` |
+| `preset=`                           | Set a pre-defined preset to be used, default is `-1`. Available presets:<br>`0` (No Hud)<br> `1` (FPS Only)<br> `2` (Horizontal)<br> `3` (Extended)<br> `4` (Detailed)<br>Own presets can be defined by creating a [presets.conf](data/presets.conf) file in `~/.config/MangoHud/`.                      |
 | `procmem`<br>`procmem_shared`, `procmem_virt`| Displays process' memory usage: resident, shared and/or virtual. `procmem` (resident) also toggles others off if disabled |
 | `ram`<br>`vram`                    | Display system RAM/VRAM usage                                                         |
 | `read_cfg`                         | Add to MANGOHUD_CONFIG as first parameter to also load config file. Otherwise only `MANGOHUD_CONFIG` parameters are used |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -42,7 +42,7 @@
 # -1 = default
 #  0 = no display
 #  1 = fps only
-#  2 = horizontal viewed
+#  2 = horizontal view
 #  3 = extended
 #  4 = high detailed information
 # preset=-1

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -38,6 +38,15 @@
 ### Legacy layout
 # legacy_layout=0
 
+### pre defined presets
+# -1 = default
+#  0 = no display
+#  1 = fps only
+#  2 = horizontal viewed
+#  3 = extended
+#  4 = high detailed information
+# preset=-1
+
 ### Display custom centered text, useful for a header
 # custom_text_center=
 

--- a/data/presets.conf
+++ b/data/presets.conf
@@ -1,0 +1,10 @@
+[preset 1]
+no_display
+
+[preset 2]
+legacy_layout=0
+cpu_stats=0
+gpu_stats=0
+fps
+fps_only=1
+frametime=0


### PR DESCRIPTION
This PR will add `preset` to the MangoHud.conf and the Readme. Also adds a `presets.conf` example file.