### PR TITLE
add intel gpu usage support via fdinfo and fix fdinfo code a little

### DIFF
--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -17,6 +17,7 @@ std::string GPU_fdinfo::get_drm_engine_type() {
 }
 
 void GPU_fdinfo::find_fd() {
+#ifdef __linux__
     DIR* dir = opendir("/proc/self/fdinfo");
     if (!dir) {
         perror("Failed to open directory");
@@ -46,6 +47,7 @@ void GPU_fdinfo::find_fd() {
     }
 
     closedir(dir);
+#endif
 }
 
 uint64_t GPU_fdinfo::get_gpu_time() {

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -27,6 +27,7 @@ class GPU_fdinfo {
 
         uint64_t get_gpu_time();
         void get_load();
+        std::string get_drm_engine_type();
 
     public:
         GPU_fdinfo(const char* module) : module(module) {


### PR DESCRIPTION
I didn't really dive into details, but for some reason DETECT_OS_UNIX is never defined when I'm compiling on either NixOS or when using flatpak-builder to test mangohud for steam, so I deleted that for now.

Next comes  "drm-engine-gpu" bit. "gpu" is only for msm gpus, for other gpu drivers we should use different names. That's why I added a "get_drm_engine_type" function to retrieve load type name based on gpu driver. For now I added only amdgpu, i915 and msm because they were already referenced in the project.

Last thing is the method of calculating load. Biggest change here is waiting for at least METRICS_UPDATE_PERIOD_MS (500ms) before trying to update usage percentage. On my pc old method was not working correctly, it either was always showing 100% or always showing 0% with spikes to 100%.

Can't wait for any feedback. Hopefully this commit will finally fix intel gpu usage and I can finally play without having my phone below my monitor with ssh and intel_gpu_top on the phone's screen.