### PR TITLE
blacklist: add monado-service

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -25,6 +25,7 @@ static  std::vector<std::string> blacklist {
     "EpicGamesLauncher.exe",
     "IGOProxy.exe",
     "IGOProxy64.exe",
+    "monado-service",
     "Origin.exe",
     "OriginThinSetupInternal.exe",
     "steam",


### PR DESCRIPTION
[Monado](https://monado.freedesktop.org/) crashes with `XRT_COMPOSITOR_COMPUTE=1` set when MangoHud is enabled. As it is a headless application, it should be blacklisted anyway.
