### PR TITLE
mangoapp: Hide the window when paused instead of iconifying.

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -363,7 +363,7 @@ int main(int, char**)
 
         if (!params.no_display){
             if (mangoapp_paused){
-                glfwRestoreWindow(window);
+                glfwShowWindow(window);
                 uint32_t value = 1;
                 XChangeProperty(x11_display, x11_window, overlay_atom, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&value, 1);
                 XSync(x11_display, 0);
@@ -404,7 +404,7 @@ int main(int, char**)
 
             glfwSwapBuffers(window);
         } else if (!mangoapp_paused) {
-            glfwIconifyWindow(window);
+            glfwHideWindow(window);
             uint32_t value = 0;
             XChangeProperty(x11_display, x11_window, overlay_atom, XA_CARDINAL, 32, PropModeReplace, (unsigned char *)&value, 1);
             XSync(x11_display, 0);


### PR DESCRIPTION
Workaround a GLFW bug with Mutter and other WM that do not unmap windows when iconified. A later glfwRestoreWindow which only calls XMapWindow is no-op in that case and won't actually restore the window.

Link: https://github.com/glfw/glfw/issues/2077