### PR TITLE
integrate zenergy into Mangohud

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Because comma is also used as option delimiter and needs to be escaped for value
 
 *Note: RAPL is currently used for Intel CPUs to show power draw with `cpu_power` which may be unreadable for non-root users due to [vulnerability](https://platypusattack.com/). The corresponding `energy_uj` file has to be readable by corresponding user, e.g. by running `chmod o+r /sys/class/powercap/intel-rapl\:0/energy_uj` as root, else the power shown will be **0 W**, though having the file readable may potentially be a security vulnerability persisting until system reboots.*
 
-*Note: The [zenpower3](https://git.exozy.me/a/zenpower3) kernel driver must be installed to show the power draw of Ryzen CPUs.*
+*Note: The [zenpower3](https://git.exozy.me/a/zenpower3) or [zenergy](https://github.com/boukehaarsma23/zenergy) kernel driver must be installed to show the power draw of Ryzen CPUs.*
 
 ## Vsync
 

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -50,6 +50,7 @@ typedef struct CPUData_ {
 enum {
    CPU_POWER_K10TEMP,
    CPU_POWER_ZENPOWER,
+   CPU_POWER_ZENERGY,
    CPU_POWER_RAPL,
    CPU_POWER_AMDGPU
 };
@@ -100,6 +101,23 @@ struct CPUPowerData_zenpower : public CPUPowerData {
 
    FILE* corePowerFile {nullptr};
    FILE* socPowerFile {nullptr};
+};
+
+struct CPUPowerData_zenergy : public CPUPowerData {
+   CPUPowerData_zenergy() {
+      this->source = CPU_POWER_ZENERGY;
+      this->lastCounterValue = 0;
+      this->lastCounterValueTime = Clock::now();
+   };
+
+   ~CPUPowerData_zenergy() {
+      if(this->energyCounterFile)
+         fclose(this->energyCounterFile);
+   };
+
+   FILE* energyCounterFile {nullptr};
+   uint64_t lastCounterValue;
+   Clock::time_point lastCounterValueTime;
 };
 
 struct CPUPowerData_rapl : public CPUPowerData {


### PR DESCRIPTION
Reuses most of the RAPL code paths and is based on the old AMD_ENERGY driver with some modifications so it does not have the vulnerability that had.

The repo can be [found here](https://github.com/BoukeHaarsma23/zenergy).

I have published an [AUR package](https://aur.archlinux.org/packages/zenergy-dkms-git) which the Arch guys can use. 

Closes #1056 