### PR TITLE
Add hardware monitoring of asus boards

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -519,8 +519,11 @@ bool CPUStats::GetCpuFile() {
         } else if (name == "it8603") {
             find_input(path, "temp", input, "temp1");
             break;
-        } else if (name == "nct6797") {
+        } else if (starts_with(name, "nct")) {
             find_input(path, "temp", input, "TSI0_TEMP");
+            break;
+        } else if (name == "asusec") {
+            find_input(path, "temp", input, "CPU");
             break;
         } else {
             path.clear();


### PR DESCRIPTION
```shell
$ cat /sys/class/dmi/id/board_name 
ROG CROSSHAIR VIII DARK HERO
```

My kernel config
```shell
$ cat /boot/config-6.7.0
...
CONFIG_SENSORS_ASUS_EC=y
...
CONFIG_SENSORS_NCT6775_CORE=y
CONFIG_SENSORS_NCT6775=y
...