### PR TITLE
doc: add present_mode to MangoHud.conf

### DIFF
--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -154,6 +154,7 @@ throttling_status
 # wine
 # exec_name
 # winesync
+# present_mode
 
 ### Display loaded MangoHud architecture
 # arch


### PR DESCRIPTION
`present_mode` is a valid option that can be enabled, which is currently only documented in `README.md`. It is, however, missing from `MangoHud.conf`.

This PR aims to add  `present_mode` to `MangoHud.conf` in an initially disabled state (commented out).