### PR TITLE
Fix MSM support for new gpu_fdinfo implementation

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -528,6 +528,9 @@ bool CPUStats::GetCpuFile() {
         } else if (name == "it8603") {
             find_input(path, "temp", input, "temp1");
             break;
+        } else if (starts_with(name, "cpuss0_")) {
+            find_fallback_input(path, "temp1", input);
+            break;
         } else if (starts_with(name, "nct")) {
             // Only break if nct module has TSI0_TEMP node
             if (find_input(path, "temp", input, "TSI0_TEMP"))

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -55,16 +55,20 @@ GPUS::GPUS(overlay_params* params) : params(params) {
 
         uint32_t vendor_id = 0;
         uint32_t device_id = 0;
-        try {
-            vendor_id = std::stoul(read_line("/sys/bus/pci/devices/" + device_address + "/vendor"), nullptr, 16);
-        } catch(...) {
-            SPDLOG_ERROR("stoul failed on: {}", "/sys/bus/pci/devices/" + device_address + "/vendor");
-        }
 
-        try {
-            device_id = std::stoul(read_line("/sys/bus/pci/devices/" + device_address + "/device"), nullptr, 16);
-        } catch (...) {
-            SPDLOG_ERROR("stoul failed on: {}", "/sys/bus/pci/devices/" + device_address + "/device");
+        if (!device_address.empty())
+        {
+            try {
+                vendor_id = std::stoul(read_line("/sys/bus/pci/devices/" + device_address + "/vendor"), nullptr, 16);
+            } catch(...) {
+                SPDLOG_ERROR("stoul failed on: {}", "/sys/bus/pci/devices/" + device_address + "/vendor");
+            }
+
+            try {
+                device_id = std::stoul(read_line("/sys/bus/pci/devices/" + device_address + "/device"), nullptr, 16);
+            } catch (...) {
+                SPDLOG_ERROR("stoul failed on: {}", "/sys/bus/pci/devices/" + device_address + "/device");
+            }
         }
 
         if (!vendor_id) {

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -67,6 +67,14 @@ GPUS::GPUS(overlay_params* params) : params(params) {
             SPDLOG_ERROR("stoul failed on: {}", "/sys/bus/pci/devices/" + device_address + "/device");
         }
 
+        if (!vendor_id) {
+            auto line = read_line("/sys/class/drm/" + node_name + "/device/uevent" );
+            if (line.find("DRIVER=msm_dpu") != std::string::npos) {
+                SPDLOG_DEBUG("MSM device found!");
+                vendor_id = 0x5143;
+            }
+        }
+
         std::shared_ptr<GPU> ptr = std::make_shared<GPU>(node_name, vendor_id, device_id, pci_dev);
 
         if (params->gpu_list.size() == 1 && params->gpu_list[0] == idx++)

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -104,7 +104,7 @@ GPUS::GPUS(overlay_params* params) : params(params) {
             "You have more than 1 active GPU, check if you use both pci_dev "
             "and gpu_list. If you use fps logging, MangoHud will log only "
             "this GPU: name = {}, vendor = {:x}, pci_dev = {}",
-            gpu->name, gpu->vendor_id, gpu->pci_dev
+            gpu->drm_node, gpu->vendor_id, gpu->pci_dev
         );
 
         break;

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -22,7 +22,7 @@ class GPU {
 
     public:
         gpu_metrics metrics;
-        std::string name;
+        std::string drm_node;
         std::unique_ptr<NVIDIA> nvidia = nullptr;
         std::unique_ptr<AMDGPU> amdgpu = nullptr;
         std::unique_ptr<GPU_fdinfo> fdinfo = nullptr;
@@ -30,8 +30,8 @@ class GPU {
         std::string pci_dev;
         uint32_t vendor_id = 0;
 
-        GPU(std::string name, uint32_t vendor_id, uint32_t device_id, const char* pci_dev)
-            : name(name), pci_dev(pci_dev), vendor_id(vendor_id), device_id(device_id) {
+        GPU(std::string drm_node, uint32_t vendor_id, uint32_t device_id, const char* pci_dev)
+            : drm_node(drm_node), pci_dev(pci_dev), vendor_id(vendor_id), device_id(device_id) {
                 if (vendor_id == 0x10de)
                     nvidia = std::make_unique<NVIDIA>(pci_dev);
 

--- a/src/gpu.h
+++ b/src/gpu.h
@@ -41,10 +41,10 @@ class GPU {
                 // For now we're only accepting one of these modules at once
                 // Might be possible that multiple can exist on a system in the future?
                 if (vendor_id == 0x8086)
-                    fdinfo = std::make_unique<GPU_fdinfo>(is_i915_or_xe(), pci_dev);
+                    fdinfo = std::make_unique<GPU_fdinfo>(is_i915_or_xe(), pci_dev, drm_node);
 
                 if (vendor_id == 0x5143)
-                    fdinfo = std::make_unique<GPU_fdinfo>("msm", pci_dev);
+                    fdinfo = std::make_unique<GPU_fdinfo>("msm", pci_dev, drm_node);
         }
 
         gpu_metrics get_metrics() {

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -58,7 +58,7 @@ void GPU_fdinfo::find_fd()
         }
 
         if (
-            driver.empty() || pdev.empty() || client_id.empty() ||
+            driver.empty() || client_id.empty() ||
             driver != module || pdev != pci_dev ||
             client_ids.find(client_id) != client_ids.end()
         )

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -82,7 +82,9 @@ private:
 
     float get_memory_used();
 
-    void find_hwmon();
+    void find_hwmon_sensors();
+    std::string find_hwmon_dir();
+    std::string find_msm_hwmon_dir();
     void get_current_hwmon_readings();
 
     float get_power_usage();
@@ -161,7 +163,7 @@ public:
         hwmon_sensors["power"]     = { .rx = std::regex("power(\\d+)_input") };
         hwmon_sensors["energy"]    = { .rx = std::regex("energy(\\d+)_input") };
 
-        find_hwmon();
+        find_hwmon_sensors();
 
         if (module == "i915")
             find_i915_gt_dir();

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -45,6 +45,7 @@ private:
 
     const std::string module;
     const std::string pci_dev;
+    const std::string drm_node;
 
     std::thread thread;
     std::condition_variable cond_var;
@@ -109,9 +110,10 @@ private:
         std::vector<std::ifstream> &throttle_reason_streams);
 
 public:
-    GPU_fdinfo(const std::string module, const std::string pci_dev)
+    GPU_fdinfo(const std::string module, const std::string pci_dev, const std::string drm_node)
         : module(module)
         , pci_dev(pci_dev)
+        , drm_node(drm_node)
     {
         SPDLOG_DEBUG("GPU driver is \"{}\"", module);
 


### PR DESCRIPTION
Initial support for MSM was added with #1206. Subsequent refactoring for generic fdinfo with commit d224507, but it unintentionally broke MSM support as refactoring implies PCI-only GPUs.

Fix MSM support for new `gpu_fdinfo` logic, enabling recognition and use of non-PCI GPUs.  
Add generic CPU and GPU sensors for MSM devices.

Successfully tested on Qualcomm X1E80100 (Adreno X1-85) devices.
Regression tested on i915 (Intel 10th Gen) and AMD Radeon 780M (Ryzen 7xxx).