### PR TITLE
Adding command for arch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,16 @@ and uncomment:
 #Include = /etc/pacman.d/mirrorlist
 ```
 
-then save the file and execute:
+then save the file and execute the command to refresh databases:
 
 ```
 sudo pacman -Syy
+```
+
+and install with:
+
+```
+sudo pacman -S mangohud
 ```
 
 ### Debian, Ubuntu


### PR DESCRIPTION
Guide was missing the actual command to install the software in arch linux and based distros, it stopped at refreshing databases.