### PR TITLE
amdgpu, overlay: Use gpu_metrics for CoreClock on Steam Deck

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -250,7 +250,7 @@ void amdgpu_metrics_polling_thread() {
 	}
 }
 
-void amdgpu_get_metrics(){
+void amdgpu_get_metrics(uint32_t deviceID){
 	static bool init = false;
 	if (!init){
 		std::thread(amdgpu_metrics_polling_thread).detach();
@@ -264,7 +264,12 @@ void amdgpu_get_metrics(){
 	gpu_info.MemClock = amdgpu_common_metrics.current_uclk_mhz;
 
 	// Use hwmon instead, see gpu.cpp
-	// gpu_info.CoreClock = amdgpu_common_metrics.current_gfxclk_mhz;
+	if ( deviceID == 0x1435 || deviceID == 0x163f )
+	{
+		// If we are on VANGOGH (Steam Deck), then
+		// always use use core clock from GPU metrics.
+		gpu_info.CoreClock = amdgpu_common_metrics.current_gfxclk_mhz;
+	}
 	// gpu_info.temp = amdgpu_common_metrics.gpu_temp_c;
 	gpu_info.apu_cpu_power = amdgpu_common_metrics.average_cpu_power_w;
 	gpu_info.apu_cpu_temp = amdgpu_common_metrics.apu_cpu_temp_c;

--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -193,7 +193,7 @@ struct amdgpu_common_metrics {
 };
 
 bool amdgpu_verify_metrics(const std::string& path);
-void amdgpu_get_metrics();
+void amdgpu_get_metrics(uint32_t deviceID);
 extern std::string metrics_path;
 extern std::condition_variable amdgpu_c;
 extern bool amdgpu_run_thread;

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -130,7 +130,7 @@ void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
          getAmdGpuInfo();
 #ifdef __linux__
       if (gpu_metrics_exists)
-         amdgpu_get_metrics();
+         amdgpu_get_metrics(deviceID);
 #endif
       if (vendorID == 0x10de)
          getNvidiaGpuInfo(params);

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -1051,6 +1051,7 @@ void presets(int preset, struct overlay_params *params, bool inherit) {
          add_to_options(params, "fps", "1");
          add_to_options(params, "fps_only", "1");
          add_to_options(params, "frametime", "0");
+         add_to_options(params, "debug", "0");
          break;
 
       case 2:
@@ -1071,6 +1072,7 @@ void presets(int preset, struct overlay_params *params, bool inherit) {
          add_to_options(params, "cpu_power", "1");
          add_to_options(params, "battery_watt", "1");
          add_to_options(params, "battery_time", "1");
+         add_to_options(params, "debug", "0");
          break;
 
       case 3:
@@ -1085,6 +1087,7 @@ void presets(int preset, struct overlay_params *params, bool inherit) {
          add_to_options(params, "gpu_core_clock", "1");
          add_to_options(params, "battery", "1");
          add_to_options(params, "hdr", "1");
+         add_to_options(params, "debug", "0");
          break;
 
       case 4:
@@ -1108,6 +1111,7 @@ void presets(int preset, struct overlay_params *params, bool inherit) {
          add_to_options(params, "hdr", "1");
          add_to_options(params, "refresh_rate", "1");
          add_to_options(params, "media_player", "0");
+         add_to_options(params, "debug", "1");
          break;
 
    }


### PR DESCRIPTION
sysfs path gives 200 or 1040 Mhz always. Don't use that!