### PR TITLE
Update regex in the get_pci_device_address

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -66,7 +66,7 @@ std::string GPUS::get_pci_device_address(const std::string& drm_card_path) {
 
     // Extract the last PCI address from the path using a regular expression
     // This regex matches typical PCI addresses like 0000:03:00.0
-    std::regex pci_address_regex(R"((\d{4}:\d{2}:\d{2}\.\d))");
+    std::regex pci_address_regex(R"((\d{4}:[a-z0-9]{2}:\d{2}\.\d))");
     std::smatch match;
     std::string pci_address;
 


### PR DESCRIPTION
Some GPUs are located on addresses that have characters in them, e.x. `0000:0c:00.0`. In those cases, old regex is not picking up the proper address an that leads to [this issue](https://github.com/flightlessmango/MangoHud/issues/1445).

The new regex, `((\d{4}:[a-z0-9]{2}:\d{2}\.\d))`, matches addresses with both characters and digits, which fixes the issue linked above.