### PR TITLE
gpu_fdinfo bug fixes, almost full support for Intel is finally here

### DIFF
--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -316,9 +316,12 @@ text_outline
 # battery_color=FF9078
 # network_color=E07B85
 
-### Specify GPU with PCI bus ID for AMDGPU and NVML stats
+### Specify GPU with PCI bus ID
 ### Set to 'domain:bus:slot.function'
-# pci_dev=0:0a:0.0
+### Example:
+###     $ lspci | grep A770
+###     03:00.0 VGA compatible controller: Intel Corporation DG2 [Arc A770] (rev 08)
+# pci_dev=0000:03:00.0
 
 ### Blacklist
 # blacklist=

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -1,4 +1,5 @@
 #include "gpu.h"
+#include <cstdint>
 #include <inttypes.h>
 #include <memory>
 #include <functional>
@@ -22,16 +23,17 @@ GPUS::GPUS(overlay_params* params) : params(params) {
     std::vector<std::string> gpu_entries;
 
     for (const auto& entry : fs::directory_iterator("/sys/class/drm")) {
-        if (entry.is_directory()) {
-            std::string node_name = entry.path().filename().string();
+        if (!entry.is_directory())
+            continue;
 
-            // Check if the directory is a render node (e.g., renderD128, renderD129, etc.)
-            if (node_name.find("renderD") == 0 && node_name.length() > 7) {
-                // Ensure the rest of the string after "renderD" is numeric
-                std::string render_number = node_name.substr(7);
-                if (std::all_of(render_number.begin(), render_number.end(), ::isdigit)) {
-                    gpu_entries.push_back(node_name);  // Store the render entry
-                }
+        std::string node_name = entry.path().filename().string();
+
+        // Check if the directory is a render node (e.g., renderD128, renderD129, etc.)
+        if (node_name.find("renderD") == 0 && node_name.length() > 7) {
+            // Ensure the rest of the string after "renderD" is numeric
+            std::string render_number = node_name.substr(7);
+            if (std::all_of(render_number.begin(), render_number.end(), ::isdigit)) {
+                gpu_entries.push_back(node_name);  // Store the render entry
             }
         }
     }
@@ -44,6 +46,8 @@ GPUS::GPUS(overlay_params* params) : params(params) {
     });
 
     // Now process the sorted GPU entries
+    uint8_t idx = 0, total_active = 0;
+
     for (const auto& node_name : gpu_entries) {
         std::string path = "/sys/class/drm/" + node_name;
         std::string device_address = get_pci_device_address(path);  // Store the result
@@ -56,7 +60,7 @@ GPUS::GPUS(overlay_params* params) : params(params) {
         } catch(...) {
             SPDLOG_ERROR("stoul failed on: {}", "/sys/bus/pci/devices/" + device_address + "/vendor");
         }
-        
+
         try {
             device_id = std::stoul(read_line("/sys/bus/pci/devices/" + device_address + "/device"), nullptr, 16);
         } catch (...) {
@@ -64,10 +68,40 @@ GPUS::GPUS(overlay_params* params) : params(params) {
         }
 
         std::shared_ptr<GPU> ptr = std::make_shared<GPU>(node_name, vendor_id, device_id, pci_dev);
+
+        if (params->gpu_list.size() == 1 && params->gpu_list[0] == idx++)
+            ptr->is_active = true;
+
+        if (!params->pci_dev.empty() && pci_dev == params->pci_dev)
+            ptr->is_active = true;
+
         available_gpus.emplace_back(ptr);
 
         SPDLOG_DEBUG("GPU Found: node_name: {}, vendor_id: {:x} device_id: {:x} pci_dev: {}", node_name, vendor_id, device_id, pci_dev);
+
+        if (ptr->is_active) {
+            SPDLOG_INFO("Set {} as active GPU (id={:x}:{:x} pci_dev={})", node_name, vendor_id, device_id, pci_dev);
+            total_active++;
+        }
     }
+
+    if (total_active < 2)
+        return;
+
+    for (auto& gpu : available_gpus) {
+        if (!gpu->is_active)
+            continue;
+
+        SPDLOG_WARN(
+            "You have more than 1 active GPU, check if you use both pci_dev "
+            "and gpu_list. If you use fps logging, MangoHud will log only "
+            "this GPU: name = {}, vendor = {:x}, pci_dev = {}",
+            gpu->name, gpu->vendor_id, gpu->pci_dev
+        );
+
+        break;
+    }
+
 }
 
 std::string GPU::is_i915_or_xe() {
@@ -120,7 +154,7 @@ std::string GPUS::get_pci_device_address(const std::string& drm_card_path) {
 
 int GPU::index_in_selected_gpus() {
     auto selected_gpus = gpus->selected_gpus();
-    auto it = std::find_if(selected_gpus.begin(), selected_gpus.end(), 
+    auto it = std::find_if(selected_gpus.begin(), selected_gpus.end(),
                         [this](const std::shared_ptr<GPU>& gpu) {
                             return gpu.get() == this;
                         });

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -181,8 +181,7 @@ void GPUS::find_active_gpu() {
             }
         }
 #endif
-    }
-    SPDLOG_DEBUG("failed to find active GPU");
+    SPDLOG_WARN("failed to find active GPU");
 }
 
 int GPU::index_in_selected_gpus() {

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -123,7 +123,6 @@ class GPUS {
         std::mutex mutex;
         overlay_params* params;
 
-        void find_active_gpu();
         GPUS(overlay_params* params);
 
         void pause() {

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -299,20 +299,33 @@ void GPU_fdinfo::find_i915_gt_dir()
         }
     }
 
-    device += "/gt_act_freq_mhz";
-
-    if (!fs::exists(device)) {
-        SPDLOG_WARN(
-            "Intel gt file ({}) not found. GPU clock will not be available.",
-            device
-        );
-        return;
-    }
-
-    gpu_clock_stream.open(device);
+    auto gpu_clock_path = device + "/gt_act_freq_mhz";
+    gpu_clock_stream.open(gpu_clock_path);
 
     if (!gpu_clock_stream.good())
         SPDLOG_WARN("Intel i915 gt dir: failed to open {}", device);
+
+    // Assuming gt0 since all recent GPUs have the RCS engine on gt0,
+    // and latest GPUs need Xe anyway
+    auto throttle_folder = device + "/gt/gt0/throttle_";
+    auto throttle_status_path = throttle_folder + "reason_status";
+
+    throttle_status_stream.open(throttle_status_path);
+    if (!throttle_status_stream.good()) {
+       SPDLOG_WARN("Intel i915 gt dir: failed to open {}", throttle_status_path);
+    } else {
+        load_xe_i915_throttle_reasons(throttle_folder,
+                                      intel_throttle_power,
+                                      throttle_power_streams);
+
+        load_xe_i915_throttle_reasons(throttle_folder,
+                                      intel_throttle_current,
+                                      throttle_current_streams);
+
+        load_xe_i915_throttle_reasons(throttle_folder,
+                                      intel_throttle_temp,
+                                      throttle_temp_streams);
+    }
 }
 
 void GPU_fdinfo::find_xe_gt_dir()
@@ -358,12 +371,54 @@ void GPU_fdinfo::find_xe_gt_dir()
         return;
     }
 
-    device += "/freq0/act_freq";
-
-    gpu_clock_stream.open(device);
+    auto gpu_clock_path = device + "/freq0/act_freq";
+    gpu_clock_stream.open(gpu_clock_path);
 
     if (!gpu_clock_stream.good())
-        SPDLOG_WARN("Intel xe gt dir: failed to open {}", device);
+        SPDLOG_WARN("Intel xe gt dir: failed to open {}", gpu_clock_path);
+
+    auto throttle_folder = device + "/freq0/throttle/";
+    auto throttle_status_path = throttle_folder + "status";
+
+    throttle_status_stream.open(throttle_status_path);
+    if (!throttle_status_stream.good()) {
+       SPDLOG_WARN("Intel xe gt dir: failed to open {}", throttle_status_path);
+    } else {
+        load_xe_i915_throttle_reasons(throttle_folder,
+                                      intel_throttle_power,
+                                      throttle_power_streams);
+
+        load_xe_i915_throttle_reasons(throttle_folder,
+                                      intel_throttle_current,
+                                      throttle_current_streams);
+
+        load_xe_i915_throttle_reasons(throttle_folder,
+                                      intel_throttle_temp,
+                                      throttle_temp_streams);
+    }
+}
+
+void GPU_fdinfo::load_xe_i915_throttle_reasons(
+    std::string throttle_folder,
+    std::vector<std::string> throttle_reasons,
+    std::vector<std::ifstream>& throttle_reason_streams
+) {
+    for (const auto& throttle_reason : throttle_reasons) {
+        std::string throttle_path = throttle_folder + throttle_reason;
+        if (!fs::exists(throttle_path)) {
+            SPDLOG_WARN(
+                "Intel xe/i915 gt dir: Throttle file {} not found",
+                throttle_path
+            );
+            continue;
+        }
+        auto throttle_stream = std::ifstream(throttle_path);
+        if (!throttle_stream.good()) {
+            SPDLOG_WARN("Intel xe/i915 gt dir: failed to open {}", throttle_path);
+            continue;
+        }
+        throttle_reason_streams.push_back(std::move(throttle_stream));
+    }
 }
 
 int GPU_fdinfo::get_gpu_clock()
@@ -383,6 +438,44 @@ int GPU_fdinfo::get_gpu_clock()
     return std::stoi(clock_str);
 }
 
