### PR TITLE
Show GPU power limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `gpu_list`                         | List GPUs to display `gpu_list=0,1`                                                   |
 | `gpu_efficiency`                   | Display GPU efficiency in frames per joule                                            |
 | `flip_efficiency`                  | Flips GPU efficiency to joules per frame                                              |
+| `gpu_power_limit`                  | Display GPU power limit                                                               |
 | `hide_fsr_sharpness`               | Hides the sharpness info for the `fsr` option (only available in gamescope)           |
 | `histogram`                        | Change FPS graph to histogram                                                         |
 | `horizontal`                       | Display Mangohud in a horizontal position                                             |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -83,6 +83,7 @@ gpu_stats
 # gpu_mem_temp
 # gpu_mem_clock
 # gpu_power
+# gpu_power_limit
 # gpu_text=
 # gpu_load_change
 # gpu_load_value=60,90

--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -241,6 +241,7 @@ struct amdgpu_files
     FILE *core_clock;
     FILE *memory_clock;
     FILE *power_usage;
+    FILE *power_limit;
     FILE *gtt_used;
     FILE *fan;
     FILE *gpu_voltage_soc;

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -608,6 +608,7 @@ void GPU_fdinfo::main_thread()
         metrics.load = get_gpu_load();
         metrics.memoryUsed = get_memory_used();
         metrics.powerUsage = get_power_usage();
+        metrics.powerLimit = hwmon_sensors["power_limit"].val / 1'000'000;
         metrics.CoreClock = get_gpu_clock();
         auto throttling = get_throttling_status();
         metrics.is_power_throttled = throttling & GPU_throttle_status::POWER;

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -170,6 +170,9 @@ public:
         hwmon_sensors["power"]     = { .rx = std::regex("power(\\d+)_input") };
         hwmon_sensors["energy"]    = { .rx = std::regex("energy(\\d+)_input") };
 
+        if (module == "i915" || module == "xe")
+            hwmon_sensors["power_limit"] = { .rx = std::regex("power(\\d+)_max") };
+
         find_hwmon_sensors();
 
         if (module == "i915")

--- a/src/gpu_metrics_util.h
+++ b/src/gpu_metrics_util.h
@@ -10,6 +10,7 @@ struct gpu_metrics {
     int MemClock;
     int CoreClock;
     float powerUsage;
+    float powerLimit;
     float apu_cpu_power;
     int apu_cpu_temp;
     bool is_power_throttled;
@@ -24,7 +25,7 @@ struct gpu_metrics {
     gpu_metrics()
         : load(0), temp(0), junction_temp(0), memory_temp(0),
           memoryUsed(0.0f), memoryTotal(0.0f), MemClock(0), CoreClock(0),
-          powerUsage(0.0f), apu_cpu_power(0.0f), apu_cpu_temp(0),
+          powerUsage(0.0f), powerLimit(0.0f), apu_cpu_power(0.0f), apu_cpu_temp(0),
           is_power_throttled(false), is_current_throttled(false),
           is_temp_throttled(false), is_other_throttled(false),
           gtt_used(0.0f), fan_speed(0), voltage(0), fan_rpm(false) {}

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -286,7 +286,10 @@ void HudElements::gpu_stats(){
                     right_aligned_text(text_color, HUDElements.ralign_width, "%.1f", gpu->metrics.powerUsage);
                 ImGui::SameLine(0, 1.0f);
                 ImGui::PushFont(HUDElements.sw_stats->font1);
-                HUDElements.TextColored(HUDElements.colors.text, "W");
+                if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_power_limit])
+                    HUDElements.TextColored(HUDElements.colors.text, "/%.0fW", gpu->metrics.powerLimit);
+                else
+                    HUDElements.TextColored(HUDElements.colors.text, "W");
                 ImGui::PopFont();
             }
 

