### PR TITLE
Show GPU efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `gpu_name`                         | Display GPU name from pci.ids                                                         |
 | `gpu_voltage`                      | Display GPU voltage (only works on AMD GPUs)                                          |
 | `gpu_list`                         | List GPUs to display `gpu_list=0,1`                                                   |
+| `gpu_efficiency`                   | Display GPU efficiency in frames per joule                                            |
+| `flip_efficiency`                  | Flips GPU efficiency to joules per frame                                              |
 | `hide_fsr_sharpness`               | Hides the sharpness info for the `fsr` option (only available in gamescope)           |
 | `histogram`                        | Change FPS graph to histogram                                                         |
 | `horizontal`                       | Display Mangohud in a horizontal position                                             |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -93,6 +93,8 @@ gpu_stats
 # gpu_voltage
 ## Select list of GPUs to display
 # gpu_list=0,1
+# gpu_efficiency
+# flip_efficiency
 
 ### Display the current CPU information
 cpu_stats

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -290,6 +290,24 @@ void HudElements::gpu_stats(){
                 ImGui::PopFont();
             }
 
+            if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_efficiency]) {
+                ImguiNextColumnOrNewRow();
+                float efficiency;
+                const char* efficiency_unit;
+                if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_flip_efficiency]) {
+                    efficiency=gpu->metrics.powerUsage/HUDElements.sw_stats->fps;
+                    efficiency_unit="J/F";
+                } else {
+                    efficiency=HUDElements.sw_stats->fps/gpu->metrics.powerUsage;
+                    efficiency_unit="F/J";
+                }
+                right_aligned_text(text_color, HUDElements.ralign_width, "%.2f", efficiency);
+                ImGui::SameLine(0, 1.0f);
+                ImGui::PushFont(HUDElements.sw_stats->font1);
+                HUDElements.TextColored(HUDElements.colors.text, efficiency_unit);
+                ImGui::PopFont();
+            }
+
             if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_voltage]) {
                 ImguiNextColumnOrNewRow();
                 right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.voltage);

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -115,6 +115,8 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(present_mode)                  \
    OVERLAY_PARAM_BOOL(time_no_label)                 \
    OVERLAY_PARAM_BOOL(display_server)                \
+   OVERLAY_PARAM_BOOL(gpu_efficiency)                \
+   OVERLAY_PARAM_BOOL(flip_efficiency)               \
    OVERLAY_PARAM_CUSTOM(fps_sampling_period)         \
    OVERLAY_PARAM_CUSTOM(output_folder)               \
    OVERLAY_PARAM_CUSTOM(output_file)                 \


### PR DESCRIPTION
Adds a HUD element that displays GPU efficiency in frames per joule (F/J), also sometimes referred to frames per second per watt (FPS/W).

Useful for getting immediate feedback when GPU undervolting and power limiting.

Optionally enable flip_efficiency to show joules per frame (J/F) instead.

If there is interest, I can work on a similar feature for CPU efficiency.

![vkcube](https://github.com/user-attachments/assets/76c204cb-a87b-48f0-8be7-b6c9a95ce102)