### PR TITLE
Add basic Elbrus CPU temperature support

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -537,6 +537,9 @@ bool CPUStats::GetCpuFile() {
             // Only break if module has CPU node
             if (find_input(path, "temp", input, "CPU"))
                 break;
+        } else if (name == "l_pcs") { // Elbrus temperature module
+            find_input(path, "temp", input, "Node 0 Max");
+            break;
         } else {
             path.clear();
         }


### PR DESCRIPTION
This currently hardcodes the node number (and there might be other temperature labels and even other temperature modules judging by some scripts in Rumia)