### PR TITLE
nvidia: fix vram usage metric not updating

### DIFF
--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -238,6 +238,9 @@ void NVIDIA::get_samples_and_copy() {
 
         GPU_UPDATE_METRIC_AVERAGE(temp);
 
+        GPU_UPDATE_METRIC_AVERAGE_FLOAT(memoryTotal);
+        GPU_UPDATE_METRIC_AVERAGE_FLOAT(memoryUsed);
+
         GPU_UPDATE_METRIC_MAX(is_power_throttled);
         GPU_UPDATE_METRIC_MAX(is_current_throttled);
         GPU_UPDATE_METRIC_MAX(is_temp_throttled);


### PR DESCRIPTION
This patch should fix VRAM usage not showing up on NVIDIA GPUs.

Before:
![before](https://github.com/user-attachments/assets/69d061c3-c743-4355-a149-dd3b81489029)

After:
![after](https://github.com/user-attachments/assets/247bec06-b6f2-4519-87d3-7dd7c14faa0b)
