### PR TITLE
pkgbuild: update source for sdplog to 1.14.1

### DIFF
--- a/pkgbuild/PKGBUILD
+++ b/pkgbuild/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Simon Hallsten <flightlessmangoyt@gmail.com>
 
 pkgname=('mangohud' 'lib32-mangohud')
-pkgver=0.7.2.rc1
+pkgver=0.7.2.rc3.r13.g5d744d3
 pkgrel=1
 pkgdesc="Vulkan and OpenGL overlay to display performance information"
 arch=('x86_64')
@@ -15,8 +15,8 @@ source=(
         "mangohud-minhook"::"git+https://github.com/flightlessmango/minhook.git"
         "imgui-1.89.9.tar.gz::https://github.com/ocornut/imgui/archive/refs/tags/v1.89.9.tar.gz"
         "imgui_1.89.9-1_patch.zip::https://wrapdb.mesonbuild.com/v2/imgui_1.89.9-1/get_patch"
-        "spdlog-1.13.0.tar.gz::https://github.com/gabime/spdlog/archive/refs/tags/v1.13.0.tar.gz"
-        "spdlog_1.13.0-1_patch.zip::https://wrapdb.mesonbuild.com/v2/spdlog_1.13.0-1/get_patch"
+        "spdlog-1.14.1.tar.gz::https://github.com/gabime/spdlog/archive/refs/tags/v1.14.1.tar.gz"
+        "spdlog_1.14.1-1_patch.zip::https://wrapdb.mesonbuild.com/v2/spdlog_1.14.1-1/get_patch"
         "nlohmann_json-3.10.5.zip::https://github.com/nlohmann/json/releases/download/v3.10.5/include.zip"
         "vulkan-headers-1.2.158.tar.gz::https://github.com/KhronosGroup/Vulkan-Headers/archive/v1.2.158.tar.gz"
         "vulkan-headers-1.2.158-2-wrap.zip::https://wrapdb.mesonbuild.com/v2/vulkan-headers_1.2.158-2/get_patch"
@@ -29,8 +29,8 @@ sha256sums=(
             'SKIP'
             '1acc27a778b71d859878121a3f7b287cd81c29d720893d2b2bf74455bf9d52d6'
             '9b21290c597d76bf8d4eeb3f9ffa024b11d9ea6c61e91d648ccc90b42843d584'
-            '534f2ee1a4dcbeb22249856edfb2be76a1cf4f708a20b0ac2ed090ee24cfdbc9'
-            '556b539cf582a46673ede4202ac037b891328dd5ea76862ffe05b060fc4f4775'
+            '1586508029a7d0670dfcb2d97575dcdc242d3868a259742b69f100801ab4e16b'
+            'ae878e732330ea1048f90d7e117c40c0cd2a6fb8ae5492c7955818ce3aaade6c'
             'b94997df68856753b72f0d7a3703b7d484d4745c567f3584ef97c96c25a5798e'
             "53361271cfe274df8782e1e47bdc9e61b7af432ba30acbfe31723f9df2c257f3"
             "860358cf5e73f458cd1e88f8c38116d123ab421d5ce2e4129ec38eaedd820e17"
@@ -53,7 +53,7 @@ prepare() {
 
   # meson subprojects
   ln -sv "$srcdir/imgui-1.89.9" subprojects
-  ln -sv "$srcdir/spdlog-1.13.0" subprojects
+  ln -sv "$srcdir/spdlog-1.14.1" subprojects
   mkdir  subprojects/nlohmann_json-3.10.5
   ln -sv "$srcdir/include" subprojects/nlohmann_json-3.10.5/
   ln -sv "$srcdir/single_include" subprojects/nlohmann_json-3.10.5/


### PR DESCRIPTION
fix building arch package using `pkgbuild/PKGBUILD`