### PR TITLE
Fix issue where presets weren't applied when MANGOHUD_CONFIG is set 

### DIFF
--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -794,6 +794,9 @@ parse_overlay_config(struct overlay_params *params,
      .preset = use_existing_preset ? params->preset : default_preset
    };
    set_param_defaults(params);
+   if (!use_existing_preset) {
+      current_preset = params->preset[0];
+   }
 
 #ifdef HAVE_X11
    params->toggle_hud = { XK_Shift_R, XK_F12 };

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -665,11 +665,11 @@ parse_overlay_env(struct overlay_params *params,
             add_to_options(params, key, value);
             initialize_preset(params);
          }
-         presets(current_preset, params);
          break;
       }
    }
 
+   presets(current_preset, params);
    env = env_start;
 
    while ((num = parse_string(env, key, value)) != 0) {


### PR DESCRIPTION
If MANGOHUD_CONFIG is set and neither read_cfg nor preset options were specified, the user was unable to swap presets.  This PR also fixes another minor bug that popped up in this scenario which caused the _current_preset_ variable to be uninitialized.

Fixes #1298 