### PR TITLE
Remove debug printf in HudElements::battery

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -834,7 +834,6 @@ void HudElements::battery(){
                 HUDElements.TextColored(HUDElements.colors.text, "%%");
             }
             if (Battery_Stats.current_watt != 0) {
-                printf("%i\n", HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_battery_watt]);
                 if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_battery_watt]){
                     ImguiNextColumnOrNewRow();
                     right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", Battery_Stats.current_watt);


### PR DESCRIPTION
This `printf` currently keeps printing `1` or `0` depending on the `battery_watt` setting.
I belive it was just forgotten here.