### PR TITLE
wayland: Fix crash in multi-seat sessions

### DIFF
--- a/src/wayland_keybinds.cpp
+++ b/src/wayland_keybinds.cpp
@@ -31,7 +31,7 @@ struct wl_seat_listener seat_listener {
 
 static void registry_handle_global(void *data, struct wl_registry* registry, uint32_t name, const char *interface, uint32_t version)
 {
-   if(strcmp(interface, wl_seat_interface.name) == 0)
+   if(strcmp(interface, wl_seat_interface.name) == 0 && !seat)
    {
       seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 5);
       wl_seat_add_listener(seat, &seat_listener, NULL);


### PR DESCRIPTION
Compositors may expose more than one wl_seat global, so only bind to the first one.

-------------------

If more than one seat is advertised by the registry then mangohud binds to all of them, but only keeps a pointer to the last one.
When this happens `seat_handle_capabilities` events are sent by the compositor for all of them.
If the last seat does not have a keyboard, but any previous one did then mangohud calls `wl_seat_get_keyboard` for this one, resulting in a fatal `missing_capability` error.

This also prevents memory leaks for every seat bound but not kept track of.

-------------------

The proper thing to do is support multiple wl_seats, but I'm not familiar enough with mangohud's code to implement it myself at the moment. For now this is a better than nothing fix.