### PR TITLE
elfhacks: d_un.d_ptr is relative on mips glibc too

### DIFF
--- a/src/elfhacks.cpp
+++ b/src/elfhacks.cpp
@@ -29,7 +29,7 @@
  *  \{
  */
 
-#if defined(__GLIBC__) && !defined(__riscv)
+#if defined(__GLIBC__) && !(defined(__riscv) || defined(__mips__))
 # define ABS_ADDR(obj, ptr) (ptr)
 #else
 # define ABS_ADDR(obj, ptr) ((obj->addr) + (ptr))


### PR DESCRIPTION
In GLIBC, this behavior is controlled by per-architecture definition DL_RO_DYN_SECTION, which is only set to 1 on MIPS (according to the comments, it's because of requirements of MIPS ABI) and RISC-V (which seems to be a left-over of copying MIPS code, and kept because of compatibility to older GLIBC versions).