### PR TITLE
vulkan: Fix present mode fallback override

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1547,6 +1547,7 @@ static VkResult overlay_CreateSwapchainKHR(
          else {
             SPDLOG_DEBUG("Present mode is not supported: {}", HUDElements.presentModeMap[HUDElements.cur_present_mode]);
             HUDElements.cur_present_mode = VK_PRESENT_MODE_FIFO_KHR;
+            createInfo.presentMode = VK_PRESENT_MODE_FIFO_KHR;
          }
       }
    }


### PR DESCRIPTION
We have seen some reports of blank screens on games with Xwayland when vsync is disabled in MangoHud:
https://forums.developer.nvidia.com/t/blank-screens-on-games-with-adaptive-vsync-fifo-relaxed-khr-enabled-driver-550-regression-works-on-535/284442

It doesn't look like MangoHud correctly handles `FIFO_RELAXED_KHR` not being supported. In `overlay_CreateSwapchainKHR`, if `IsPresentModeSupported` returns false (which it will for `FIFO_RELAXED` on our driver with Xwayland at the moment) it sets  `HUDElements.cur_present_mode` to `VK_PRESENT_MODE_FIFO_KHR` but it does not update `createInfo.presentMode`. This could cause swapchain creation to fail since it's trying to use an unsupported present mode.

Does this analysis sound correct or am I misunderstanding how this should work?

Some additional context: earlier this summer we had stopped advertising `FIFO_RELAXED_KHR` with Xwayland in the NVIDIA driver since we weren't properly handling it and were treating it as regular FIFO, which was a bug. That seems to have triggered this issue. We will be implementing `FIFO_RELAXED_KHR` properly as we do want to support it on Xwayland, but figured I would report this issue in the meantime.