### PR TITLE
Use vulkan/GL device name

### DIFF
--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -146,7 +146,7 @@ void imgui_create(void *ctx, const gl_wsi plat)
 
     SPDLOG_DEBUG("GL device id: {:04X}", device_id);
     init_gpu_stats(vendorID, device_id, params);
-    sw_stats.gpuName = gpu = get_device_name(vendorID, deviceID);
+    sw_stats.gpuName = gpu = deviceName;
     SPDLOG_DEBUG("gpu: {}", gpu);
     // Setup Dear ImGui context
     IMGUI_CHECKVERSION();

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -1023,26 +1023,6 @@ void init_system_info(){
 #endif
 }
 
-std::string get_device_name(uint32_t vendorID, uint32_t deviceID)
-{
-   string desc;
-#ifdef __linux__
-   if (pci_ids.find(vendorID) == pci_ids.end())
-      parse_pciids();
-
-   desc = pci_ids[vendorID].second[deviceID].desc;
-   size_t position = desc.find("[");
-   if (position != std::string::npos) {
-      desc = desc.substr(position);
-      string chars = "[]";
-      for (char c: chars)
-         desc.erase(remove(desc.begin(), desc.end(), c), desc.end());
-   }
-   trim(desc);
-#endif
-   return desc;
-}
-
 void update_fan(){
    // This just handles steam deck fan for now
    static bool init;

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -104,7 +104,6 @@ void init_cpu_stats(overlay_params& params);
 void check_keybinds(overlay_params& params, uint32_t vendorID);
 void init_system_info(void);
 void FpsLimiter(struct fps_limit& stats);
-std::string get_device_name(uint32_t vendorID, uint32_t deviceID);
 void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*& small_font, ImFont*& text_font);
 void right_aligned_text(ImVec4& col, float off_x, const char *fmt, ...);
 void center_text(const std::string& text);

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1544,7 +1544,7 @@ static VkResult overlay_CreateSwapchainKHR(
    std::string deviceName = prop.deviceName;
    if (!is_blacklisted()) {
 #ifdef __linux__
-      swapchain_data->sw_stats.gpuName = get_device_name(prop.vendorID, prop.deviceID);
+      swapchain_data->sw_stats.gpuName = deviceName;
 #endif
    }
    swapchain_data->sw_stats.driverName = driverProps.driverInfo;
@@ -1810,7 +1810,7 @@ static VkResult overlay_CreateDevice(
    if (!is_blacklisted()) {
       device_map_queues(device_data, pCreateInfo);
 #ifdef __linux__
-      gpu = get_device_name(device_data->properties.vendorID, device_data->properties.deviceID);
+      gpu = device_data->properties.deviceName;
       SPDLOG_DEBUG("gpu: {}", gpu);
 #endif
       init_gpu_stats(device_data->properties.vendorID, device_data->properties.deviceID, device_data->instance->params);


### PR DESCRIPTION
Instead of using PCI ids, which could be the same for 3-8 gpus, we use the vulkan/GL device name. 