### PR TITLE
elfhacks: d_un.d_ptr is relative on riscv glibc

### DIFF
--- a/src/elfhacks.cpp
+++ b/src/elfhacks.cpp
@@ -29,7 +29,7 @@
  *  \{
  */
 
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(__riscv)
 # define ABS_ADDR(obj, ptr) (ptr)
 #else
 # define ABS_ADDR(obj, ptr) ((obj->addr) + (ptr))


### PR DESCRIPTION
This PR fixes MangoHud on RISC-V, tested on several different RISC-V machines I have. Related commit is a4332733c3d09dcea3780d395730d9246bb5d3ae, which states that "d_un.d_ptr is relative on non glibc systems". But it seems on RISC-V, even with glibc, `d_un.d_ptr` is still relative for some reason.

I've used MangoHud on x86_64, AArch64, LoongArch and RISC-V, RISC-V is the only one has this behavior, but I don't know the reason. 