### PR TITLE
gpu_fdinfo: add vram usage (amd, intel) and power usage via hwmon (only intel)

### DIFF
--- a/src/gpu.h
+++ b/src/gpu.h
@@ -38,10 +38,10 @@ class GPU {
                 // For now we're only accepting one of these modules at once
                 // Might be possible that multiple can exist on a system in the future?
                 if (vendor_id == 0x8086)
-                    fdinfo = std::make_unique<GPU_fdinfo>("i915");
+                    fdinfo = std::make_unique<GPU_fdinfo>("i915", pci_dev);
 
                 if (vendor_id == 0x5143)
-                    fdinfo = std::make_unique<GPU_fdinfo>("msm");
+                    fdinfo = std::make_unique<GPU_fdinfo>("msm", pci_dev);
         }
 
         gpu_metrics get_metrics() {

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -168,12 +168,15 @@ void GPU_fdinfo::get_load() {
         static uint64_t previous_gpu_time, previous_time, now, gpu_time_now;
         static float power_usage_now, previous_power_usage;
 
-        gpu_time_now = get_gpu_time();
-        power_usage_now = get_power_usage();
         now = os_time_get_nano();
 
-        if (gpu_time_now > previous_gpu_time &&
-            now - previous_time > METRICS_UPDATE_PERIOD_MS * 1'000'000) {
+        if (now - previous_time < METRICS_UPDATE_PERIOD_MS * 1'000'000)
+            continue;
+
+        gpu_time_now = get_gpu_time();
+        power_usage_now = get_power_usage();
+
+        if (gpu_time_now > previous_gpu_time) {
             float time_since_last = now - previous_time;
             float gpu_since_last = gpu_time_now - previous_gpu_time;
             float power_usage_since_last = power_usage_now - previous_power_usage;

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -113,6 +113,11 @@ void GPU_fdinfo::find_intel_hwmon() {
     device += pci_dev;
     device += "/hwmon";
 
+    if (!fs::exists(device)) {
+        SPDLOG_DEBUG("Intel hwmon directory {} doesn't exist.", device);
+        return;
+    }
+
     auto dir_iterator = fs::directory_iterator(device);
     auto hwmon = dir_iterator->path().string();
 
@@ -123,7 +128,13 @@ void GPU_fdinfo::find_intel_hwmon() {
 
     hwmon += "/energy1_input";
 
+    if (!fs::exists(hwmon)) {
+        SPDLOG_DEBUG("Intel hwmon: file {} doesn't exist.", hwmon);
+        return;
+    }
+
     SPDLOG_DEBUG("Intel hwmon found: hwmon = {}", hwmon);
+
     energy_stream.open(hwmon);
 
     if (!energy_stream.good())
@@ -138,7 +149,12 @@ float GPU_fdinfo::get_power_usage() {
     uint64_t energy_input;
 
     energy_stream.seekg(0);
+
     std::getline(energy_stream, energy_input_str);
+
+    if (energy_input_str.empty())
+        return 0.f;
+
     energy_input = std::stoull(energy_input_str);
 
     return energy_input / 1'000'000;

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -16,6 +16,21 @@ std::string GPU_fdinfo::get_drm_engine_type() {
     return drm_type;
 }
 
+std::string GPU_fdinfo::get_drm_memory_type() {
+    std::string drm_type = "drm-";
+
+    // msm driver does not report vram usage
+
+    if (strstr(module, "amdgpu"))
+        drm_type += "memory-vram";
+    else if (strstr(module, "i915"))
+        drm_type += "total-local0";
+    else
+        drm_type += "memory-none";
+
+    return drm_type;
+}
+
 void GPU_fdinfo::find_fd() {
 #ifdef __linux__
     DIR* dir = opendir("/proc/self/fdinfo");
@@ -70,24 +85,51 @@ uint64_t GPU_fdinfo::get_gpu_time() {
     return total_val;
 }
 
+float GPU_fdinfo::get_vram_usage() {
+    char line[256];
+    uint64_t total_val = 0;
+
+    for (auto fd : fdinfo) {
+        rewind(fd);
+        fflush(fd);
+
+        uint64_t val = 0;
+
+        while (fgets(line, sizeof(line), fd)) {
+            std::string scan_str = get_drm_memory_type() + ": %llu KiB";
+
+            if (sscanf(line, scan_str.c_str(), &val) == 1) {
+                total_val += val;
+                break;
+            }
+        }
+    }
+
+    return (float)total_val / 1024 / 1024;
+}
+
 void GPU_fdinfo::get_load() {
     while (!stop_thread) {
         std::unique_lock<std::mutex> lock(metrics_mutex);
         cond_var.wait(lock, [this]() { return !paused || stop_thread; });
 
         static uint64_t previous_gpu_time, previous_time, now, gpu_time_now;
+
         gpu_time_now = get_gpu_time();
         now = os_time_get_nano();
 
         if (gpu_time_now > previous_gpu_time &&
-            now - previous_time > METRICS_UPDATE_PERIOD_MS * 1'000'000){
+            now - previous_time > METRICS_UPDATE_PERIOD_MS * 1'000'000) {
             float time_since_last = now - previous_time;
             float gpu_since_last = gpu_time_now - previous_gpu_time;
+
             auto result = int((gpu_since_last / time_since_last) * 100);
             if (result > 100)
                 result = 100;
 
             metrics.load = result;
+            metrics.memoryUsed = get_vram_usage();
+
             previous_gpu_time = gpu_time_now;
             previous_time = now;
         }

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -169,10 +169,6 @@ void GPU_fdinfo::get_load() {
         static float power_usage_now, previous_power_usage;
 
         now = os_time_get_nano();
-
-        if (now - previous_time < METRICS_UPDATE_PERIOD_MS * 1'000'000)
-            continue;
-
         gpu_time_now = get_gpu_time();
         power_usage_now = get_power_usage();
 
@@ -193,5 +189,7 @@ void GPU_fdinfo::get_load() {
             previous_time = now;
             previous_power_usage = power_usage_now;
         }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(METRICS_UPDATE_PERIOD_MS));
     }
 }

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -18,7 +18,10 @@ class GPU_fdinfo {
         struct gpu_metrics metrics;
         std::vector<FILE*> fdinfo;
         const char* module;
+        const char* pci_dev;
         void find_fd();
+        void find_intel_hwmon();
+        std::ifstream energy_stream;
         std::thread thread;
         std::condition_variable cond_var;
         std::atomic<bool> stop_thread{false};
@@ -30,10 +33,15 @@ class GPU_fdinfo {
         std::string get_drm_engine_type();
         std::string get_drm_memory_type();
         float get_vram_usage();
+        float get_power_usage();
 
     public:
-        GPU_fdinfo(const char* module) : module(module) {
+        GPU_fdinfo(const char* module, const char* pci_dev) : module(module), pci_dev(pci_dev) {
             find_fd();
+
+            if (strstr(module, "i915"))
+                find_intel_hwmon();
+
             std::thread thread(&GPU_fdinfo::get_load, this);
             thread.detach();
         }

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -28,6 +28,8 @@ class GPU_fdinfo {
         uint64_t get_gpu_time();
         void get_load();
         std::string get_drm_engine_type();
+        std::string get_drm_memory_type();
+        float get_vram_usage();
 
     public:
         GPU_fdinfo(const char* module) : module(module) {


### PR DESCRIPTION
I have tested that vram usage works both on my machine (intel arc a770) and on my laptop with integrated raven2 amd gpu (with changing a line to fdinfo [here](https://github.com/flightlessmango/MangoHud/blob/a109f0baf5b5477fb1b4c3ccdfbac2284077caec/src/gpu.h#L36)). Qualcomm have not implemented vram usage via fdinfo, so no vram for msm for now :).

One thing which I'm concerned about is that power usage might not work on older intel integrated gpus. The only test subject that I have is an i5-2500M and it doesn't have any gpu sensors. 