### PR TITLE
Fix build issues for LLVM based toolchains.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('MangoHud',
   ['c', 'cpp'],
   version : 'v0.8.4',
   license : 'MIT',
-  meson_version: '>=1.3.2',
+  meson_version: '>=0.64.0',
   default_options : ['buildtype=release', 'c_std=c99', 'cpp_std=c++17', 'warning_level=2']
 )
 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('MangoHud',
   ['c', 'cpp'],
   version : 'v0.8.4',
   license : 'MIT',
-  meson_version: '>=0.60.0',
+  meson_version: '>=1.3.2',
   default_options : ['buildtype=release', 'c_std=c99', 'cpp_std=c++17', 'warning_level=2']
 )
 

--- a/src/mangohud.version
+++ b/src/mangohud.version
@@ -4,10 +4,5 @@
     overlay_GetInstanceProcAddr;
     overlay_GetDeviceProcAddr;
     vkNegotiateLoaderLayerInterfaceVersion;
-    glX*;
-    egl*;
-    dlsym;
-    mangohud_find_glx_ptr;
-    mangohud_find_egl_ptr;
   local: *;
 };

--- a/src/mangohud_opengl.version
+++ b/src/mangohud_opengl.version
@@ -1,0 +1,10 @@
+{
+    global:
+        #if defined(HAVE_X11)
+        mangohud_find_glx_ptr;
+        #endif
+        #if defined(HAVE_WAYLAND)
+        mangohud_find_egl_ptr;
+        #endif
+    local: *;
+};

--- a/src/meson.build
+++ b/src/meson.build
@@ -176,7 +176,23 @@ if is_unixy
   endif
 endif
 
