### PR TITLE
Add ability to toggle through presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `permit_upload`                    | Allow uploading of logs to Flightlessmango.com                                        |
 | `picmip`                           | Mip-map LoD bias. Negative values will increase texture sharpness (and aliasing). Positive values will increase texture blurriness `-16`-`16` |
 | `position=`                        | Location of the HUD: `top-left` (default), `top-right`, `middle-left`, `middle-right`, `bottom-left`, `bottom-right`, `top-center`, `bottom-center` |
-| `preset=`                           | Set a pre-defined preset to be used, default is `-1`. Available presets:<br>`0` (No Hud)<br> `1` (FPS Only)<br> `2` (Horizontal)<br> `3` (Extended)<br> `4` (Detailed)<br>Own presets can be defined by creating a [presets.conf](data/presets.conf) file in `~/.config/MangoHud/`.                      |
+| `preset=`                          | Comma separated list of one or more presets. Default is `-1,0,1,2,3,4`. Available presets:<br>`0` (No Hud)<br> `1` (FPS Only)<br> `2` (Horizontal)<br> `3` (Extended)<br> `4` (Detailed)<br>User defined presets can be created by using a [presets.conf](data/presets.conf) file in `~/.config/MangoHud/`.                      |
 | `procmem`<br>`procmem_shared`, `procmem_virt`| Displays process' memory usage: resident, shared and/or virtual. `procmem` (resident) also toggles others off if disabled |
 | `ram`<br>`vram`                    | Display system RAM/VRAM usage                                                         |
 | `read_cfg`                         | Add to MANGOHUD_CONFIG as first parameter to also load config file. Otherwise only `MANGOHUD_CONFIG` parameters are used |
