### PR TITLE
Add core_bars for a per CPU core load histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `control=`                         | Sets up a unix socket with a specific name that can be connected to with mangohud-control.<br>I.e. `control=mangohud` or `control=mangohud-%p` (`%p` will be replaced by process id)    |
 | `core_load_change`                 | Change the colors of cpu core loads, uses the same data from `cpu_load_value` and `cpu_load_change` |
 | `core_load`                        | Display load & frequency per core                                                     |
+| `core_bars`                        | Change the display of `core_load` from numbers to vertical bars                       |
 | `cpu_load_change`                  | Change the color of the CPU load depending on load                                    |
 | `cpu_load_color`                   | Set the colors for the gpu load change low, medium and high. e.g `cpu_load_color=0000FF,00FFFF,FF00FF` |
 | `cpu_load_value`                   | Set the values for medium and high load e.g `cpu_load_value=50,90`                    |

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -348,10 +348,50 @@ void HudElements::cpu_stats(){
     }
 }
 
+
+static float get_core_load_stat(void*,int);
+static float get_core_load_stat(void *data, int idx){
+    return ((CPUStats *)data)->GetCPUData().at(idx).percent;
+}
+
 void HudElements::core_load(){
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_core_load]){
-         for (const CPUData &cpuData : cpuStats.GetCPUData())
-         {
+    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_core_load])
+        return;
+
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_core_bars]){
+        ImguiNextColumnFirstItem();
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
+            ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
+            HUDElements.TextColored(HUDElements.colors.cpu, "CPU Cores");
+            ImGui::TableSetColumnIndex(ImGui::TableGetColumnCount() - 1);
+            ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
+            ImguiNextColumnFirstItem();
+        }
+        char hash[40];
+        snprintf(hash, sizeof(hash), "##%s", overlay_param_names[OVERLAY_PARAM_ENABLED_core_bars]);
+        ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+        float width, height = 0;
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal]){
+            width = 150;
+            height = HUDElements.params->font_size;
+        } else {
+            width = ImGui::GetWindowContentRegionWidth();
+            height = 50;
+        }
+
+        if (ImGui::BeginChild("core_bars_window", ImVec2(width, height))) {
+            ImGui::PlotHistogram(hash, get_core_load_stat, &cpuStats,
+                                cpuStats.GetCPUData().size(), 0,
+                                NULL, 0.0, 100.0,
+                                ImVec2(width, height));
+        }
+        ImGui::EndChild();
+        ImGui::PopFont();
+        ImGui::PopStyleColor();
+    } else {
+        for (const CPUData &cpuData : cpuStats.GetCPUData())
+        {
             ImguiNextColumnFirstItem();
             HUDElements.TextColored(HUDElements.colors.cpu, "CPU");
             ImGui::SameLine(0, 1.0f);
@@ -386,7 +426,7 @@ void HudElements::core_load(){
             ImGui::PushFont(HUDElements.sw_stats->font1);
             HUDElements.TextColored(HUDElements.colors.text, "MHz");
             ImGui::PopFont();
-         }
+        }
     }
 }
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -566,6 +566,7 @@ parse_overlay_env(struct overlay_params *params,
          params->enabled[OVERLAY_PARAM_ENABLED_engine_short_names] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_dynamic_frame_timing] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit] = 0;
+         params->enabled[OVERLAY_PARAM_ENABLED_core_bars] = false;
       }
 #define OVERLAY_PARAM_BOOL(name)                                       \
       if (!strcmp(#name, key)) {                                       \
@@ -591,6 +592,7 @@ static void set_param_defaults(struct overlay_params *params){
    params->enabled[OVERLAY_PARAM_ENABLED_fps] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_frame_timing] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_core_load] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_core_bars] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_power] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp] = false;
@@ -750,6 +752,7 @@ parse_overlay_config(struct overlay_params *params,
          params->enabled[OVERLAY_PARAM_ENABLED_dynamic_frame_timing] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit] = 0;
          params->enabled[OVERLAY_PARAM_ENABLED_duration] = false;
+         params->enabled[OVERLAY_PARAM_ENABLED_core_bars] = false;
          params->options.erase("full");
       }
       for (auto& it : params->options) {

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -29,6 +29,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(fps)                           \
    OVERLAY_PARAM_BOOL(frame_timing)                  \
    OVERLAY_PARAM_BOOL(core_load)                     \
+   OVERLAY_PARAM_BOOL(core_bars)                     \
    OVERLAY_PARAM_BOOL(cpu_temp)                      \
    OVERLAY_PARAM_BOOL(cpu_power)                     \
    OVERLAY_PARAM_BOOL(gpu_temp)                      \


### PR DESCRIPTION
Decided to take a stab at the core histogram I mentioned in #1038 

Not sure if it solves OP's problem there, but for me I find that it helps get a rough idea of the structure of the CPU load.

![Screenshot](https://github.com/flightlessmango/MangoHud/assets/2588851/6480dd3b-7053-4ef2-82df-b71e3da5ae2c)
