### PR TITLE
shim: Define RTLD_DEEPBIND if not already

### DIFF
--- a/src/gl/shim.c
+++ b/src/gl/shim.c
@@ -9,6 +9,10 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#ifndef RTLD_DEEPBIND
+#define RTLD_DEEPBIND 0
+#endif
+
 static void* handle = NULL;
 static bool mangoHudLoaded = false;
 


### PR DESCRIPTION
RTLD_DEEPBIND is a glibc quirc and is not defined on other libc like musl libc