### PR TITLE
Don't rely on x11 when with_x11 is disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -89,7 +89,7 @@ if is_unixy
   dep_wayland_client = dependency('wayland-client',
       required: get_option('with_wayland'), version : '>=1.11')
   dbus_dep = dependency('dbus-1', required: get_option('with_dbus')).partial_dependency(compile_args : true, includes : true)
-  dep_xkb = dependency('xkbcommon', required: get_option('with_wayland'))
+  dep_xkb = dependency('xkbcommon', required: get_option('with_x11').enabled() or get_option('with_wayland').enabled())
 else
   dep_x11 = null_dep
   dep_wayland_client = null_dep

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -356,7 +356,7 @@ int main(int, char**)
                     PropModeReplace, (unsigned char *)&value, 1);
     // Main loop
     while (!glfwWindowShouldClose(window)){
-        check_keybinds(params, vendorID);
+        check_keybinds(params);
 
         if (!params.no_display){
             if (mangoapp_paused){

--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -217,7 +217,7 @@ void imgui_render(unsigned int width, unsigned int height)
         process_control_socket(control_client, params);
     }
 
-    check_keybinds(params, vendorID);
+    check_keybinds(params);
     update_hud_info(sw_stats, params, vendorID);
 
     ImGuiContext *saved_ctx = ImGui::GetCurrentContext();

--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -22,7 +22,9 @@
 #define GLX_RENDERER_VENDOR_ID_MESA                      0x8183
 #define GLX_RENDERER_DEVICE_ID_MESA                      0x8184
 
+#ifdef HAVE_X11
 bool glx_mesa_queryInteger(int attrib, unsigned int *value);
+#endif
 
 namespace MangoHud { namespace GL {
 
@@ -148,9 +150,10 @@ void imgui_create(void *ctx, const gl_wsi plat)
     HUDElements.vendorID = vendorID;
 
     uint32_t device_id = 0;
+#ifdef HAVE_X11
     if (plat == gl_wsi::GL_WSI_GLX)
         glx_mesa_queryInteger(GLX_RENDERER_DEVICE_ID_MESA, &device_id);
-
+#endif
     SPDLOG_DEBUG("GL device id: {:04X}", device_id);
     sw_stats.gpuName = gpu = remove_parentheses(deviceName);
     SPDLOG_DEBUG("gpu: {}", gpu);

--- a/src/gl/inject_egl.cpp
+++ b/src/gl/inject_egl.cpp
@@ -118,13 +118,16 @@ EXPORT_C_(void*) eglGetDisplay( void* native_display )
     try
     {
         void** display_ptr = (void**)native_display;
-        wl_interface* iface = (wl_interface*)*display_ptr;
-        if(iface && strcmp(iface->name, wl_display_interface.name) == 0)
+        if (native_display)
         {
-            wl_display_ptr = (struct wl_display*)native_display;
-            HUDElements.display_server = HUDElements.display_servers::WAYLAND;
-            wl_handle = real_dlopen("libwayland-client.so", RTLD_LAZY);
-            init_wayland_data();
+            wl_interface* iface = (wl_interface*)*display_ptr;
+            if(iface && strcmp(iface->name, wl_display_interface.name) == 0)
+            {
+                wl_display_ptr = (struct wl_display*)native_display;
+                HUDElements.display_server = HUDElements.display_servers::WAYLAND;
+                wl_handle = real_dlopen("libwayland-client.so", RTLD_LAZY);
+                init_wayland_data();
+            }
         }
     }
     catch(...)

--- a/src/keybinds.cpp
+++ b/src/keybinds.cpp
@@ -11,7 +11,7 @@
 
 Clock::time_point last_f2_press, toggle_fps_limit_press, toggle_preset_press, last_f12_press, reload_cfg_press, last_upload_press;
 
-void check_keybinds(struct overlay_params& params, uint32_t vendorID){
+void check_keybinds(struct overlay_params& params){
    using namespace std::chrono_literals;
    auto now = Clock::now(); /* us */
    auto elapsedF2 = now - last_f2_press;

--- a/src/meson.build
+++ b/src/meson.build
@@ -143,12 +143,12 @@ if is_unixy
       'loaders/loader_x11.cpp',
       'shared_x11.cpp',
     )
-  endif
 
     opengl_files += files(
       'loaders/loader_glx.cpp',
       'gl/inject_glx.cpp',
     )
+  endif
 
   if get_option('with_wayland').enabled()
     pre_args += '-DHAVE_WAYLAND'

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -102,7 +102,7 @@ void update_hud_info(struct swapchain_stats& sw_stats, const struct overlay_para
 void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, const struct overlay_params& params, uint32_t vendorID, uint64_t frametime_ns);
 void update_hw_info(const struct overlay_params& params, uint32_t vendorID);
 void init_cpu_stats(overlay_params& params);
-void check_keybinds(overlay_params& params, uint32_t vendorID);
+void check_keybinds(overlay_params& params);
 void init_system_info(void);
 void FpsLimiter(struct fps_limit& stats);
 void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*& small_font, ImFont*& text_font);

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -463,7 +463,7 @@ static void snapshot_swapchain_frame(struct swapchain_data *data)
    struct device_data *device_data = data->device;
    struct instance_data *instance_data = device_data->instance;
    update_hud_info(data->sw_stats, instance_data->params, device_data->properties.vendorID);
-   check_keybinds(instance_data->params, device_data->properties.vendorID);
+   check_keybinds(instance_data->params);
 #ifdef __linux__
    if (instance_data->params.control >= 0) {
       control_client_check(instance_data->params.control, instance_data->control_client, gpu.c_str());

--- a/src/win/d3d_shared.cpp
+++ b/src/win/d3d_shared.cpp
@@ -20,6 +20,6 @@ void init_d3d_shared(){
 }
 
 void d3d_run(){
-    check_keybinds(params, vendorID);
+    check_keybinds(params);
 	update_hud_info(sw_stats, params, vendorID);
 }


### PR DESCRIPTION
Fixes (partially): #1497 
Part 1... will expand in the future to switch everything to xkb_keysym_t, seems like that's what we are forced to do