### PR TITLE
Use k10-temp power sensors if exist

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -296,9 +296,23 @@ bool CPUStats::UpdateCpuTemp() {
 static bool get_cpu_power_k10temp(CPUPowerData* cpuPowerData, float& power) {
     CPUPowerData_k10temp* powerData_k10temp = (CPUPowerData_k10temp*)cpuPowerData;
 
+    if(powerData_k10temp->corePowerFile || powerData_k10temp->socPowerFile)
+    {
+        rewind(powerData_k10temp->corePowerFile);
+        rewind(powerData_k10temp->socPowerFile);
+        fflush(powerData_k10temp->corePowerFile);
+        fflush(powerData_k10temp->socPowerFile);
+        int corePower, socPower;
+        if (fscanf(powerData_k10temp->corePowerFile, "%d", &corePower) != 1)
+            goto voltagebased;
+        if (fscanf(powerData_k10temp->socPowerFile, "%d", &socPower) != 1)
+            goto voltagebased;
+        power = (corePower + socPower) / 1000000;
+        return true;
+    }
+    voltagebased:
     if (!powerData_k10temp->coreVoltageFile || !powerData_k10temp->coreCurrentFile || !powerData_k10temp->socVoltageFile || !powerData_k10temp->socCurrentFile)
         return false;
-
     rewind(powerData_k10temp->coreVoltageFile);
     rewind(powerData_k10temp->coreCurrentFile);
     rewind(powerData_k10temp->socVoltageFile);

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -72,12 +72,18 @@ struct CPUPowerData_k10temp : public CPUPowerData {
          fclose(this->socVoltageFile);
       if(this->socCurrentFile)
          fclose(this->socCurrentFile);
+      if(this->corePowerFile)
+         fclose(this->corePowerFile);
+      if(this->socPowerFile)
+         fclose(this->socPowerFile);
    };
 
    FILE* coreVoltageFile {nullptr};
    FILE* coreCurrentFile {nullptr};
    FILE* socVoltageFile {nullptr};
    FILE* socCurrentFile {nullptr};
+   FILE* corePowerFile {nullptr};
+   FILE* socPowerFile {nullptr};
 };
 
 struct CPUPowerData_zenpower : public CPUPowerData {


### PR DESCRIPTION
For chimeraos we are preparing for updating k10temp to output a powerfile to userspace.
The full patch is [available here](https://github.com/ChimeraOS/linux-chimeraos/blob/main/linux/0001-k10temp-add-voltage-and-current-monitoring.patch) 

I also had updated mangohud, and confirmed it is indeed using the power sensors now.

I tried to keep it backwards compatible, but if I missed something there please let me know :)
