### PR TITLE
mangoapp: Use XInitThreads

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -285,6 +285,8 @@ static bool render(GLFWwindow* window) {
 
 int main(int, char**)
 {
+    XInitThreads();
+
     // Setup window
     glfwSetErrorCallback(glfw_error_callback);
     if (!glfwInit())


### PR DESCRIPTION
We use xlib stuff across threads, we need to set this or bad things can happen. We are just very lucky. =)