### PR TITLE
logging: fix bug where 97th percentile prints frametime instead of fps

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -88,7 +88,7 @@ static void writeSummary(string filename){
       out << fixed << setprecision(1) << result << ",";
     }
     // 97th percentile
-    result = sorted.empty() ? 0.0f : sorted[floor(0.97 * (sorted.size() - 1))].frametime;
+    result = sorted.empty() ? 0.0f : 1000 / sorted[floor(0.97 * (sorted.size() - 1))].frametime;
     out << fixed << setprecision(1) << result << ",";
     // avg
     total = 0;


### PR DESCRIPTION
Seems like in the recent change of shifting from fps to frametime for the calculation of averages you forgot to convert the framtime back to fps before printing it out..