### PR TITLE
Add 'horizontal separator color' parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `hide_fsr_sharpness`               | Hides the sharpness info for the `fsr` option (only available in gamescope)           |
 | `histogram`                        | Change FPS graph to histogram                                                         |
 | `horizontal`                       | Display Mangohud in a horizontal position                                             |
+| `horizontal_separator_color`       | Set the colors for the horizontal separators (horizontal layout only)                 |
 | `horizontal_stretch`               | Stretches the background to the screens width in `horizontal` mode                    |
 | `hud_compact`                      | Display compact version of MangoHud                                                   |
 | `hud_no_margin`                    | Remove margins around MangoHud                                                        |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -319,6 +319,7 @@ text_outline
 # wine_color=EB5B5B
 # battery_color=FF9078
 # network_color=E07B85
+# horizontal_separator_color=AD64C1
 
 ### Specify GPU with PCI bus ID
 ### Set to 'domain:bus:slot.function'

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -88,6 +88,7 @@ void HudElements::convert_colors(const struct overlay_params& params)
     HUDElements.colors.text = convert(params.text_color);
     HUDElements.colors.media_player = convert(params.media_player_color);
     HUDElements.colors.wine = convert(params.wine_color);
+    HUDElements.colors.horizontal_separator = convert(params.horizontal_separator_color);
     HUDElements.colors.battery = convert(params.battery_color);
     HUDElements.colors.gpu_load_low = convert(params.gpu_load_color[0]);
     HUDElements.colors.gpu_load_med = convert(params.gpu_load_color[1]);

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -135,6 +135,7 @@ class HudElements{
                 text,
                 media_player,
                 wine,
+                horizontal_separator,
                 battery,
                 gpu_load_low,
                 gpu_load_med,

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -650,7 +650,8 @@ void horizontal_separator(struct overlay_params& params) {
    }
 
     // Draw the separator line
-    drawList->AddLine(startPos, endPos, params.vram_color, outlineThickness);
+    ImU32 separator_color = ImGui::ColorConvertFloat4ToU32(HUDElements.colors.horizontal_separator);
+    drawList->AddLine(startPos, endPos, separator_color, outlineThickness);
 
     ImGui::SameLine();
     ImGui::Spacing();

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -504,6 +504,7 @@ parse_fex_stats(const char *str) {
 #define parse_text_color(s) parse_color(s)
 #define parse_media_player_color(s) parse_color(s)
 #define parse_wine_color(s) parse_color(s)
+#define parse_horizontal_separator_color(s) parse_color(s)
 #define parse_network_color(s) parse_color(s)
 #define parse_gpu_load_color(s) parse_load_color(s)
 #define parse_cpu_load_color(s) parse_load_color(s)
@@ -781,6 +782,7 @@ static void set_param_defaults(struct overlay_params *params){
    params->media_player_name = "";
    params->font_scale = 1.0f;
    params->wine_color = 0xeb5b5b;
+   params->horizontal_separator_color = 0xad64c1;
    params->gpu_load_color = { 0x39f900, 0xfdfd09, 0xb22222 };
    params->cpu_load_color = { 0x39f900, 0xfdfd09, 0xb22222 };
    params->font_scale_media_player = 0.55f;
@@ -922,7 +924,7 @@ parse_overlay_config(struct overlay_params *params,
       params->font_scale_media_player = 0.55f;
 
    // Convert from 0xRRGGBB to ImGui's format
-   std::array<unsigned *, 23> colors = {
+   std::array<unsigned *, 24> colors = {
       &params->cpu_color,
       &params->gpu_color,
       &params->vram_color,
@@ -934,6 +936,7 @@ parse_overlay_config(struct overlay_params *params,
       &params->text_color,
       &params->media_player_color,
       &params->wine_color,
+      &params->horizontal_separator_color,
       &params->battery_color,
       &params->gpu_load_color[0],
       &params->gpu_load_color[1],

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -163,6 +163,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(io_color)                    \
    OVERLAY_PARAM_CUSTOM(text_color)                  \
    OVERLAY_PARAM_CUSTOM(wine_color)                  \
+   OVERLAY_PARAM_CUSTOM(horizontal_separator_color)  \
    OVERLAY_PARAM_CUSTOM(battery_color)               \
    OVERLAY_PARAM_CUSTOM(network_color)               \
    OVERLAY_PARAM_CUSTOM(alpha)                       \
@@ -275,7 +276,8 @@ struct overlay_params {
    int64_t log_duration, log_interval;
    unsigned cpu_color, gpu_color, vram_color, ram_color,
             engine_color, io_color, frametime_color, background_color,
-            text_color, wine_color, battery_color, network_color;
+            text_color, wine_color, battery_color, network_color,
+            horizontal_separator_color;
    std::vector<unsigned> gpu_load_color;
    std::vector<unsigned> cpu_load_color;
    std::vector<unsigned> gpu_load_value;


### PR DESCRIPTION
Adds parameter to customize the color of the horizontal separator when using the horizontal layout, since by default it is hardcoded to be the same as the VRAM's color. Additionally this change makes it respect the alpha parameter.