### PR TITLE
README: 32-bit mangohud is available in Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ If you are using Debian 11 (Bullseye) or later, Ubuntu 21.10 (Impish) or later, 
 sudo apt install mangohud
 ```
 
+Optionally, if you also need MangoHud for 32-bit applications,
+on Debian you can execute:
+
+```
+sudo apt install mangohud:i386
+```
+
+The 32-bit package is not available on Ubuntu.
+
 ### Fedora
 
 If you are using Fedora, to install the [MangoHud](https://src.fedoraproject.org/rpms/mangohud) package, execute:


### PR DESCRIPTION
Debian still builds most packages for 32-bit and has mangohud:i386 available.

The i386 architecture on Ubuntu has been cut down to only build packages on an allowlist, and that allowlist does not currently include mangohud, so it continues to be missing from Ubuntu.

This partially reverts commit 7ad6215eefdeff62410be208b07d58c0e78302c8.