+bool GPU_fdinfo::check_throttle_reasons(
+    std::vector<std::ifstream>& throttle_reason_streams)
+{
+    for (auto& throttle_reason_stream : throttle_reason_streams) {
+        std::string throttle_reason_str;
+        throttle_reason_stream.seekg(0);
+        std::getline(throttle_reason_stream, throttle_reason_str);
+
+        if (throttle_reason_str == "1")
+            return true;
+    }
+
+    return false;
+}
+
+int GPU_fdinfo::get_throttling_status()
+{
+    if (!throttle_status_stream.is_open())
+        return 0;
+
+    std::string throttle_status_str;
+    throttle_status_stream.seekg(0);
+    std::getline(throttle_status_stream, throttle_status_str);
+
+    if (throttle_status_str != "1")
+        return 0;
+
+    int reasons =
+        check_throttle_reasons(throttle_power_streams) * GPU_throttle_status::POWER +
+        check_throttle_reasons(throttle_current_streams) * GPU_throttle_status::CURRENT +
+        check_throttle_reasons(throttle_temp_streams) * GPU_throttle_status::TEMP;
+    // No throttle reasons for OTHER currently
+    if (reasons == 0)
+        reasons |= GPU_throttle_status::OTHER;
+
+    return reasons;
+}
+
 void GPU_fdinfo::main_thread()
 {
     while (!stop_thread) {
@@ -396,6 +489,11 @@ void GPU_fdinfo::main_thread()
         metrics.memoryUsed = get_memory_used();
         metrics.powerUsage = get_power_usage();
         metrics.CoreClock = get_gpu_clock();
+        auto throttling = get_throttling_status();
+        metrics.is_power_throttled = throttling & GPU_throttle_status::POWER;
+        metrics.is_current_throttled = throttling & GPU_throttle_status::CURRENT;
+        metrics.is_temp_throttled = throttling & GPU_throttle_status::TEMP;
+        metrics.is_other_throttled = throttling & GPU_throttle_status::OTHER;
         metrics.temp = hwmon_sensors["temp"].val / 1000;
         metrics.fan_speed = hwmon_sensors["fan_speed"].val;
         metrics.voltage = hwmon_sensors["voltage"].val;

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -244,6 +244,104 @@ int GPU_fdinfo::get_gpu_load()
     return result;
 }
 
+void GPU_fdinfo::find_i915_gt_dir()
+{
+    std::string device = "/sys/bus/pci/devices/" + pci_dev + "/drm";
+
+    // Find first dir which starts with name "card"
+    for (const auto& entry : fs::directory_iterator(device)) {
+        auto path = entry.path().string();
+
+        if (path.substr(device.size() + 1, 4) == "card") {
+            device = path;
+            break;
+        }
+    }
+
+    device += "/gt_act_freq_mhz";
+
+    if (!fs::exists(device)) {
+        SPDLOG_WARN(
+            "Intel gt file ({}) not found. GPU clock will not be available.",
+            device
+        );
+        return;
+    }
+
+    gpu_clock_stream.open(device);
+
+    if (!gpu_clock_stream.good())
+        SPDLOG_WARN("Intel i915 gt dir: failed to open {}", device);
+}
+
+void GPU_fdinfo::find_xe_gt_dir()
+{
+    std::string device = "/sys/bus/pci/devices/" + pci_dev + "/tile0";
+
+    if (!fs::exists(device)) {
+        SPDLOG_WARN(
+            "\"{}\" doesn't exist. GPU clock will be unavailable.",
+            device
+        );
+        return;
+    }
+
+    bool has_rcs = true;
+
+    // Check every "gt" dir if it has "engines/rcs" inside
+    for (const auto& entry : fs::directory_iterator(device)) {
+        auto path = entry.path().string();
+
+        if (path.substr(device.size() + 1, 2) != "gt")
+            continue;
+
+        SPDLOG_DEBUG("Checking \"{}\" for rcs.", path);
+
+        if (!fs::exists(path + "/engines/rcs")) {
+            SPDLOG_DEBUG("Skipping \"{}\" because rcs doesn't exist.", path);
+            continue;
+        }
+
+        SPDLOG_DEBUG("Found rcs in \"{}\"", path);
+        has_rcs = true;
+        device = path;
+        break;
+
+    }
+
+    if (!has_rcs) {
+        SPDLOG_WARN(
+            "rcs not found inside \"{}\". GPU clock will not be available.",
+            device
+        );
+        return;
+    }
+
+    device += "/freq0/act_freq";
+
+    gpu_clock_stream.open(device);
+
+    if (!gpu_clock_stream.good())
+        SPDLOG_WARN("Intel xe gt dir: failed to open {}", device);
+}
+
+int GPU_fdinfo::get_gpu_clock()
+{
+    if (!gpu_clock_stream.is_open())
+        return 0;
+
+    std::string clock_str;
+
+    gpu_clock_stream.seekg(0);
+
+    std::getline(gpu_clock_stream, clock_str);
+
+    if (clock_str.empty())
+        return 0;
+
+    return std::stoi(clock_str);
+}
+
 void GPU_fdinfo::main_thread()
 {
     while (!stop_thread) {
@@ -255,6 +353,7 @@ void GPU_fdinfo::main_thread()
         metrics.load = get_gpu_load();
         metrics.memoryUsed = get_memory_used();
         metrics.powerUsage = get_power_usage();
+        metrics.CoreClock = get_gpu_clock();
 
         SPDLOG_DEBUG(
             "pci_dev = {}, pid = {}, module = {}, load = {}, mem = {}, power = {}",

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -141,13 +141,12 @@ float GPU_fdinfo::get_current_power()
 
 float GPU_fdinfo::get_power_usage()
 {
-    static float last;
     float now = get_current_power();
 
-    float delta = now - last;
+    float delta = now - this->last_power;
     delta /= (float)METRICS_UPDATE_PERIOD_MS / 1000;
 
-    last = now;
+    this->last_power = now;
 
     return delta;
 }
@@ -219,8 +218,6 @@ int GPU_fdinfo::get_xe_load()
 
 int GPU_fdinfo::get_gpu_load()
 {
-    static uint64_t previous_gpu_time, previous_time;
-
     if (module == "xe")
         return get_xe_load();
 
@@ -253,7 +250,13 @@ void GPU_fdinfo::main_thread()
         metrics.memoryUsed = get_memory_used();
         metrics.powerUsage = get_power_usage();
 
+        SPDLOG_DEBUG(
+            "pci_dev = {}, pid = {}, module = {}, load = {}, mem = {}, power = {}",
+            pci_dev, pid, module, metrics.load, metrics.memoryUsed, metrics.powerUsage
+        );
+
         std::this_thread::sleep_for(
-            std::chrono::milliseconds(METRICS_UPDATE_PERIOD_MS));
+            std::chrono::milliseconds(METRICS_UPDATE_PERIOD_MS)
+        );
     }
 }

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -144,6 +144,10 @@ void GPU_fdinfo::find_intel_hwmon()
 
     if (!energy_stream.good())
         SPDLOG_DEBUG("Intel hwmon: failed to open {}", hwmon);
+
+    // Initialize value for the first time, otherwise delta will be very large
+    // and your gpu power usage will be like 1 million watts for a second.
+    this->last_power = get_current_power();
 }
 
 float GPU_fdinfo::get_current_power()

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -53,8 +53,8 @@ private:
     uint64_t previous_gpu_time, previous_time = 0;
 
     std::vector<uint64_t> xe_fdinfo_last_cycles;
+    std::map<std::string, std::pair<uint64_t, uint64_t>> prev_xe_cycles;
     int get_xe_load();
-    std::pair<uint64_t, uint64_t> get_gpu_time_xe();
 
     float get_memory_used();
 

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -70,6 +70,7 @@ public:
         SPDLOG_DEBUG("GPU driver is \"{}\"", module);
 
         find_fd();
+        gather_fdinfo_data();
 
         if (module == "i915") {
             drm_engine_type = "drm-engine-render";
@@ -77,6 +78,17 @@ public:
         } else if (module == "xe") {
             drm_engine_type = "drm-total-cycles-rcs";
             drm_memory_type = "drm-resident-vram0";
+
+            if (
+                fdinfo_data.size() > 0 &&
+                fdinfo_data[0].find(drm_memory_type) == fdinfo_data[0].end()
+            ) {
+                SPDLOG_DEBUG(
+                    "\"{}\" is not found, you probably have an integrated GPU. "
+                    "Using \"drm-resident-gtt\".", drm_memory_type
+                );
+                drm_memory_type = "drm-resident-gtt";
+            }
         } else if (module == "amdgpu") {
             drm_engine_type = "drm-engine-gfx";
             drm_memory_type = "drm-memory-vram";

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -2,6 +2,7 @@
 #include <filesystem.h>
 #include <inttypes.h>
 #include <sys/stat.h>
+#include <unistd.h>
 #include <thread>
 #ifdef TEST_ONLY
 #include <../src/mesa/util/os_time.h>
@@ -16,6 +17,7 @@
 class GPU_fdinfo {
 private:
     bool init = false;
+    pid_t pid = getpid();
 
     const std::string module;
     const std::string pci_dev;
@@ -45,6 +47,7 @@ private:
 
     int get_gpu_load();
     uint64_t get_gpu_time();
+    uint64_t previous_gpu_time, previous_time = 0;
 
     std::vector<uint64_t> xe_fdinfo_last_cycles;
     int get_xe_load();
@@ -54,6 +57,7 @@ private:
 
     float get_current_power();
     float get_power_usage();
+    float last_power = 0;
 
 public:
     GPU_fdinfo(const std::string module, const std::string pci_dev)

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -10,7 +10,7 @@
 #ifdef TEST_ONLY
 #include <../src/mesa/util/os_time.h>
 #else
-#include <mesa/util/os_time.h>
+#include "mesa/util/os_time.h"
 #endif
 
 #include "gpu_metrics_util.h"

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -14,7 +14,6 @@
 #include <spdlog/spdlog.h>
 #include <map>
 #include <set>
-#include <unistd.h>
 
 class GPU_fdinfo {
 private:
@@ -46,7 +45,6 @@ private:
 
     void find_fd();
     void open_fdinfo_fd(std::string path);
-    void find_intel_hwmon();
 
     int get_gpu_load();
     uint64_t get_gpu_time();
@@ -58,9 +56,15 @@ private:
 
     float get_memory_used();
 
+    void find_intel_hwmon();
     float get_current_power();
     float get_power_usage();
     float last_power = 0;
+
+    std::ifstream gpu_clock_stream;
+    void find_i915_gt_dir();
+    void find_xe_gt_dir();
+    int get_gpu_clock();
 
 public:
     GPU_fdinfo(const std::string module, const std::string pci_dev)
@@ -104,6 +108,11 @@ public:
 
         if (module == "i915" || module == "xe")
             find_intel_hwmon();
+
+        if (module == "i915")
+            find_i915_gt_dir();
+        else if (module == "xe")
+            find_xe_gt_dir();
 
         std::thread thread(&GPU_fdinfo::main_thread, this);
         thread.detach();

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -28,6 +28,13 @@ struct hwmon_sensor {
     uint64_t val = 0;
 };
 
+enum GPU_throttle_status : int {
+    POWER = 0b0001,
+    CURRENT = 0b0010,
+    TEMP = 0b0100,
+    OTHER = 0b1000,
+};
+
 class GPU_fdinfo {
 private:
     bool init = false;
@@ -80,6 +87,22 @@ private:
     void find_i915_gt_dir();
     void find_xe_gt_dir();
     int get_gpu_clock();
+
+    std::ifstream throttle_status_stream;
+    std::vector<std::ifstream> throttle_power_streams;
+    std::vector<std::ifstream> throttle_current_streams;
+    std::vector<std::ifstream> throttle_temp_streams;
+    bool check_throttle_reasons(std::vector<std::ifstream> &throttle_reason_streams);
+    int get_throttling_status();
+
+    const std::vector<std::string> intel_throttle_power = {"reason_pl1", "reason_pl2"};
+    const std::vector<std::string> intel_throttle_current = {"reason_pl4", "reason_vr_tdc"};
+    const std::vector<std::string> intel_throttle_temp = {
+        "reason_prochot", "reason_ratl", "reason_thermal", "reason_vr_thermalert"};
+    void load_xe_i915_throttle_reasons(
+        std::string throttle_folder,
+        std::vector<std::string> throttle_reasons,
+        std::vector<std::ifstream> &throttle_reason_streams);
 
 public:
     GPU_fdinfo(const std::string module, const std::string pci_dev)

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -250,22 +250,20 @@ void HudElements::gpu_stats(){
                 ImGui::PopFont();
             }
 
-            if (HUDElements.vendorID == 0x1002 || HUDElements.vendorID == 0x10de){
-                if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_fan] && cpuStats.cpu_type != "APU"){
-                    ImguiNextColumnOrNewRow();
-                    right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.fan_speed);
+            if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_fan] && !gpu->is_apu()){
+                ImguiNextColumnOrNewRow();
+                right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.fan_speed);
+                ImGui::SameLine(0, 1.0f);
+                if (gpu->metrics.fan_rpm) {
+                    ImGui::PushFont(HUDElements.sw_stats->font1);
+                    HUDElements.TextColored(HUDElements.colors.text, "RPM");
+                } else {
+                    HUDElements.TextColored(HUDElements.colors.text, "%%");
+                    ImGui::PushFont(HUDElements.sw_stats->font1);
                     ImGui::SameLine(0, 1.0f);
-                    if (gpu->metrics.fan_rpm) {
-                        ImGui::PushFont(HUDElements.sw_stats->font1);
-                        HUDElements.TextColored(HUDElements.colors.text, "RPM");
-                    } else {
-                        HUDElements.TextColored(HUDElements.colors.text, "%%");
-                        ImGui::PushFont(HUDElements.sw_stats->font1);
-                        ImGui::SameLine(0, 1.0f);
-                        HUDElements.TextColored(HUDElements.colors.text, "FAN");
-                    }
-                    ImGui::PopFont();
+                    HUDElements.TextColored(HUDElements.colors.text, "FAN");
                 }
+                ImGui::PopFont();
             }
 
             if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_core_clock]){

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -91,7 +91,7 @@ void init_spdlog()
       }
 #ifndef DEBUG
    } else {
-      std::string log_level = "err";
+      std::string log_level = "info";
       transform(log_level.begin(), log_level.end(), log_level.begin(), ::tolower);
       spdlog::set_level(spdlog::level::from_str(log_level));
 #endif

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -997,6 +997,13 @@ parse_overlay_config(struct overlay_params *params,
    if (HUDElements.net)
       HUDElements.net->should_reset = true;
 
+   if (!params->gpu_list.empty() && !params->pci_dev.empty()) {
+      SPDLOG_WARN(
+         "You have specified both gpu_list and pci_dev, "
+         "ignoring pci_dev."
+      );
+   }
+
    {
       std::lock_guard<std::mutex> lock(config_mtx);
       config_ready = true;


### PR DESCRIPTION
Resolves #1082
Resolves #1454

First I would like to thank you these guys for testing patches: @PerAstraAdDeum, @nokia8801 and @retrixe for helping in development.

In short, this pr fixes: 

1. wrong power usage for some people (https://github.com/flightlessmango/MangoHud/issues/1082#issuecomment-2513772813)
2. wrong gpu usage in some cases
3. vram support for integrated gpus in xe (forgot about those :crying_cat_face:)
4. 1 million watt gpu power at start (which confused one user when testing)
5. some info messages.
6. gpu clock support for i915 and xe
7. fan speed support (tested only on i915 and xe, should have linux 6.12+)
8. generic hwmon support (tested only on i915 and xe)
9. throttling support (only i915 and xe)
10. temperature support (only i915, should have linux 6.13+)
11. shows all gpus by default, otherwise user can choose which gpus he wants to see by using `pci_dev` or `gpu_list`

To summarize: pretty much every vital metric is available now for intel.

struct gpu_metrics:
  - [x] int load;
  - [X] int temp; (**only i915, no xe support by intel yet**)
  - [ ] int junction_temp {-1}; (**isn't exposed by intel**)
  - [ ] int memory_temp {-1}; (**isn't exposed by intel**)
  - [X] float memoryUsed;
  - [ ] float memoryTotal; (**isn't exposed by intel**)
  - [ ] int MemClock; (**isn't exposed by intel**)
  - [X] int CoreClock;
  - [X] float powerUsage;
  - [ ] float apu_cpu_power;
  - [ ] int apu_cpu_temp;
  - [X] bool is_power_throttled;
  - [X] bool is_current_throttled;
  - [X] bool is_temp_throttled;
  - [X] bool is_other_throttled;
  - [ ] float gtt_used; (**not used by mangohud**)
  - [X] int fan_speed; (**only i915, no xe support by intel yet**)
  - [X] int voltage;
  
  
Example metrics (using linux kernel 6.13): 
![image](https://github.com/user-attachments/assets/9311fb9f-dcdf-4db6-a13c-3668de54d3dc)