-link_args = cc.get_supported_link_arguments(['-Wl,-Bsymbolic-functions', '-Wl,-z,relro', '-Wl,--exclude-libs,ALL', '-lGL', '-static-libstdc++'])
+link_args = cpp.get_supported_link_arguments(['-Wl,-Bsymbolic-functions', '-Wl,-z,relro', '-Wl,--exclude-libs,ALL', '-lGL'])
+
+# Approach for libc++ detection taken from https://github.com/mesonbuild/meson/commit/675b47b0692131fae974298829ba807d730ab098
+# Rationale for the approach is explained in this SO answer https://stackoverflow.com/a/31658120
+if cpp.has_header('<version>')
+  header = 'version'
+else
+  header = 'ciso646'
+endif
+is_libcxx = cpp.has_header_symbol(header, '_LIBCPP_VERSION')
+
+# https://github.com/llvm/llvm-project/issues/38622
+if is_libcxx
+  message('Detected libcxx, not appending -static-libstc++ to linker arguments')
+else
+  link_args+=['-static-libstdc++']
+endif
 
 mangohud_static_lib = static_library(
   'MangoHud',

--- a/src/meson.build
+++ b/src/meson.build
@@ -177,8 +177,6 @@ if is_unixy
 endif
 
 link_args = cc.get_supported_link_arguments(['-Wl,-Bsymbolic-functions', '-Wl,-z,relro', '-Wl,--exclude-libs,ALL', '-lGL', '-static-libstdc++'])
-# meson fails to check version-script so just force add
-link_args += '-Wl,--version-script,@0@'.format(join_paths(meson.current_source_dir(), 'mangohud.version'))
 
 mangohud_static_lib = static_library(
   'MangoHud',
@@ -222,9 +220,15 @@ mangohud_shared_lib = shared_library(
   'MangoHud',
   objects: mangohud_static_lib.extract_all_objects(),
   link_with: mangohud_static_lib,
-  link_args : link_args,
+  link_args : [link_args, '-Wl,--version-script,@0@'.format(
+    join_paths(meson.current_source_dir(), 'mangohud.version'))],
   install_dir : libdir_mangohud,
   install: true
+)
+
+mangohud_opengl_versionscript = cpp.preprocess(
+  'mangohud_opengl.version',
+  compile_args: pre_args,
 )
 
 mangohud_opengl_shared_lib = shared_library(
@@ -255,8 +259,9 @@ mangohud_opengl_shared_lib = shared_library(
     windows_deps,
     implot_dep],
   include_directories : [inc_common],
-  link_args : link_args,
+  link_args : [link_args, '-Wl,--version-script,@0@'.format(mangohud_opengl_versionscript[0].full_path())],
   link_with: mangohud_static_lib,
+  link_depends: mangohud_opengl_versionscript,
   install_dir : libdir_mangohud,
   install: true
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -146,7 +146,7 @@ if is_unixy
   endif
 
   if get_option('with_x11').enabled()
-    pre_args += '-DHAVE_X11'
+    add_project_arguments('-DHAVE_X11', language : ['c', 'cpp'])
 
     vklayer_files += files(
       'loaders/loader_x11.cpp',
@@ -160,7 +160,7 @@ if is_unixy
   endif
 
   if get_option('with_wayland').enabled()
-    pre_args += '-DHAVE_WAYLAND'
+    add_project_arguments('-DHAVE_WAYLAND', language : ['c', 'cpp'])
 
     vklayer_files += files(
       'wayland_keybinds.cpp'
@@ -243,10 +243,7 @@ mangohud_shared_lib = shared_library(
 )
 
 if is_unixy
-  mangohud_opengl_versionscript = cpp.preprocess(
-    'mangohud_opengl.version',
-    compile_args: pre_args,
-  )
+  mangohud_opengl_versionscript = cpp.preprocess('mangohud_opengl.version')
 
   mangohud_opengl_shared_lib = shared_library(
     'MangoHud_opengl',

--- a/src/meson.build
+++ b/src/meson.build
@@ -242,45 +242,47 @@ mangohud_shared_lib = shared_library(
   install: true
 )
 
-mangohud_opengl_versionscript = cpp.preprocess(
-  'mangohud_opengl.version',
-  compile_args: pre_args,
-)
+if is_unixy
+  mangohud_opengl_versionscript = cpp.preprocess(
+    'mangohud_opengl.version',
+    compile_args: pre_args,
+  )
 
-mangohud_opengl_shared_lib = shared_library(
-  'MangoHud_opengl',
-  mangohud_version,
-  opengl_files,
-  vklayer_files,
-  util_files,
-  c_args : [
-    pre_args,
-    vulkan_wsi_args
-    ],
-  cpp_args : [
-    pre_args,
-    vulkan_wsi_args
-    ],
-  dependencies : [
-    mangohud_version_dep,
-    vulkan_wsi_deps,
-    dearimgui_dep,
-    spdlog_dep,
-    dbus_dep,
-    dep_dl,
-    dep_rt,
-    dep_pthread,
-    dep_vulkan_headers,
-    dep_vulkan_utility_libraries,
-    windows_deps,
-    implot_dep],
-  include_directories : [inc_common],
-  link_args : [link_args, '-Wl,--version-script,@0@'.format(mangohud_opengl_versionscript[0].full_path())],
-  link_with: mangohud_static_lib,
-  link_depends: mangohud_opengl_versionscript,
-  install_dir : libdir_mangohud,
-  install: true
-)
+  mangohud_opengl_shared_lib = shared_library(
+    'MangoHud_opengl',
+    mangohud_version,
+    opengl_files,
+    vklayer_files,
+    util_files,
+    c_args : [
+      pre_args,
+      vulkan_wsi_args
+      ],
+    cpp_args : [
+      pre_args,
+      vulkan_wsi_args
+      ],
+    dependencies : [
+      mangohud_version_dep,
+      vulkan_wsi_deps,
+      dearimgui_dep,
+      spdlog_dep,
+      dbus_dep,
+      dep_dl,
+      dep_rt,
+      dep_pthread,
+      dep_vulkan_headers,
+      dep_vulkan_utility_libraries,
+      windows_deps,
+      implot_dep],
+    include_directories : [inc_common],
+    link_args : [link_args, '-Wl,--version-script,@0@'.format(mangohud_opengl_versionscript[0].full_path())],
+    link_with: mangohud_static_lib,
+    link_depends: mangohud_opengl_versionscript,
+    install_dir : libdir_mangohud,
+    install: true
+  )
+endif
 
 if get_option('mangoapp')
   if not get_option('with_x11').enabled()

--- a/tests/test_amdgpu.cpp
+++ b/tests/test_amdgpu.cpp
@@ -2,11 +2,13 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <stdint.h>
+#include "stdio.h"
+#include "../src/amdgpu.h"
+// cmocka and libc++ have clashing symbols which causes issues if the symbols
+// are defined before libc++ can hide its own with _LIBCPP_HIDE_FROM_ABI.
 extern "C" {
 #include <cmocka.h>
 }
-#include "stdio.h"
-#include "../src/amdgpu.h"
 
 #define UNUSED(x) (void)(x)
 


### PR DESCRIPTION
~~Keeping it a draft as this would in its current state break builds for Windows. I'm unsure what is the intent with mangohud_opengl and what symbols should be visible in it for Windows.~~

With LLVM toolchain I mean clang as the compiler, lld is the linker and libcxx as the c++ stdlib.

I didn't touch mangohud_shim, but its visible symbols are shown as well. It could also be explicitly specified like mangohud_opengl.

```
$ nm -UD build/src/libMangoHud*.so
build/src/libMangoHud_dlsym.so:
0000000000002b20 T dlsym

build/src/libMangoHud_opengl.so:
0000000000054c10 T eglGetDisplay
0000000000054b60 T eglGetPlatformDisplay
0000000000054ce0 T eglGetProcAddress
00000000000549b0 T eglSwapBuffers
0000000000055e40 T glXCreateContext
0000000000055f20 T glXCreateContextAttribs
0000000000056010 T glXCreateContextAttribsARB
0000000000056100 T glXDestroyContext
0000000000055c20 T glXGetProcAddress
0000000000055d30 T glXGetProcAddressARB
00000000000565b0 T glXGetSwapIntervalMESA
00000000000561b0 T glXMakeCurrent
0000000000055830 T glXSwapBuffers
0000000000055720 T glXSwapBuffersMscOML
0000000000056360 T glXSwapIntervalEXT
00000000000564f0 T glXSwapIntervalMESA
0000000000056430 T glXSwapIntervalSGI
0000000000054520 T mangohud_find_egl_ptr
00000000000558f0 T mangohud_find_glx_ptr

build/src/libMangoHud_shim.so:
00000000000012e0 T eglGetDisplay
0000000000001340 T eglGetPlatformDisplay
00000000000013c0 T eglSwapBuffers
0000000000001280 T glXSwapBuffers
0000000000001420 T glXSwapBuffersMscOML

build/src/libMangoHud.so:
000000000004eb80 T overlay_GetDeviceProcAddr
000000000004f960 T overlay_GetInstanceProcAddr

```

<details>
<summary>
Current HEAD built with GCC/ld.bfd
</summary>

```
$ nm -UD build/src/libMangoHud*.so

build/src/libMangoHud_dlsym.so:
0000000000002b20 T dlsym

build/src/libMangoHud_opengl.so:
0000000000054c10 T eglGetDisplay
0000000000054b60 T eglGetPlatformDisplay
0000000000054ce0 T eglGetProcAddress
00000000000549b0 T eglSwapBuffers
0000000000055e40 T glXCreateContext
0000000000055f20 T glXCreateContextAttribs
0000000000056010 T glXCreateContextAttribsARB
0000000000056100 T glXDestroyContext
0000000000055c20 T glXGetProcAddress
0000000000055d30 T glXGetProcAddressARB
00000000000565b0 T glXGetSwapIntervalMESA
00000000000561b0 T glXMakeCurrent
0000000000055830 T glXSwapBuffers
0000000000055720 T glXSwapBuffersMscOML
0000000000056360 T glXSwapIntervalEXT
00000000000564f0 T glXSwapIntervalMESA
0000000000056430 T glXSwapIntervalSGI
0000000000054520 T mangohud_find_egl_ptr
00000000000558f0 T mangohud_find_glx_ptr

build/src/libMangoHud_shim.so:
00000000000012e0 T eglGetDisplay
0000000000001340 T eglGetPlatformDisplay
00000000000013c0 T eglSwapBuffers
0000000000001280 T glXSwapBuffers
0000000000001420 T glXSwapBuffersMscOML

build/src/libMangoHud.so:
000000000004eb80 T overlay_GetDeviceProcAddr
000000000004f960 T overlay_GetInstanceProcAddr
```
</details>