### PR TITLE
[blacklist] Add Plutonium launcher

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -58,7 +58,9 @@ static  std::vector<std::string> blacklist {
     "Launcher", //Paradox Interactive Launcher
     "steamwebhelper.exe",
     "EpicWebHelper.exe",
-    "UplayWebCore.exe"
+    "UplayWebCore.exe",
+    "plutonium.exe",
+    "plutonium-launcher-win32.exe"
 };
 
 


### PR DESCRIPTION
Adds Plutonium Launcher to the blacklist which is a custom client for dedicated servers on old Call of Duty games.