### PR TITLE
meson: Install example configuration file for presets.conf

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -47,3 +47,10 @@ install_data(
   rename : ['MangoHud.conf.example'],
   install_tag : 'doc',
 )
+
+install_data(
+  files('presets.conf'),
+  install_dir : join_paths(get_option('datadir'), 'doc', 'mangohud'),
+  rename : ['presets.conf.example'],
+  install_tag : 'doc',
+)


### PR DESCRIPTION
Got annoyed by error  
`[2023-12-05 20:55:17.077] [MANGOHUD] [error] [overlay_params.cpp:999] Failed to read presets file: '/home/billli11/.config/MangoHud/presets.conf'`  
and find no example file for `presets.conf` in the package.( Have to find the config in git repo.)

This PR add `presets.conf.example` to `/usr/share/doc/mangohud`.