### PR TITLE
Fix sound in minecraft

### DIFF
--- a/src/gl/inject_egl.cpp
+++ b/src/gl/inject_egl.cpp
@@ -35,7 +35,7 @@ static void* get_egl_proc_address(const char* name) {
         func = get_proc_address( name );
 
     if (!func) {
-        SPDLOG_DEBUG("Failed to get function '{}'", name);
+        SPDLOG_ERROR("Failed to get function '{}'", name);
     }
 
     return func;

--- a/src/hook_dlsym.cpp
+++ b/src/hook_dlsym.cpp
@@ -15,8 +15,8 @@ EXPORT_C_(void*) dlsym(void * handle, const char * name)
         find_egl_ptr = reinterpret_cast<decltype(find_egl_ptr)> (real_dlsym(RTLD_NEXT, "mangohud_find_egl_ptr"));
 
     void* func = nullptr;
+    bool is_angle = real_dlsym(handle, "eglStreamPostD3DTextureANGLE");
     void* real_func = real_dlsym(handle, name);
-    bool is_angle = !!real_dlsym(handle, "eglStreamPostD3DTextureANGLE");
 
     if (find_glx_ptr && real_func) {
         func = find_glx_ptr(name);


### PR DESCRIPTION
running the angle check second causes an incorrect dlerror, therefore you have to run it before the actual dlopen