### PR TITLE
logging: fix double-logging of avg fps

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -104,7 +104,7 @@ static void writeSummary(string filename){
       fps_values.push_back(data.fps);
 
     std::unique_ptr<fpsMetrics> fpsmetrics;
-    std::vector<std::string> metrics {"0.001", "0.01", "0.97", "avg"};
+    std::vector<std::string> metrics {"0.001", "0.01", "0.97"};
     fpsmetrics = std::make_unique<fpsMetrics>(metrics, fps_values);
     for (auto& metric : fpsmetrics->metrics)
       out << metric.value << ",";


### PR DESCRIPTION
the average fps was being logged twice in the summary: once alongside other frame percentage metrics (97%, .01%, ...) and once alongside every other metric. 

I've removed the first occurence and left the latter, since it uses precision(1). The pictures illustrate the before fix and after fix. The after fix works as expected:
![image](https://github.com/user-attachments/assets/e17c2f80-3693-4880-9b9f-ac1839bbdcff)
![image](https://github.com/user-attachments/assets/9aaccc02-b7d0-4f48-95ee-2b28ee542b18)
