### PR TITLE
Default to -1 preset instead of 0 when preset is unset

### DIFF
--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -698,7 +698,6 @@ static void set_param_defaults(struct overlay_params *params){
    params->table_columns = 3;
    params->text_outline_color = 0x000000;
    params->text_outline_thickness = 1.5;
-   current_preset = -1;
 }
 
 void
@@ -993,10 +992,6 @@ void add_to_options(struct overlay_params *params, std::string option, std::stri
 }
 
 void presets(int preset, struct overlay_params *params) {
-   printf("preset: %i\n", preset);
-   if (preset == -1)
-      return;
-
    if (parse_preset_config(preset, params))
       return;
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -753,10 +753,12 @@ parse_overlay_config(struct overlay_params *params,
       // Get config options
       parseConfigFile(*params);
 
-      if (!use_existing_preset && params->options.find("preset") != params->options.end()) {
-        auto presets = parse_preset(params->options.find("preset")->second.c_str());
-        if (!presets.empty())
-          params->preset = presets;
+      if (!use_existing_preset) {
+         if (params->options.find("preset") != params->options.end()) {
+            auto presets = parse_preset(params->options.find("preset")->second.c_str());
+            if (!presets.empty())
+               params->preset = presets;
+         }
         current_preset = params->preset[0];
       }
 


### PR DESCRIPTION
Default to -1 preset if `preset` is not set and fix toggling issue caused by [02c3b4f](https://github.com/flightlessmango/MangoHud/commit/02c3b4f235a2ff5581220b2cd1aa34a50dd20bcf)