### PR TITLE
cpu temp: support LoongArch cpu

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -537,6 +537,10 @@ bool CPUStats::GetCpuFile() {
             // Only break if module has CPU node
             if (find_input(path, "temp", input, "CPU"))
                 break;
+        } else if (name == "cpu_hwmon") {
+            // for loongarch cpu temp, read /sys/class/hwmon{n}, with name cpu_hwmon
+                find_input(path, "temp1", input, "CPU");
+                break;
         } else {
             path.clear();
         }

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -761,7 +761,7 @@ void init_system_info(){
 
       ram =  exec("sed -n 's/^MemTotal: *\\([0-9]*\\).*/\\1/p' /proc/meminfo");
       trim(ram);
-      cpu =  exec("sed -n 's/^model name.*: \\(.*\\)/\\1/p' /proc/cpuinfo | sed 's/([^)]*)//g' | tail -n1");
+      cpu =  exec("sed -n 's/^[M,m]odel [N,n]ame.*: \\(.*\\)/\\1/p' /proc/cpuinfo | sed 's/([^)]*)//g' | tail -n1");
       trim(cpu);
       kernel = exec("uname -r");
       trim(kernel);


### PR DESCRIPTION
LoongArch cpu linux hwmon temp driver support.
LoongArch cpu /proc/cpuinfo support ( "Model Name" vs "model name").

tested on Loongson 3A5000/3A6000/3C6000.

Changed files:
	modified:   src/cpu.cpp
	modified:   src/overlay.cpp

working result:
![2024-11-27 23-34-42屏幕截图](https://github.com/user-attachments/assets/83188025-9fc3-4f58-8530-448e86abbf33)
