### PR TITLE
nvctrl: call XDefaultScreen for screen id (#1152)

### DIFF
--- a/src/loaders/loader_x11.cpp
+++ b/src/loaders/loader_x11.cpp
@@ -37,6 +37,14 @@ bool libx11_loader::Load(const std::string& library_name) {
     return false;
   }
 
+  XDefaultScreen =
+      reinterpret_cast<decltype(this->XDefaultScreen)>(
+          dlsym(library_, "XDefaultScreen"));
+  if (!XDefaultScreen) {
+      CleanUp(true);
+      return false;
+  }
+
   XQueryKeymap =
       reinterpret_cast<decltype(this->XQueryKeymap)>(
           dlsym(library_, "XQueryKeymap"));

--- a/src/loaders/loader_x11.h
+++ b/src/loaders/loader_x11.h
@@ -16,6 +16,7 @@ class libx11_loader {
 
   decltype(&::XOpenDisplay) XOpenDisplay;
   decltype(&::XCloseDisplay) XCloseDisplay;
+  decltype(&::XDefaultScreen) XDefaultScreen;
   decltype(&::XQueryKeymap) XQueryKeymap;
   decltype(&::XKeysymToKeycode) XKeysymToKeycode;
   decltype(&::XStringToKeysym) XStringToKeysym;

--- a/src/nvctrl.cpp
+++ b/src/nvctrl.cpp
@@ -26,7 +26,8 @@ static bool find_nv_x11(libnvctrl_loader& nvctrl, Display*& dpy)
         snprintf(buf, sizeof(buf), ":%d", i);
         Display *d = libx11->XOpenDisplay(buf);
         if (d) {
-            if (nvctrl.XNVCTRLIsNvScreen(d, i)) {
+            int s = libx11->XDefaultScreen(d);
+            if (nvctrl.XNVCTRLIsNvScreen(d, s)) {
                 dpy = d;
                 SPDLOG_DEBUG("XNVCtrl is using display {}", buf);
                 return true;


### PR DESCRIPTION
Calling nvctrl XNVCTRLIsNvScreen with X display ID used for screen id is a programmer error. For most common use cases, Gnome on X11 may launch user sessions on X display ":1" but still uses screen 0. Current code will always fail to find a correct display in this case, as both `IsNvScreen(":0", 0)` and `IsNvScreen(":1", 1)` returns false.

Call XDefaultScreen with `struct Display *` to obtain the correct screen id, then use this id for `IsNvScreen()`.