### PR TITLE
Try harder to locate libMangoHud_opengl.so

### DIFF
--- a/src/gl/shim.c
+++ b/src/gl/shim.c
@@ -35,7 +35,7 @@ static void loadMangoHud() {
                 mangoHudLoaded = true;
                 break;
             }
-            else fprintf(stderr, "shim: Failed to load from: %s\n", lib);
+            else fprintf(stderr, "shim: Failed to load from \"%s\": %s\n", lib, dlerror());
 
             lib = strtok(NULL, ":");
         }
@@ -47,7 +47,7 @@ static void loadMangoHud() {
         if (handle) mangoHudLoaded = true;
         else
         {
-            fprintf(stderr, "shim: Failed to load from ${ORIGIN}/libMangoHud_opengl.so\n");
+            fprintf(stderr, "shim: Failed to load from ${ORIGIN}/libMangoHud_opengl.so: %s\n", dlerror());
             handle = RTLD_NEXT;
         }
     }


### PR DESCRIPTION
* shim: Show error messages from dlopen() where appropriate
    
    If dlopen() returns null, then a subsequent dlerror() tells you why.

* shim: Try to locate an adjacent libMangoHud_opengl.so using dladdr1()
    
    When the Steam Linux Runtime's container tool pressure-vessel finds a
    LD_PRELOAD module, it must map it into the filesystem namespace of the
    container, and its procedure to achieve this in the presence of `$LIB`
    and other dynamic string tokens involves symbolic links in a temporary
    directory.
    
    However, this means we end up with a symlink to libMangoHud_shim.so in
    `$LD_PRELOAD`, and no corresponding symlink to libMangoHud_opengl.so in
    the same directory, because pressure-vessel has no way to know that
    we'll load the latter. In this situation, libdl expands `${ORIGIN}`
    to the directory containing the symlink, and not the directory below
    /run/host that it points into.
    
    We can improve on this by finding out the path to libMangoHud_shim.so
    by looking up information about one of our own symbols, then using
    realpath() to resolve that to a physical path somewhere below /run/host,
    and resolving libMangoHud_opengl.so relative to that physical path.
    The result is that we can find the implementation library.
    
    steamrt/tasks#595