### PR TITLE
Fix gpu_voltage option in the config file

### DIFF
--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -87,7 +87,8 @@ gpu_stats
 # gpu_load_color=39F900,FDFD09,B22222
 ## GPU fan in rpm on AMD, FAN in percent on NVIDIA
 # gpu_fan
-# gpu_voltage (only works on AMD GPUs)
+## gpu_voltage only works on AMD GPUs
+# gpu_voltage 
 
 ### Display the current CPU information
 cpu_stats


### PR DESCRIPTION
"Separate the comment 'Only works on AMD GPUs' from the gpu_voltage option itself because those were appended, which invalidated the option."