--- a/src/loaders/loader_nvml.cpp
+++ b/src/loaders/loader_nvml.cpp
@@ -215,6 +215,19 @@ bool libnvml_loader::Load(const std::string& library_name) {
   }
 
 #if defined(LIBRARY_LOADER_NVML_H_DLOPEN)
+  nvmlDeviceGetPowerManagementLimit =
+      reinterpret_cast<decltype(this->nvmlDeviceGetPowerManagementLimit)>(
+          dlsym(library_, "nvmlDeviceGetPowerManagementLimit"));
+#endif
+#if defined(LIBRARY_LOADER_NVML_H_DT_NEEDED)
+  nvmlDeviceGetPowerManagementLimit = &::nvmlDeviceGetPowerManagementLimit;
+#endif
+  if (!nvmlDeviceGetPowerManagementLimit) {
+    CleanUp(true);
+    return false;
+  }
+
+#if defined(LIBRARY_LOADER_NVML_H_DLOPEN)
   nvmlUnitGetFanSpeedInfo =
       reinterpret_cast<decltype(this->nvmlUnitGetFanSpeedInfo)>(
           dlsym(library_, "nvmlUnitGetFanSpeedInfo"));

--- a/src/loaders/loader_nvml.h
+++ b/src/loaders/loader_nvml.h
@@ -37,6 +37,7 @@ class libnvml_loader {
   decltype(&::nvmlDeviceGetClockInfo) nvmlDeviceGetClockInfo;
   decltype(&::nvmlErrorString) nvmlErrorString;
   decltype(&::nvmlDeviceGetPowerUsage) nvmlDeviceGetPowerUsage;
+  decltype(&::nvmlDeviceGetPowerManagementLimit) nvmlDeviceGetPowerManagementLimit;
   decltype(&::nvmlDeviceGetCurrentClocksThrottleReasons) nvmlDeviceGetCurrentClocksThrottleReasons;
   decltype(&::nvmlUnitGetFanSpeedInfo) nvmlUnitGetFanSpeedInfo;
   decltype(&::nvmlUnitGetHandleByIndex) nvmlUnitGetHandleByIndex;

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -118,9 +118,11 @@ void NVIDIA::get_instant_metrics_nvml(struct gpu_metrics *metrics) {
         }
 
         if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_power] || (logger && logger->is_active())) {
-            unsigned int power;
+            unsigned int power, limit;
             nvml.nvmlDeviceGetPowerUsage(device, &power);
+            nvml.nvmlDeviceGetPowerManagementLimit(device, &limit);
             metrics->powerUsage = power / 1000;
+            metrics->powerLimit = limit / 1000;
         }
 
         if (params->enabled[OVERLAY_PARAM_ENABLED_throttling_status]) {
@@ -238,6 +240,7 @@ void NVIDIA::get_samples_and_copy() {
         cond_var.wait(lock, [this]() { return !paused || stop_thread; });
         GPU_UPDATE_METRIC_AVERAGE(load);
         GPU_UPDATE_METRIC_AVERAGE_FLOAT(powerUsage);
+        GPU_UPDATE_METRIC_MAX(powerLimit);
         GPU_UPDATE_METRIC_AVERAGE(CoreClock);
         GPU_UPDATE_METRIC_AVERAGE(MemClock);
 

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -117,6 +117,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(display_server)                \
    OVERLAY_PARAM_BOOL(gpu_efficiency)                \
    OVERLAY_PARAM_BOOL(flip_efficiency)               \
+   OVERLAY_PARAM_BOOL(gpu_power_limit)               \
    OVERLAY_PARAM_CUSTOM(fps_sampling_period)         \
    OVERLAY_PARAM_CUSTOM(output_folder)               \
    OVERLAY_PARAM_CUSTOM(output_file)                 \


### PR DESCRIPTION
As requested in #1622, this modifies the GPU power HUD element to include the current power limit.

Currently, the power limit label is not optional. Should it be?

This is currently marked as draft since it currently only supports NVIDIA.
AMD/Intel help wanted!

