### PR TITLE
Gamescope: Added parameters for scaler

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -163,6 +163,7 @@ static void msg_read_thread(){
                     update_hud_info_with_frametime(sw_stats, params, vendorID, mangoapp_v1->visible_frametime_ns);
 
                 if (msg_size > offsetof(mangoapp_msg_v1, scaler_filter)){
+                    HUDElements.g_scaler = mangoapp_v1->scaler;
                     HUDElements.g_scaler_filter = mangoapp_v1->scaler_filter;
                     if (params.fsr_steam_sharpness < 0)
                         HUDElements.g_fsrSharpness = mangoapp_v1->fsrSharpness;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -162,8 +162,8 @@ static void msg_read_thread(){
                 if (!params.no_display || logger->is_active())
                     update_hud_info_with_frametime(sw_stats, params, vendorID, mangoapp_v1->visible_frametime_ns);
 
-                if (msg_size > offsetof(mangoapp_msg_v1, fsrUpscale)){
-                    HUDElements.g_fsrUpscale = mangoapp_v1->fsrUpscale;
+                if (msg_size > offsetof(mangoapp_msg_v1, scaler_filter)){
+                    HUDElements.g_scaler_filter = mangoapp_v1->scaler_filter;
                     if (params.fsr_steam_sharpness < 0)
                         HUDElements.g_fsrSharpness = mangoapp_v1->fsrSharpness;
                     else

--- a/src/app/mangoapp_proto.h
+++ b/src/app/mangoapp_proto.h
@@ -10,7 +10,7 @@ struct mangoapp_msg_v1 {
 
     uint32_t pid;
     uint64_t visible_frametime_ns;
-    uint8_t fsrUpscale;
+    uint8_t scaler_filter;
     uint8_t fsrSharpness;
     // For debugging
     uint64_t app_frametime_ns;

--- a/src/app/mangoapp_proto.h
+++ b/src/app/mangoapp_proto.h
@@ -17,6 +17,7 @@ struct mangoapp_msg_v1 {
     uint64_t latency_ns;
     uint32_t outputWidth;
     uint32_t outputHeight;
+    uint8_t scaler;
     // WARNING: Always ADD fields, never remove or repurpose fields
 } __attribute__((packed));
 

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -839,31 +839,28 @@ void HudElements::battery(){
 #endif
 }
 
-void HudElements::gamescope_fsr(){
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fsr] && HUDElements.g_fsrUpscale >= 0) {
-        ImguiNextColumnFirstItem();
-        string FSR_TEXT;
-        ImVec4 FSR_COLOR;
-        if (HUDElements.g_fsrUpscale){
-            FSR_TEXT = "ON";
-            FSR_COLOR = HUDElements.colors.fps_value_high;
-        } else {
-            FSR_TEXT = "OFF";
-            FSR_COLOR = HUDElements.colors.fps_value_low;
-        }
+void HudElements::gamescope_scaler_filter(){
+    static const char* const gamescope_upscale_filter[] = {"LINEAR", "NEAREST", "FSR", "NIS"};
+    if (HUDElements.g_scaler_filter < 0 || HUDElements.g_scaler_filter > (int)ARRAY_SIZE(gamescope_upscale_filter))
+        return;
 
-        HUDElements.TextColored(HUDElements.colors.engine, "%s", "FSR");
-        ImguiNextColumnOrNewRow();
-        right_aligned_text(FSR_COLOR, HUDElements.ralign_width, "%s", FSR_TEXT.c_str());
-        if (HUDElements.g_fsrUpscale){
-            if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hide_fsr_sharpness]) {
-                ImguiNextColumnOrNewRow();
-                right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", HUDElements.g_fsrSharpness);
-                ImGui::SameLine(0,1.0f);
-                ImGui::PushFont(HUDElements.sw_stats->font1);
-                HUDElements.TextColored(HUDElements.colors.text, "Sharp");
-                ImGui::PopFont();
-            }
+    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_filter])
+        return;
+
+    ImguiNextColumnFirstItem();
+    HUDElements.TextColored(HUDElements.colors.engine, "%s", "FILTER");
+    ImguiNextColumnOrNewRow();
+    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", gamescope_upscale_filter[HUDElements.g_scaler_filter]);
+
+    // Additional parameters
+    if (HUDElements.g_scaler_filter == 2) { // FSR
+        if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hide_fsr_sharpness]) {
+            ImguiNextColumnOrNewRow();
+            right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", HUDElements.g_fsrSharpness);
+            ImGui::SameLine(0,1.0f);
+            ImGui::PushFont(HUDElements.sw_stats->font1);
+            HUDElements.TextColored(HUDElements.colors.text, "Sharp");
+            ImGui::PopFont();
         }
     }
 }
@@ -1194,7 +1191,7 @@ void HudElements::sort_elements(const std::pair<std::string, std::string>& optio
                                       exec_list.push_back({int(ordered_functions.size() - 1), value});       }
     if (param == "battery")         { ordered_functions.push_back({battery, value});                }
     if (param == "fps_only")        { ordered_functions.push_back({fps_only, value});               }
-    if (param == "fsr")             { ordered_functions.push_back({gamescope_fsr, value});          }
+    if (param == "filter")          { ordered_functions.push_back({gamescope_scaler_filter, value});}
     if (param == "debug")           { ordered_functions.push_back({gamescope_frame_timing, value}); }
     if (param == "gamepad_battery") { ordered_functions.push_back({gamepad_battery, value});        }
     if (param == "frame_count")     { ordered_functions.push_back({frame_count, value});            }
@@ -1240,8 +1237,8 @@ void HudElements::legacy_elements(){
         ordered_functions.push_back({battery,            value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_fan])
         ordered_functions.push_back({fan,                value});
-    if (params->enabled[OVERLAY_PARAM_ENABLED_fsr])
-        ordered_functions.push_back({gamescope_fsr,      value});
+    if (params->enabled[OVERLAY_PARAM_ENABLED_filter])
+        ordered_functions.push_back({gamescope_scaler_filter, value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_throttling_status])
         ordered_functions.push_back({throttling_status,  value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_fps])

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -839,6 +839,20 @@ void HudElements::battery(){
 #endif
 }
 
+void HudElements::gamescope_scaler(){
+    static const char* const gamescope_upscale_scaler[] = {"AUTO", "INTEGER", "FIT", "FILL", "STRETCH"};
+    if (HUDElements.g_scaler < 0 || HUDElements.g_scaler > (int)ARRAY_SIZE(gamescope_upscale_scaler))
+        return;
+
+    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_scaler])
+        return;
+
+    ImguiNextColumnFirstItem();
+    HUDElements.TextColored(HUDElements.colors.engine, "%s", "SCALER");
+    ImguiNextColumnOrNewRow();
+    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", gamescope_upscale_scaler[HUDElements.g_scaler]);
+}
+
 void HudElements::gamescope_scaler_filter(){
     static const char* const gamescope_upscale_filter[] = {"LINEAR", "NEAREST", "FSR", "NIS"};
     if (HUDElements.g_scaler_filter < 0 || HUDElements.g_scaler_filter > (int)ARRAY_SIZE(gamescope_upscale_filter))
@@ -1191,6 +1205,7 @@ void HudElements::sort_elements(const std::pair<std::string, std::string>& optio
                                       exec_list.push_back({int(ordered_functions.size() - 1), value});       }
     if (param == "battery")         { ordered_functions.push_back({battery, value});                }
     if (param == "fps_only")        { ordered_functions.push_back({fps_only, value});               }
+    if (param == "scaler")          { ordered_functions.push_back({gamescope_scaler, value});       }
     if (param == "filter")          { ordered_functions.push_back({gamescope_scaler_filter, value});}
     if (param == "debug")           { ordered_functions.push_back({gamescope_frame_timing, value}); }
     if (param == "gamepad_battery") { ordered_functions.push_back({gamepad_battery, value});        }
@@ -1237,6 +1252,8 @@ void HudElements::legacy_elements(){
         ordered_functions.push_back({battery,            value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_fan])
         ordered_functions.push_back({fan,                value});
+    if (params->enabled[OVERLAY_PARAM_ENABLED_scaler])
+        ordered_functions.push_back({gamescope_scaler,   value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_filter])
         ordered_functions.push_back({gamescope_scaler_filter, value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_throttling_status])
@@ -1258,7 +1275,7 @@ void HudElements::legacy_elements(){
     if (params->enabled[OVERLAY_PARAM_ENABLED_frame_timing])
         ordered_functions.push_back({frame_timing,       value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_frame_count])
-        ordered_functions.push_back({frame_count,         value});
+        ordered_functions.push_back({frame_count,        value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_debug] && !params->enabled[OVERLAY_PARAM_ENABLED_horizontal])
         ordered_functions.push_back({gamescope_frame_timing, value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_gamemode])

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -23,6 +23,7 @@ class HudElements{
         int text_column = 1;
         int table_columns_count = 0;
         int g_scaler_filter = -1;
+        int g_scaler = -1;
         int g_fsrSharpness = -1;
         Clock::time_point last_exec;
         std::vector<std::pair<std::string, std::string>> options;
@@ -65,6 +66,7 @@ class HudElements{
         static void _exec();
         static void battery();
         static void fps_only();
+        static void gamescope_scaler();
         static void gamescope_scaler_filter();
         static void gamescope_frame_timing();
         static void gamepad_battery();

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -22,7 +22,7 @@ class HudElements{
         int place;
         int text_column = 1;
         int table_columns_count = 0;
-        int g_fsrUpscale = -1;
+        int g_scaler_filter = -1;
         int g_fsrSharpness = -1;
         Clock::time_point last_exec;
         std::vector<std::pair<std::string, std::string>> options;
@@ -65,7 +65,7 @@ class HudElements{
         static void _exec();
         static void battery();
         static void fps_only();
-        static void gamescope_fsr();
+        static void gamescope_scaler_filter();
         static void gamescope_frame_timing();
         static void gamepad_battery();
         static void frame_count();

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -77,7 +77,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(battery)                       \
    OVERLAY_PARAM_BOOL(battery_icon)                  \
    OVERLAY_PARAM_BOOL(fps_only)                      \
-   OVERLAY_PARAM_BOOL(fsr)                           \
+   OVERLAY_PARAM_BOOL(filter)                        \
    OVERLAY_PARAM_BOOL(mangoapp_steam)                \
    OVERLAY_PARAM_BOOL(debug)                         \
    OVERLAY_PARAM_BOOL(gamepad_battery)               \

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -77,6 +77,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(battery)                       \
    OVERLAY_PARAM_BOOL(battery_icon)                  \
    OVERLAY_PARAM_BOOL(fps_only)                      \
+   OVERLAY_PARAM_BOOL(scaler)                        \
    OVERLAY_PARAM_BOOL(filter)                        \
    OVERLAY_PARAM_BOOL(mangoapp_steam)                \
    OVERLAY_PARAM_BOOL(debug)                         \


### PR DESCRIPTION
As Gamescope has also implemented NIS, a single FSR output is really limited. They might add even more filters in the future, so it would be nice to have a singular output for all filters.

Also there is currently no output for the used scaler, which will be a easier to set option if https://github.com/ValveSoftware/gamescope/pull/893 gets merged.

I have repurposed the FSR field, please forgive me. I think a double inclusion of FSR would be wasteful.
Feedback regarding this situation is appreciated and necessary. Thank you!