### PR TITLE
blacklist: fix missing comma

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -57,7 +57,7 @@ static  std::vector<std::string> blacklist {
     "steam",
     "Steam.exe",
     "steamwebhelper",
-    "steamwebhelper.exe"
+    "steamwebhelper.exe",
     "tabtip.exe",
     "UplayWebCore.exe",
     "vrcompositor",


### PR DESCRIPTION
Commit 11c8fb187ce31c206996f4b6bdc8c8fc2db4d645 seems to have accidentally dropped a comma, which caused the entries for "steamwebhelper.exe" and "tabtip.exe" to be concatenated together.