### PR TITLE
pkgbuild: update source for sdplog to 1.13.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -230,7 +230,8 @@ if not spdlog_dep.found()
     'compile_library=true',
     'werror=false',
     'tests=disabled',
-    'external_fmt=disabled'
+    'external_fmt=disabled',
+    'std_format=disabled'
   ])
   spdlog_dep = spdlog_sp.get_variable('spdlog_dep')
 else

--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -14,8 +14,8 @@ source=(
         "mangohud-minhook"::"git+https://github.com/flightlessmango/minhook.git"
         "imgui-1.89.9.tar.gz::https://github.com/ocornut/imgui/archive/refs/tags/v1.89.9.tar.gz"
         "imgui_1.89.9-1_patch.zip::https://wrapdb.mesonbuild.com/v2/imgui_1.89.9-1/get_patch"
-        "spdlog-1.12.0.tar.gz::https://github.com/gabime/spdlog/archive/refs/tags/v1.12.0.tar.gz"
-        "spdlog_1.12.0-1_patch.zip::https://wrapdb.mesonbuild.com/v2/spdlog_1.12.0-1/get_patch"
+        "spdlog-1.13.0.tar.gz::https://github.com/gabime/spdlog/archive/refs/tags/v1.13.0.tar.gz"
+        "spdlog_1.13.0-1_patch.zip::https://wrapdb.mesonbuild.com/v2/spdlog_1.13.0-1/get_patch"
         "nlohmann_json-3.10.5.zip::https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip"
         "vulkan-headers-1.2.158.tar.gz::https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.158.tar.gz"
         "vulkan-headers-1.2.158-2-wrap.zip::https://wrapdb.mesonbuild.com/v2/vulkan-headers_1.2.158-2/get_patch"
@@ -28,8 +28,8 @@ sha256sums=(
             'SKIP'
             '1acc27a778b71d859878121a3f7b287cd81c29d720893d2b2bf74455bf9d52d6'
             '9b21290c597d76bf8d4eeb3f9ffa024b11d9ea6c61e91d648ccc90b42843d584'
-            '4dccf2d10f410c1e2feaff89966bfc49a1abb29ef6f08246335b110e001e09a9'
-            '0515906db7324df0e439bdd018bf019a60304430f6af8f1725910652e30ebe69'
+            '534f2ee1a4dcbeb22249856edfb2be76a1cf4f708a20b0ac2ed090ee24cfdbc9'
+            '556b539cf582a46673ede4202ac037b891328dd5ea76862ffe05b060fc4f4775'
             'b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e'
             "53361271cfe274df8782e1e47bdc9e61b7af432ba30acbfe31723f9df2c257f3"
             "860358cf5e73f458cd1e88f8c38116d123ab421d5ce2e4129ec38eaedd820e17"
@@ -52,7 +52,7 @@ prepare() {
 
   # meson subprojects
   ln -sv "$srcdir/imgui-1.89.9" subprojects
-  ln -sv "$srcdir/spdlog-1.12.0" subprojects
+  ln -sv "$srcdir/spdlog-1.13.0" subprojects
   mkdir  subprojects/nlohmann_json-3.10.5
   ln -sv "$srcdir/include" subprojects/nlohmann_json-3.10.5/
   ln -sv "$srcdir/single_include" subprojects/nlohmann_json-3.10.5/


### PR DESCRIPTION
This also disable `std_format` feature for spdlog in `meson.build`  
The feature require `std::format` which added in `c++20`.( gcc still default to `c++17` )