### PR TITLE
One-line media player when horizontal

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -901,6 +901,13 @@ void HudElements::media_player(){
         else
             SPDLOG_DEBUG("failed to acquire lock");
     }
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal]) {
+        ImguiNextColumnFirstItem();
+    }
+    if (!main_metadata.meta.playing) {
+        HUDElements.TextColored(HUDElements.colors.media_player, "(paused)");
+    }
+
     ImGui::PopFont();
 #endif
 }

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -481,8 +481,10 @@ void render_mpris_metadata(const struct overlay_params& params, mutexed_metadata
    if (meta.meta.valid) {
       auto color = ImGui::ColorConvertU32ToFloat4(params.media_player_color);
       ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(8,0));
-      ImGui::Dummy(ImVec2(0.0f, 20.0f));
-      //ImGui::PushFont(data.font1);
+
+      if (!params.enabled[OVERLAY_PARAM_ENABLED_horizontal]) {
+         ImGui::Dummy(ImVec2(0.0f, 20.0f));
+      }
 
       if (meta.ticker.needs_recalc) {
          meta.ticker.formatted.clear();
@@ -529,11 +531,6 @@ void render_mpris_metadata(const struct overlay_params& params, mutexed_metadata
          HUDElements.TextColored(color, "%s", fmt.text.c_str());
       }
 
-      if (!meta.meta.playing) {
-         HUDElements.TextColored(color, "(paused)");
-      }
-
-      //ImGui::PopFont();
       ImGui::PopStyleVar();
    }
 }


### PR DESCRIPTION
Remove margin above the media player info for horizontal configurations. (Fixes #1053)
One-line the paused status indicator for horizontal configurations.

I've only tested with vkcubes & default build configuration.

## Before:
### Horizontal
![image](https://github.com/user-attachments/assets/9de9963d-a94e-4f5d-b5c1-c55601ce3153)

### Default config + media_player
![image](https://github.com/user-attachments/assets/a8388f1c-3a31-4733-8c0f-679f98d8b228)


## After:
### Horizontal
![image](https://github.com/user-attachments/assets/c150494b-cc38-4c72-a1b2-0c137dca91d2)


### Default config + media_player (should look the same as before)
![image](https://github.com/user-attachments/assets/efb1cb3a-a9b9-48f6-a550-1ec23063caf1)
