### PR TITLE
build.sh: install mako and meson from apt, instead of pip

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,11 +77,15 @@ dependencies() {
                 MANAGER_QUERY="dpkg-query -s"
                 MANAGER_INSTALL="apt install"
                 DEPS="{${DEPS_DEBIAN}}"
+
+                if ! dpkg --print-foreign-architectures | grep i386 > /dev/null; then
+                    echo "i386 architecture is not enabled. adding it."
+                    $SU_CMD dpkg --add-architecture i386
+                    $SU_CMD apt update
+                fi
+
                 dep_install
 
-                if [[ $(pip3 show meson; echo $?) == 1 || $(pip3 show mako; echo $?) == 1 ]]; then
-                    $SU_CMD pip3 install 'meson>=0.54' mako
-                fi
                 if [[ ! -f /usr/local/bin/glslangValidator ]]; then
                     wget https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-linux-Release.zip
                     unzip glslang-master-linux-Release.zip bin/glslangValidator

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -1,6 +1,6 @@
 DEPS_ARCH="gcc,meson,pkgconf,python-mako,glslang,libglvnd,lib32-libglvnd,libxnvctrl,libdrm,python-numpy,python-matplotlib,libxkbcommon,lib32-libxkbcommon"
 DEPS_FEDORA="meson,gcc,gcc-c++,libX11-devel,glslang,python3-mako,mesa-libGL-devel,libXNVCtrl-devel,dbus-devel,python3-numpy,python3-matplotlib,libstdc++-static,libstdc++-static.i686,libxkbcommon-devel,wayland-devel"
-DEPS_DEBIAN="gcc,g++,gcc-multilib,g++-multilib,ninja-build,python3-pip,python3-setuptools,python3-wheel,pkg-config,mesa-common-dev,libx11-dev,libxnvctrl-dev,libdbus-1-dev,python3-numpy,python3-matplotlib,libxkbcommon-dev,libxkbcommon-dev:i386,libwayland-dev,libwayland-dev:i386"
+DEPS_DEBIAN="gcc,g++,gcc-multilib,g++-multilib,ninja-build,meson,python3-mako,python3-setuptools,python3-wheel,pkg-config,mesa-common-dev,libx11-dev,libxnvctrl-dev,libdbus-1-dev,python3-numpy,python3-matplotlib,libxkbcommon-dev,libxkbcommon-dev:i386,libwayland-dev,libwayland-dev:i386"
 DEPS_SOLUS="mesalib-32bit-devel,glslang,libstdc++-32bit,glibc-32bit-devel,mako,numpy,matplotlib,libxkbcommon-devel"
 
 DEPS_SUSE="gcc-c++,gcc-c++-32bit,libpkgconf-devel,ninja,python3-pip,python3-Mako,libX11-devel,glslang-devel,glibc-devel,glibc-devel-32bit,libstdc++-devel,libstdc++-devel-32bit,Mesa-libGL-devel,dbus-1-devel,python-numpy,python-matplotlib,libxkbcommon-devel,libxkbcommon-devel-32bit,wayland-devel-32bit"


### PR DESCRIPTION
this commit fixes errors about "externally managed environment":

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

meson >= 0.54 is available on oldest lts on debian and second-oldest ubuntu 22.04 (20.04 will stop being lts in april 2025)

also, add i386 architecture if not enabled already for debian