### PR TITLE
Fix amdgpu hwmon reading

### DIFF
--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -892,26 +892,26 @@ void init_gpu_stats(uint32_t& vendorID, uint32_t reported_deviceID, overlay_para
                if (!amdgpu.gpu_voltage_soc)
                   amdgpu.gpu_voltage_soc = fopen((hwmon_path + dir + "/in0_input").c_str(), "r");
             }
-         }
 
-         if (!metrics_path.empty())
-            break;
+            if (!metrics_path.empty())
+               break;
 
-         // The card output nodes - cardX-output, will point to the card node
-         // As such the actual metrics nodes will be missing.
-         amdgpu.busy = fopen((device_path + "/gpu_busy_percent").c_str(), "r");
-         if (!amdgpu.busy)
-            continue;
+            // The card output nodes - cardX-output, will point to the card node
+            // As such the actual metrics nodes will be missing.
+            amdgpu.busy = fopen((device_path + "/gpu_busy_percent").c_str(), "r");
+            if (!amdgpu.busy)
+               continue;
 
-         SPDLOG_DEBUG("using amdgpu path: {}", device_path);
+            SPDLOG_DEBUG("using amdgpu path: {}", device_path);
 
-         for (const auto& dir : dirs) {
-            if (!amdgpu.memory_clock)
-               amdgpu.memory_clock = fopen((hwmon_path + dir + "/freq2_input").c_str(), "r");
-            if (!amdgpu.power_usage)
-               amdgpu.power_usage = fopen((hwmon_path + dir + "/power1_average").c_str(), "r");
-            if (!amdgpu.fan)
-               amdgpu.fan = fopen((hwmon_path + dir + "/fan1_input").c_str(), "r");
+            for (const auto& dir : dirs) {
+               if (!amdgpu.memory_clock)
+                  amdgpu.memory_clock = fopen((hwmon_path + dir + "/freq2_input").c_str(), "r");
+               if (!amdgpu.power_usage)
+                  amdgpu.power_usage = fopen((hwmon_path + dir + "/power1_average").c_str(), "r");
+               if (!amdgpu.fan)
+                  amdgpu.fan = fopen((hwmon_path + dir + "/fan1_input").c_str(), "r");
+            }
          }
          break;
       }


### PR DESCRIPTION
Attempt to fix #1099.

## Issue

There are 2 variables named `dirs` - one for cards, one for hwmons.
Due to the `if` block, only first group of `fopen`s use the hwmon dir.

## Solution

Extend the `if` block so that `freq2_input`, `power1_average` and `fan1_input` are also read from the hwmon directory.

## Result

Before

![mangohud-17d4541](https://github.com/flightlessmango/MangoHud/assets/14021/b78323f4-178f-48d6-99ac-0e23cc3083c6)

After

![mangohud-f4f2bcd](https://github.com/flightlessmango/MangoHud/assets/14021/903a5ade-c2ba-4dc9-a540-291b1b8bee5b)

Note: fan input, power draw and MCLK are now present.

## Notes

There's probably a better way to fix this, e.g. rename one (or both) of the variables.
Please feel free to merge or fix as you see fit.

Thanks!