### PR TITLE
Add missing opengl files for wayland option

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -144,6 +144,13 @@ if is_unixy
     )
   endif
 
+  if get_option('with_wayland').enabled()
+    opengl_files += files(
+      'loaders/loader_glx.cpp',
+      'gl/inject_glx.cpp',
+    )
+  endif
+
   if dbus_dep.found() and get_option('with_dbus').enabled()
     pre_args += '-DHAVE_DBUS'
     vklayer_files += files(


### PR DESCRIPTION
When meson setup with below options:

```shell
$ meson setup -Dwith_wayland=enabled -Dwith_x11=disabled -Dwith_nvml=disabled -Dwith_xnvctrl=disabled build
```

Compiling fails with:

```shell
$ ninja -C build
...
mold: warning: /tmp/project/mangohud-git/src/mangohud.version: cannot assign version `global` to symbol `overlay_GetInstanceProcAddr`: symbol not found
mold: warning: /tmp/project/mangohud-git/src/mangohud.version: cannot assign version `global` to symbol `overlay_GetDeviceProcAddr`: symbol not found
mold: warning: /tmp/project/mangohud-git/src/mangohud.version: cannot assign version `global` to symbol `mangohud_find_glx_ptr`: symbol not found
mold: warning: /tmp/project/mangohud-git/src/mangohud.version: cannot assign version `global` to symbol `overlay_GetInstanceProcAddr`: symbol not found
mold: warning: /tmp/project/mangohud-git/src/mangohud.version: cannot assign version `global` to symbol `overlay_GetDeviceProcAddr`: symbol not found
mold: warning: /tmp/project/mangohud-git/src/mangohud.version: cannot assign version `global` to symbol `mangohud_find_glx_ptr`: symbol not found
mold: error: undefined symbol: glx_mesa_queryInteger(int, unsigned int*)
>>> referenced by gl_hud.cpp
>>>               /tmp/lto-llvm-253b46.o:(MangoHud::GL::imgui_create(void*, MangoHud::GL::gl_wsi))
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

I belive if you are enabling only wayland option, `loaders/loader_glx.cpp` and `gl/inject_glx.cpp` files won't be added to opengl_files. This causes linking errors.