### PR TITLE
Add an option to disable ImPlot

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `text_outline_color=`              | Set the color of `text_outline`. Default = `000000`                                   |
 | `text_outline_thickness=`          | Set the thickness of `text_outline`. Default = `1.5`                                  |
 | `throttling_status`                | Show if GPU is throttling based on Power, current, temp or "other" (Only shows if throttling is currently happening). Currently disabled by default for Nvidia as it causes lag on 3000 series |
-| `throttling_status_graph`          | Same as `throttling_status` but displays throttling in the frametime graph and only power and temp throttling |
+| `throttling_status_graph`          | Same as `throttling_status` but displays throttling in the frametime graph and only power and temp throttling (requires ImPlot dependency) |
 | `time`<br>`time_format=%T`         | Display local time. See [std::put_time](https://en.cppreference.com/w/cpp/io/manip/put_time) for formatting help. NOTE: Sometimes apps may set `TZ` (timezone) environment variable to UTC/GMT |
 | `time_no_label`                    | Remove the label before time                                                          |
 | `toggle_fps_limit`                 | Cycle between FPS limits (needs at least two values set with `fps_limit`). Defaults to `Shift_L+F1`                                    |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -143,7 +143,7 @@ frametime
 ### Display GPU throttling status based on Power, current, temp or "other"
 ## Only shows if throttling is currently happening
 throttling_status
-## Same as throttling_status but displays throttling on the frametime graph
+## Same as throttling_status but displays throttling on the frametime graph (requires ImPlot dependency)
 #throttling_status_graph
 
 ### Display miscellaneous information

--- a/meson.build
+++ b/meson.build
@@ -224,8 +224,9 @@ if get_option('mangoapp')
 endif
 dearimgui_dep = dependency('imgui', fallback: ['imgui'], required: true, default_options: imgui_options)
 
-if is_unixy
+if is_unixy and get_option('with_implot').enabled()
 implot_dep = dependency('implot', fallback: ['implot'], required: true, default_options: ['default_library=static'])
+pre_args += '-DHAVE_IMPLOT'
 else
 implot_dep = null_dep
 implot_lib = static_library('nulllib', [])

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,6 +7,7 @@ option('with_xnvctrl', type : 'feature', value : 'enabled', description: 'Enable
 option('with_x11', type : 'feature', value : 'enabled')
 option('with_wayland', type : 'feature', value : 'enabled')
 option('with_dbus', type : 'feature', value : 'enabled')
+option('with_implot', type : 'feature', value : 'enabled', description: 'Enable ImPlot support (required for throttling graph; disable for smaller debug library size)')
 option('loglevel', type: 'combo', choices : ['trace', 'debug', 'info', 'warn', 'err', 'critical', 'off'], value : 'info', description: 'Max log level in non-debug build')
 option('mangoapp', type: 'boolean', value : false)
 option('mangohudctl', type: 'boolean', value : false)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -19,7 +19,7 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 #include "amdgpu.h"
-#ifdef __linux__
+#ifdef hAVE_IMPLOT
 #include "implot.h"
 #endif
 
@@ -241,7 +241,7 @@ static GLFWwindow* init(const char* glsl_version){
     glfwMakeContextCurrent(window);
     glfwSwapInterval(1); // Enable vsync
     ImGui::CreateContext();
-#ifdef __linux__
+#ifdef HAVE_IMPLOT
     ImPlot::CreateContext();
 #endif
     ImGuiIO& io = ImGui::GetIO(); (void)io;

--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -8,7 +8,7 @@
 #include <unistd.h>
 #include <spdlog/spdlog.h>
 #include <imgui.h>
-#ifdef __linux__
+#ifdef HAVE_IMPLOT
 #include <implot.h>
 #endif
 #include "gl_hud.h"
@@ -159,7 +159,7 @@ void imgui_create(void *ctx, const gl_wsi plat)
     IMGUI_CHECKVERSION();
     ImGuiContext *saved_ctx = ImGui::GetCurrentContext();
     state.imgui_ctx = ImGui::CreateContext();
-#ifdef __linux__
+#ifdef HAVE_IMPLOT
     ImPlot::CreateContext();
 #endif
     ImGuiIO& io = ImGui::GetIO(); (void)io;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -20,7 +20,7 @@
 #include <IconsForkAwesome.h>
 #include "version.h"
 #include "blacklist.h"
-#ifdef __linux__
+#ifdef HAVE_IMPLOT
 #include "implot.h"
 #endif
 #include "amdgpu.h"
@@ -787,7 +787,7 @@ void HudElements::frame_timing(){
                                     NULL, min_time, max_time,
                                     ImVec2(width, height));
             } else {
-#ifndef __linux__
+#ifndef HAVE_IMPLOT
                 ImGui::PlotLines(hash, get_time_stat, HUDElements.sw_stats,
                                 ARRAY_SIZE(HUDElements.sw_stats->frames_stats), 0,
                                 NULL, min_time, max_time,
@@ -828,7 +828,7 @@ void HudElements::frame_timing(){
             }
         }
         ImGui::EndChild();
-#ifdef __linux__
+#ifdef HAVE_IMPLOT
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_throttling_status_graph] && throttling){
             ImGui::Dummy(ImVec2(0.0f, real_font_size.y / 2));
 
@@ -848,6 +848,11 @@ void HudElements::frame_timing(){
         }
         ImGui::PopFont();
         ImGui::PopStyleColor();
+#else
+        static unsigned int once;
+
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_throttling_status_graph] && !once++)
+            SPDLOG_DEBUG("Throttling status graph requires ImPlot");
 #endif
     }
 }

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -57,6 +57,9 @@
 #include "file_utils.h"
 #ifdef __linux__
 #include <dlfcn.h>
+#endif
+
+#ifdef HAVE_IMPLOT
 #include "implot.h"
 #endif
 
@@ -1319,7 +1322,7 @@ static void setup_swapchain_data(struct swapchain_data *data,
    data->format = pCreateInfo->imageFormat;
 
    data->imgui_context = ImGui::CreateContext(data->font_atlas);
-#ifdef __linux__
+#ifdef HAVE_IMPLOT
    ImPlot::CreateContext();
 #endif
    ImGui::SetCurrentContext(data->imgui_context);


### PR DESCRIPTION
The ImPlot dependency causes significant library size and build time increases (at least for debug builds) so add an option to disable it

This change also adds more mentions of the ImPlot dependency in the documentation (and adds a warning about missing ImPlot)