### PR TITLE
logging: include swap and RSS sizes

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -125,7 +125,7 @@ static void writeFileHeaders(ofstream& out){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_log_versioning])
       out << "--------------------FRAME METRICS--------------------" << endl;
 
-    out << "fps," << "frametime," << "cpu_load," << "gpu_load," << "cpu_temp," << "gpu_temp," << "gpu_core_clock," << "gpu_mem_clock," << "gpu_vram_used," << "gpu_power," << "ram_used," << "swap_used," << "elapsed" << endl;
+    out << "fps," << "frametime," << "cpu_load," << "gpu_load," << "cpu_temp," << "gpu_temp," << "gpu_core_clock," << "gpu_mem_clock," << "gpu_vram_used," << "gpu_power," << "ram_used," << "swap_used," << "process_rss," << "elapsed" << endl;
 
 }
 
@@ -149,6 +149,7 @@ void Logger::writeToFile(){
     output_file << logArray.back().gpu_power << ",";
     output_file << logArray.back().ram_used << ",";
     output_file << logArray.back().swap_used << ",";
+    output_file << logArray.back().process_rss << ",";
     output_file << std::chrono::duration_cast<std::chrono::nanoseconds>(logArray.back().previous).count() << "\n";
     output_file.flush();
   } else {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -125,7 +125,8 @@ static void writeFileHeaders(ofstream& out){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_log_versioning])
       out << "--------------------FRAME METRICS--------------------" << endl;
 
-    out << "fps," << "frametime," << "cpu_load," << "gpu_load," << "cpu_temp," << "gpu_temp," << "gpu_core_clock," << "gpu_mem_clock," << "gpu_vram_used," << "gpu_power," << "ram_used," << "elapsed" << endl;
+    out << "fps," << "frametime," << "cpu_load," << "gpu_load," << "cpu_temp," << "gpu_temp," << "gpu_core_clock," << "gpu_mem_clock," << "gpu_vram_used," << "gpu_power," << "ram_used," << "swap_used," << "elapsed" << endl;
+
 }
 
 void Logger::writeToFile(){
@@ -147,6 +148,7 @@ void Logger::writeToFile(){
     output_file << logArray.back().gpu_vram_used << ",";
     output_file << logArray.back().gpu_power << ",";
     output_file << logArray.back().ram_used << ",";
+    output_file << logArray.back().swap_used << ",";
     output_file << std::chrono::duration_cast<std::chrono::nanoseconds>(logArray.back().previous).count() << "\n";
     output_file.flush();
   } else {

--- a/src/logging.h
+++ b/src/logging.h
@@ -25,6 +25,7 @@ struct logData{
   int gpu_power;
   float gpu_vram_used;
   float ram_used;
+  float swap_used;
 
   Clock::duration previous;
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -26,6 +26,7 @@ struct logData{
   float gpu_vram_used;
   float ram_used;
   float swap_used;
+  float process_rss;
 
   Clock::duration previous;
 };

--- a/src/memory.h
+++ b/src/memory.h
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <thread>
 
-extern float memused, memmax, swapused, swapmax;
+extern float memused, memmax, swapused, swapmax, rss;
 
 struct memory_information {
   /* memory information in kilobytes */

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -159,6 +159,7 @@ void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
 #ifdef __linux__
    currentLogData.ram_used = memused;
    currentLogData.swap_used = swapused;
+   currentLogData.process_rss = proc_mem.resident / float((2 << 29)); // GiB, consistent w/ other mem stats
 #endif
 
    currentLogData.cpu_load = cpuStats.GetCPUDataTotal().percent;

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -158,6 +158,7 @@ void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
    currentLogData.gpu_power = gpu_info.powerUsage;
 #ifdef __linux__
    currentLogData.ram_used = memused;
+   currentLogData.swap_used = swapused;
 #endif
 
    currentLogData.cpu_load = cpuStats.GetCPUDataTotal().percent;


### PR DESCRIPTION
These stats are useful for comparing memory usage over time, and any impacts to performance that might be from changing swap usage during runtime.