### PR TITLE
Add note about zenpower3

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,8 @@ Because comma is also used as option delimiter and needs to be escaped for value
 
 *Note: RAPL is currently used for Intel CPUs to show power draw with `cpu_power` which may be unreadable for non-root users due to [vulnerability](https://platypusattack.com/). The corresponding `energy_uj` file has to be readable by corresponding user, e.g. by running `chmod o+r /sys/class/powercap/intel-rapl\:0/energy_uj` as root, else the power shown will be **0 W**, though having the file readable may potentially be a security vulnerability persisting until system reboots.*
 
+*Note: The [zenpower3](https://git.exozy.me/a/zenpower3) kernel driver must be installed to show the power draw of Ryzen CPUs.*
+
 ## Vsync
 
 ### OpenGL Vsync


### PR DESCRIPTION
To avoid confusion, add note about the necessity of having the zenpower3 driver installed to show the power draw of AMD Ryzen CPUs