### PR TITLE
param: cellpadding_x

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `benchmark_percentiles`            | Configure which framerate percentiles are shown in the logging summary. Default is `97,AVG,1,0.1` |
 | `bicubic`                          | Force bicubic filtering                                                               |
 | `blacklist`                        | Add a program to the blacklist. e.g `blacklist=vkcube,WatchDogs2.exe`                 |
-| `cellpadding_y`                    | Set the vertical cellpadding, default is `-0.085` |
+| `cellpadding_x`                    | Set the horizontal cellpadding, default is `0`                                        |
+| `cellpadding_y`                    | Set the vertical cellpadding, default is `-0.085`                                     |
 | `control=`                         | Sets up a unix socket with a specific name that can be connected to with mangohud-control.<br>I.e. `control=mangohud` or `control=mangohud-%p` (`%p` will be replaced by process id)    |
 | `core_load_change`                 | Change the colors of cpu core loads, uses the same data from `cpu_load_value` and `cpu_load_change` |
 | `core_load`                        | Display load & frequency per core                                                     |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -271,6 +271,7 @@ text_outline
 # width=0
 # height=140
 # table_columns=3
+# cellpadding_x=0
 # cellpadding_y=-0.085
 
 ### Hud transparency / alpha

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -105,6 +105,7 @@ void HudElements::convert_colors(const struct overlay_params& params)
     style.Colors[ImGuiCol_PlotHistogram] = convert(params.frametime_color);
     style.Colors[ImGuiCol_WindowBg]  = convert(params.background_color);
     style.Colors[ImGuiCol_Text] = convert(params.text_color);
+    style.CellPadding.x = params.cellpadding_x * real_font_size.x;
     style.CellPadding.y = params.cellpadding_y * real_font_size.y;
     style.WindowRounding = params.round_corners;
 }

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -464,6 +464,7 @@ parse_fps_metrics(const char *str){
 #define parse_alpha(s) parse_float(s)
 #define parse_permit_upload(s) parse_unsigned(s)
 #define parse_no_small_font(s) parse_unsigned(s) != 0
+#define parse_cellpadding_x(s) parse_float(s)
 #define parse_cellpadding_y(s) parse_float(s)
 #define parse_table_columns(s) parse_unsigned(s)
 #define parse_autostart_log(s) parse_unsigned(s)
@@ -771,6 +772,7 @@ static void set_param_defaults(struct overlay_params *params){
    params->benchmark_percentiles = { "97", "AVG"};
    params->gpu_load_value = { 60, 90 };
    params->cpu_load_value = { 60, 90 };
+   params->cellpadding_x = 0;
    params->cellpadding_y = -0.085;
    params->fps_color = { 0xb22222, 0xfdfd09, 0x39f900 };
    params->fps_value = { 30, 60 };
@@ -917,15 +919,17 @@ parse_overlay_config(struct overlay_params *params,
 
    //increase hud width if io read and write
    if (!params->width && !params->enabled[OVERLAY_PARAM_ENABLED_horizontal]) {
-      params->width = params->font_size * params->font_scale * params->table_columns * 4.6;
+      const auto real_size = params->font_size * params->font_scale;
+
+      params->width = static_cast<uint>(((1.0 + params->cellpadding_x * 2.0) * 4.6) * real_size * params->table_columns);
 
       if ((params->enabled[OVERLAY_PARAM_ENABLED_io_read] || params->enabled[OVERLAY_PARAM_ENABLED_io_write])) {
-         params->width += 2 * params->font_size * params->font_scale;
+         params->width += 2 * real_size;
       }
 
       // Treat it like hud would need to be ~7 characters wider with default font.
       if (params->no_small_font)
-         params->width += 7 * params->font_size * params->font_scale;
+         params->width += 7 * real_size;
    }
 
    params->font_params_hash = get_hash(params->font_size,

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -183,6 +183,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(cpu_load_color)              \
    OVERLAY_PARAM_CUSTOM(fps_value)                   \
    OVERLAY_PARAM_CUSTOM(fps_color)                   \
+   OVERLAY_PARAM_CUSTOM(cellpadding_x)               \
    OVERLAY_PARAM_CUSTOM(cellpadding_y)               \
    OVERLAY_PARAM_CUSTOM(table_columns)               \
    OVERLAY_PARAM_CUSTOM(blacklist)                   \
@@ -287,6 +288,7 @@ struct overlay_params {
    float font_size_text;
    float font_scale_media_player;
    float background_alpha, alpha;
+   float cellpadding_x;
    float cellpadding_y;
    std::vector<KeySym> toggle_hud;
    std::vector<KeySym> toggle_preset;


### PR DESCRIPTION
This allows take make the overlay smaller than it was possible:
![image](https://github.com/user-attachments/assets/d5f16164-7f91-432c-a838-eb196978dd7c)
