### PR TITLE
Include map header in hud_elements.h

### DIFF
--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <utility>
+#include <map>
 #include <imgui.h>
 #include "timing.hpp"
 #include <functional>


### PR DESCRIPTION
Otherwise, I get the following compilation errors on OSX

```
2024-09-09T22:58:12.8720860Z In file included from ../src/vulkan.cpp:49:
2024-09-09T22:58:12.8751290Z In file included from ../src/overlay.h:12:
2024-09-09T22:58:12.8785670Z ../src/hud_elements.h:147:14: error: no template named 'map' in namespace 'std'; did you mean 'max'?
2024-09-09T22:58:12.8805510Z   147 |         std::map<VkPresentModeKHR, std::string> presentModeMap = {
2024-09-09T22:58:12.8821870Z       |         ~~~~~^~~
2024-09-09T22:58:12.8838900Z       |              max
```

full log to be attached: 
[23_osx_fail.txt](https://github.com/user-attachments/files/16937451/23_osx_fail.txt)