@@ -405,6 +405,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `throttling_status`                | Show if GPU is throttling based on Power, current, temp or "other" (Only shows if throttling is currently happening). Currently disabled by default for Nvidia as it causes lag on 3000 series |
 | `time`<br>`time_format=%T`         | Display local time. See [std::put_time](https://en.cppreference.com/w/cpp/io/manip/put_time) for formatting help. NOTE: Sometimes apps may set `TZ` (timezone) environment variable to UTC/GMT |
 | `toggle_fps_limit`                 | Cycle between FPS limits. Defaults to `Shift_L+F1`                                    |
+| `toggle_preset`                    | Cycle between Presets. Defaults to `Shift_R+F10`                                      |
 | `toggle_hud=`<br>`toggle_logging=` | Modifiable toggle hotkeys. Default are `Shift_R+F12` and `Shift_L+F2`, respectively   |
 | `toggle_hud_position`              | Toggle MangoHud postion. Default is `R_Shift+F11`                                     |
 | `trilinear`                        | Force trilinear filtering                                                             |

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -98,12 +98,12 @@ static void ctrl_thread(){
             case 0:
                 break;
             case 1:
-                parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"));
+                parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
                 break;
             case 2:
                 break;
             case 3:
-                parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"));
+                parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
                 break;
         }
         {
@@ -286,7 +286,7 @@ int main(int, char**)
 
     // Setup Platform/Renderer backends
     int control_client = -1;
-    parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"));
+    parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
     create_fonts(nullptr, params, sw_stats.font1, sw_stats.font_text);
     HUDElements.convert_colors(params);
     init_cpu_stats(params);

--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -75,7 +75,7 @@ void imgui_init()
     if (is_blacklisted())
         return;
 
-    parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"));
+    parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
     _params = &params;
 
    //check for blacklist item in the config file

--- a/src/keybinds.cpp
+++ b/src/keybinds.cpp
@@ -9,6 +9,7 @@ void check_keybinds(struct overlay_params& params, uint32_t vendorID){
    auto now = Clock::now(); /* us */
    auto elapsedF2 = now - last_f2_press;
    auto elapsedFpsLimitToggle = now - toggle_fps_limit_press;
+   auto elapsedPresetToggle = now - toggle_preset_press;
    auto elapsedF12 = now - last_f12_press;
    auto elapsedReloadCfg = now - reload_cfg_press;
    auto elapsedUpload = now - last_upload_press;
@@ -50,6 +51,19 @@ void check_keybinds(struct overlay_params& params, uint32_t vendorID){
       }
    }
 
+   if (elapsedPresetToggle >= keyPressDelay &&
+       keys_are_pressed(params.toggle_preset)) {
+     toggle_preset_press = now;
+     size_t size = params.preset.size();
+     for (size_t i = 0; i < size; i++){
+       if(params.preset[i] == current_preset) {
+         current_preset = params.preset[++i%size];
+         parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), true);
+         break;
+       }
+     }
+   }
+
    if (elapsedF12 >= keyPressDelay &&
        keys_are_pressed(params.toggle_hud)) {
       last_f12_press = now;
@@ -58,7 +72,7 @@ void check_keybinds(struct overlay_params& params, uint32_t vendorID){
 
    if (elapsedReloadCfg >= keyPressDelay &&
        keys_are_pressed(params.reload_cfg)) {
-      parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"));
+      parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
       _params = &params;
       reload_cfg_press = now;
    }

--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -11,7 +11,7 @@
 typedef unsigned long KeySym;
 #endif
 
-Clock::time_point last_f2_press, toggle_fps_limit_press , last_f12_press, reload_cfg_press, last_upload_press;
+Clock::time_point last_f2_press, toggle_fps_limit_press, toggle_preset_press, last_f12_press, reload_cfg_press, last_upload_press;
 
 #if defined(HAVE_X11)
 static inline bool keys_are_pressed(const std::vector<KeySym>& keys) {

--- a/src/notify.cpp
+++ b/src/notify.cpp
@@ -25,7 +25,7 @@ static void fileChanged(notify_thread *nt) {
                 // In the case of IN_DELETE_SELF, some editors may do a save-to-temp-file/delete-original/move-temp-file
                 // so sleep a little to let file to be replaced
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                parse_overlay_config(&local_params, getenv("MANGOHUD_CONFIG"));
+                parse_overlay_config(&local_params, getenv("MANGOHUD_CONFIG"), false);
                 if ((event->mask & IN_DELETE_SELF) || (nt->params->config_file_path != local_params.config_file_path)) {
                     SPDLOG_DEBUG("Watching config file: {}", local_params.config_file_path.c_str());
                     inotify_rm_watch(nt->fd, nt->wd);

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -51,6 +51,7 @@ vector<float> frametime_data(200,0.f);
 int fan_speed;
 fcatoverlay fcatstatus;
 std::string drm_dev;
+int current_preset;
 
 void init_spdlog()
 {

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -90,6 +90,7 @@ extern overlay_params *_params;
 extern double min_frametime, max_frametime;
 extern bool steam_focused;
 extern int fan_speed;
+extern int current_preset;
 
 void init_spdlog();
 void overlay_new_frame(const struct overlay_params& params);

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -129,6 +129,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(gl_dont_flip)                \
    OVERLAY_PARAM_CUSTOM(toggle_hud)                  \
    OVERLAY_PARAM_CUSTOM(toggle_hud_position)         \
+   OVERLAY_PARAM_CUSTOM(toggle_preset)               \
    OVERLAY_PARAM_CUSTOM(toggle_fps_limit)            \
    OVERLAY_PARAM_CUSTOM(toggle_logging)              \
    OVERLAY_PARAM_CUSTOM(reload_cfg)                  \
@@ -179,7 +180,6 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(fcat_overlay_width)          \
    OVERLAY_PARAM_CUSTOM(picmip)                      \
    OVERLAY_PARAM_CUSTOM(af)                          \
-   OVERLAY_PARAM_CUSTOM(preset)                      \
    OVERLAY_PARAM_CUSTOM(text_outline_color)          \
    OVERLAY_PARAM_CUSTOM(text_outline_thickness)      \
    OVERLAY_PARAM_CUSTOM(fps_text)                    \
@@ -271,6 +271,7 @@ struct overlay_params {
    float background_alpha, alpha;
    float cellpadding_y;
    std::vector<KeySym> toggle_hud;
+   std::vector<KeySym> toggle_preset;
    std::vector<KeySym> toggle_fps_limit;
    std::vector<KeySym> toggle_logging;
    std::vector<KeySym> reload_cfg;
@@ -297,7 +298,7 @@ struct overlay_params {
    unsigned short fcat_overlay_width;
    int picmip;
    int af;
-   int preset;
+   std::vector<int> preset;
    size_t font_params_hash;
    unsigned text_outline_color;
    float text_outline_thickness;
@@ -306,7 +307,7 @@ struct overlay_params {
 const extern char *overlay_param_names[];
 
 void parse_overlay_config(struct overlay_params *params,
-                       const char *env);
+                       const char *env, bool ignore_preset);
 void presets(int preset, struct overlay_params *params);
 bool parse_preset_config(int preset, struct overlay_params *params);
 void add_to_options(struct overlay_params *params, std::string option, std::string value);

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1896,7 +1896,7 @@ static VkResult overlay_CreateInstance(
    if (is_blacklisted())
       return result;
 
-   parse_overlay_config(&instance_data->params, getenv("MANGOHUD_CONFIG"));
+   parse_overlay_config(&instance_data->params, getenv("MANGOHUD_CONFIG"), false);
    _params = &instance_data->params;
 
    //check for blacklist item in the config file

--- a/src/win/d3d_shared.cpp
+++ b/src/win/d3d_shared.cpp
@@ -13,7 +13,7 @@ void init_d3d_shared(){
     vendorID = get_device_id_dxgi();
     if (cfg_inited)
         return;
-     parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"));
+     parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
      _params = &params;
      cfg_inited = true;
     //  init_cpu_stats(params);


### PR DESCRIPTION
Allow the user to toggle presets with a keybind similar to `toggle_fps_limit`.  This change updates the `preset` option to a list of presets instead of a single preset.  Just like with `fps_limit`, when loading the config for mangohud, the first listed preset is chosen, and just like with `fps_limit`, when the user presses the keybind associated with `toggle_preset`, the next (or the first if the end of the list is reached) preset is loaded.

Closes #1048 