### PR TITLE
mangoapp: Use glXQueryCurrentRendererIntegerMESA if available

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -295,13 +295,20 @@ int main(int, char**)
     window_size = ImVec2(params.width, params.height);
     deviceName = (char*)glGetString(GL_RENDERER);
     sw_stats.deviceName = deviceName;
-    if (deviceName.find("Radeon") != std::string::npos
-    || deviceName.find("AMD") != std::string::npos){
-        vendorID = 0x1002;
-    } else if (deviceName.find("Intel") != std::string::npos) {
-        vendorID = 0x8086;
+
+    #define GLX_RENDERER_VENDOR_ID_MESA 0x8183
+    auto pfn_glXQueryCurrentRendererIntegerMESA = (Bool (*)(int, unsigned int*)) (glfwGetProcAddress("glXQueryCurrentRendererIntegerMESA"));
+    if (pfn_glXQueryCurrentRendererIntegerMESA) {
+        pfn_glXQueryCurrentRendererIntegerMESA(GLX_RENDERER_VENDOR_ID_MESA, &vendorID);
     } else {
-        vendorID = 0x10de;
+        if (deviceName.find("Radeon") != std::string::npos
+        || deviceName.find("AMD") != std::string::npos){
+            vendorID = 0x1002;
+        } else if (deviceName.find("Intel") != std::string::npos) {
+            vendorID = 0x8086;
+        } else {
+            vendorID = 0x10de;
+        }
     }
     init_gpu_stats(vendorID, 0, params);
     init_system_info();

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -927,7 +927,7 @@ void HudElements::gamescope_frame_timing(){
         static std::vector<float>::iterator min, max;
         static double min_time = 0.0f;
         static double max_time = 50.0f;
-        if (HUDElements.gamescope_debug_app.size() > 0){
+        if (HUDElements.gamescope_debug_app.size() > 0 && HUDElements.gamescope_debug_app.back() > -1){
             ImguiNextColumnFirstItem();
             ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
             ImGui::PushFont(HUDElements.sw_stats->font1);


### PR DESCRIPTION
This is the best way to get vendor IDs instead of hardcoding based on the GL_RENDERER vendor string.