### PR TITLE
gpu_fdinfo: add support for intel xe driver, rewrite c code with c++ and code cleanup

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -72,6 +72,26 @@ GPUS::GPUS(overlay_params* params) : params(params) {
     find_active_gpu();
 }
 
+std::string GPU::is_i915_or_xe() {
+    std::string path = "/sys/bus/pci/devices/";
+    path += pci_dev + "/driver";
+
+    if (!fs::exists(path)) {
+        SPDLOG_ERROR("{} doesn't exist", path);
+        return "";
+    }
+
+    if (!fs::is_symlink(path)) {
+        SPDLOG_ERROR("{} is not a symlink (it should be)", path);
+        return "";
+    }
+
+    std::string driver = fs::read_symlink(path);
+    driver = driver.substr(driver.rfind("/") + 1);
+
+    return driver;
+}
+
 std::string GPUS::get_pci_device_address(const std::string& drm_card_path) {
     // Resolve the symbolic link to get the actual device path
     fs::path device_path = fs::canonical(fs::path(drm_card_path) / "device");

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -86,7 +86,7 @@ std::string GPU::is_i915_or_xe() {
         return "";
     }
 
-    std::string driver = fs::read_symlink(path);
+    std::string driver = fs::read_symlink(path).string();
     driver = driver.substr(driver.rfind("/") + 1);
 
     return driver;

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -17,6 +17,9 @@
 #include "gpu_fdinfo.h"
 
 class GPU {
+    private:
+        std::string is_i915_or_xe();
+
     public:
         gpu_metrics metrics;
         std::string name;
@@ -38,7 +41,7 @@ class GPU {
                 // For now we're only accepting one of these modules at once
                 // Might be possible that multiple can exist on a system in the future?
                 if (vendor_id == 0x8086)
-                    fdinfo = std::make_unique<GPU_fdinfo>("i915", pci_dev);
+                    fdinfo = std::make_unique<GPU_fdinfo>(is_i915_or_xe(), pci_dev);
 
                 if (vendor_id == 0x5143)
                     fdinfo = std::make_unique<GPU_fdinfo>("msm", pci_dev);

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -1,7 +1,8 @@
 #include "gpu_fdinfo.h"
 namespace fs = ghc::filesystem;
 
-void GPU_fdinfo::find_fd() {
+void GPU_fdinfo::find_fd()
+{
     auto path = fs::path("/proc/self/fdinfo");
 
     if (!fs::exists(path)) {
@@ -33,7 +34,8 @@ void GPU_fdinfo::find_fd() {
         fdinfo.push_back(std::ifstream(fd));
 }
 
-uint64_t GPU_fdinfo::get_gpu_time() {
+uint64_t GPU_fdinfo::get_gpu_time()
+{
     uint64_t total_val = 0;
 
     for (auto& fd : fdinfo) {
@@ -52,7 +54,8 @@ uint64_t GPU_fdinfo::get_gpu_time() {
     return total_val;
 }
 
-float GPU_fdinfo::get_vram_usage() {
+float GPU_fdinfo::get_vram_usage()
+{
     uint64_t total_val = 0;
 
     for (auto& fd : fdinfo) {
@@ -71,7 +74,8 @@ float GPU_fdinfo::get_vram_usage() {
     return (float)total_val / 1024 / 1024;
 }
 
-void GPU_fdinfo::find_intel_hwmon() {
+void GPU_fdinfo::find_intel_hwmon()
+{
     std::string device = "/sys/bus/pci/devices/";
     device += pci_dev;
     device += "/hwmon";
@@ -104,7 +108,8 @@ void GPU_fdinfo::find_intel_hwmon() {
         SPDLOG_DEBUG("Intel hwmon: failed to open {}", hwmon);
 }
 
-float GPU_fdinfo::get_power_usage() {
+float GPU_fdinfo::get_power_usage()
+{
     if (!energy_stream.is_open())
         return 0.f;
 
@@ -123,7 +128,8 @@ float GPU_fdinfo::get_power_usage() {
     return (float)energy_input / 1'000'000;
 }
 
-void GPU_fdinfo::get_load() {
+void GPU_fdinfo::get_load()
+{
     while (!stop_thread) {
         std::unique_lock<std::mutex> lock(metrics_mutex);
         cond_var.wait(lock, [this]() { return !paused || stop_thread; });

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -37,8 +37,6 @@ class GPU_fdinfo {
 
     public:
         GPU_fdinfo(const std::string module, const std::string pci_dev) : module(module), pci_dev(pci_dev) {
-            find_fd();
-
             if (module == "i915") {
                 drm_engine_type = "drm-engine-render";
                 drm_memory_type = "drm-total-local0";
@@ -50,6 +48,8 @@ class GPU_fdinfo {
                 // msm driver does not report vram usage
                 drm_engine_type = "drm-engine-gpu";
             }
+
+            find_fd();
 
             std::thread thread(&GPU_fdinfo::get_load, this);
             thread.detach();

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -11,6 +11,7 @@
 #include "gpu_metrics_util.h"
 #include <atomic>
 #include <spdlog/spdlog.h>
+#include <map>
 
 class GPU_fdinfo {
 private:
@@ -33,6 +34,9 @@ private:
 
     std::string drm_engine_type = "EMPTY";
     std::string drm_memory_type = "EMPTY";
+
+    std::vector<std::map<std::string, std::string>> fdinfo_data;
+    void gather_fdinfo_data();
 
     void main_thread();
 

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -1,71 +1,77 @@
 #pragma once
-#include <sys/stat.h>
-#include <thread>
 #include <filesystem.h>
 #include <inttypes.h>
+#include <sys/stat.h>
+#include <thread>
 #ifdef TEST_ONLY
 #include <../src/mesa/util/os_time.h>
 #else
 #include <mesa/util/os_time.h>
 #endif
-#include <spdlog/spdlog.h>
 #include "gpu_metrics_util.h"
 #include <atomic>
+#include <spdlog/spdlog.h>
 
 class GPU_fdinfo {
-    private:
-        bool init = false;
-        struct gpu_metrics metrics;
-        std::vector<std::ifstream> fdinfo;
-        const std::string module;
-        const std::string pci_dev;
-        void find_fd();
-        void find_intel_hwmon();
-        std::ifstream energy_stream;
-        std::thread thread;
-        std::condition_variable cond_var;
-        std::atomic<bool> stop_thread{false};
-        std::atomic<bool> paused{false};
-        mutable std::mutex metrics_mutex;
+private:
+    bool init = false;
+    struct gpu_metrics metrics;
+    std::vector<std::ifstream> fdinfo;
+    const std::string module;
+    const std::string pci_dev;
+    void find_fd();
+    void find_intel_hwmon();
+    std::ifstream energy_stream;
+    std::thread thread;
+    std::condition_variable cond_var;
+    std::atomic<bool> stop_thread { false };
+    std::atomic<bool> paused { false };
+    mutable std::mutex metrics_mutex;
 
-        uint64_t get_gpu_time();
-        void get_load();
-        std::string drm_engine_type = "EMPTY";
-        std::string drm_memory_type = "EMPTY";
-        float get_vram_usage();
-        float get_power_usage();
+    uint64_t get_gpu_time();
+    void get_load();
+    std::string drm_engine_type = "EMPTY";
+    std::string drm_memory_type = "EMPTY";
+    float get_vram_usage();
+    float get_power_usage();
 
-    public:
-        GPU_fdinfo(const std::string module, const std::string pci_dev) : module(module), pci_dev(pci_dev) {
-            if (module == "i915") {
-                drm_engine_type = "drm-engine-render";
-                drm_memory_type = "drm-total-local0";
-                find_intel_hwmon();
-            } else if (module == "amdgpu") {
-                drm_engine_type = "drm-engine-gfx";
-                drm_memory_type = "drm-memory-vram";
-            } else if (module == "msm") {
-                // msm driver does not report vram usage
-                drm_engine_type = "drm-engine-gpu";
-            }
-
-            find_fd();
-
-            std::thread thread(&GPU_fdinfo::get_load, this);
-            thread.detach();
+public:
+    GPU_fdinfo(const std::string module, const std::string pci_dev)
+        : module(module)
+        , pci_dev(pci_dev)
+    {
+        if (module == "i915") {
+            drm_engine_type = "drm-engine-render";
+            drm_memory_type = "drm-total-local0";
+            find_intel_hwmon();
+        } else if (module == "amdgpu") {
+            drm_engine_type = "drm-engine-gfx";
+            drm_memory_type = "drm-memory-vram";
+        } else if (module == "msm") {
+            // msm driver does not report vram usage
+            drm_engine_type = "drm-engine-gpu";
         }
 
-        gpu_metrics copy_metrics() const {
-            return metrics;
-        };
+        find_fd();
 
-        void pause() {
-            paused = true;
-            cond_var.notify_one();
-        }
+        std::thread thread(&GPU_fdinfo::get_load, this);
+        thread.detach();
+    }
 
-        void resume() {
-            paused = false;
-            cond_var.notify_one();
-        }
+    gpu_metrics copy_metrics() const
+    {
+        return metrics;
+    };
+
+    void pause()
+    {
+        paused = true;
+        cond_var.notify_one();
+    }
+
+    void resume()
+    {
+        paused = false;
+        cond_var.notify_one();
+    }
 };

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -15,24 +15,36 @@
 class GPU_fdinfo {
 private:
     bool init = false;
-    struct gpu_metrics metrics;
-    std::vector<std::ifstream> fdinfo;
+
     const std::string module;
     const std::string pci_dev;
-    void find_fd();
-    void find_intel_hwmon();
-    std::ifstream energy_stream;
+
     std::thread thread;
     std::condition_variable cond_var;
+
     std::atomic<bool> stop_thread { false };
     std::atomic<bool> paused { false };
+
+    struct gpu_metrics metrics;
     mutable std::mutex metrics_mutex;
 
-    uint64_t get_gpu_time();
-    void get_load();
+    std::vector<std::ifstream> fdinfo;
+    std::ifstream energy_stream;
+
     std::string drm_engine_type = "EMPTY";
     std::string drm_memory_type = "EMPTY";
-    float get_vram_usage();
+
+    void main_thread();
+
+    void find_fd();
+    void find_intel_hwmon();
+
+    int get_gpu_load();
+    uint64_t get_gpu_time();
+
+    float get_memory_used();
+
+    float get_current_power();
     float get_power_usage();
 
 public:
@@ -54,7 +66,7 @@ public:
 
         find_fd();
 
-        std::thread thread(&GPU_fdinfo::get_load, this);
+        std::thread thread(&GPU_fdinfo::main_thread, this);
         thread.detach();
     }
 


### PR DESCRIPTION
Tested that it's working on `i915`, `xe` and `amdgpu` drivers.

Off-Topic: While writing this code I found out that current method of fdinfo load calculation is not always correct. It has to do with duplicated or stuck values. I'll fix that later. This concerns `i915`, `amdgpu` and `msm` drivers. I'm not sure that it concerns `xe`, because as far as I can tell all values are matching to `gputop` utility.