### PR TITLE
Continue looping power data when k10temp is found.

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -624,7 +624,6 @@ bool CPUStats::InitCpuPowerData() {
 
         if (name == "k10temp") {
             cpuPowerData = (CPUPowerData*)init_cpu_power_data_k10temp(path);
-            break;
         } else if (name == "zenpower") {
             cpuPowerData = (CPUPowerData*)init_cpu_power_data_zenpower(path);
             break;


### PR DESCRIPTION
Vanilla upstream versions don't have any power monitoring support. Also, if zenpower/zenergy are found in the AMD options always pick that over the k10temp version.