### PR TITLE
Fix small CPU power usage value bug

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -335,7 +335,7 @@ void HudElements::cpu_stats(){
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_power]){
             ImguiNextColumnOrNewRow();
             char str[16];
-            snprintf(str, sizeof(str), "%.1f", gpu_info.powerUsage);
+            snprintf(str, sizeof(str), "%.1f", cpuStats.GetCPUDataTotal().power);
             if (strlen(str) > 4)
                 right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.0f", cpuStats.GetCPUDataTotal().power);
             else


### PR DESCRIPTION
Check CPU power string length instead of GPU power string length for determining whether the CPU power value should be displayed as a whole number or with a decimal. #1089