### PR TITLE
imgui: Disable webgpu option in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -191,6 +191,7 @@ imgui_options = [
   'metal=disabled',
   'opengl=disabled',
   'vulkan=disabled',
+  'webgpu=disabled',
   'glfw=disabled',
   'sdl2=disabled',
   'osx=disabled',


### PR DESCRIPTION
Since imgui have been updated to 1.89.9, new option 'webgpu' have been added to imgui's meson.build.

Keeping it set to auto can have building problem if --auto_features is enabled for meson.(like arch-meson)