### PR TITLE
add core_type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `control=`                         | Sets up a unix socket with a specific name that can be connected to with mangohud-control.<br>I.e. `control=mangohud` or `control=mangohud-%p` (`%p` will be replaced by process id)    |
 | `core_load_change`                 | Change the colors of cpu core loads, uses the same data from `cpu_load_value` and `cpu_load_change` |
 | `core_load`                        | Display load & frequency per core                                                     |
+| `core_type`                        | Display CPU core type per core. For Intel, it shows which cores are performance and efficient cores, for ARM it shows core codenames like A52, A53, A76, etc...                                                     |
 | `core_bars`                        | Change the display of `core_load` from numbers to vertical bars                       |
 | `cpu_load_change`                  | Change the color of the CPU load depending on load                                    |
 | `cpu_load_color`                   | Set the colors for the gpu load change low, medium and high. e.g `cpu_load_color=0000FF,00FFFF,FF00FF` |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -110,6 +110,7 @@ cpu_stats
 # core_load
 # core_load_change
 # core_bars
+# core_type
 
 ### Display IO read and write for the app (not system)
 # io_read

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -554,7 +554,7 @@ bool CPUStats::GetCpuFile() {
             // E2K (Elbrus 2000) CPU temperature module
             find_input(path, "temp", input, "Node 0 Max");
             break;
-        } else if (std::regex_match(name, match, std::regex("cpu\\d+_thermal"))) {
+        } else if (std::regex_match(name, match, std::regex("cpu\\d*_thermal"))) {
             find_fallback_input(path, "temp1", input);
             break;
         } else {

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -46,6 +46,8 @@ typedef struct CPUData_ {
    int temp;
    int cpu_mhz;
    float power;
+
+   std::string label = "unknown";
 } CPUData;
 
 enum {
@@ -165,6 +167,9 @@ public:
    bool GetCpuFile();
    bool InitCpuPowerData();
    double GetCPUPeriod() { return m_cpuPeriod; }
+   void get_cpu_cores_types();
+   void get_cpu_cores_types_intel();
+   void get_cpu_cores_types_arm();
 
    const std::vector<CPUData>& GetCPUData() const {
       return m_cpuData;
@@ -182,6 +187,38 @@ private:
    bool m_inited = false;
    FILE *m_cpuTempFile = nullptr;
    std::unique_ptr<CPUPowerData> m_cpuPowerData;
+
+   const std::map<std::string, std::string> intel_cores = {
+      {"P", "/sys/devices/cpu_core/cpus"},
+      {"E", "/sys/devices/cpu_atom/cpus"}
+   };
+
+   const std::map<std::string, std::string> arm_cores = {
+      // Performance cores
+      {"0xd07", "A57"},
+      {"0xd08", "A72"},
+      {"0xd09", "A73"},
+      {"0xd0a", "A75"},
+      {"0xd0b", "A76"},
+      {"0xd0c", "A77"},
+      {"0xd41", "A78"},
+      {"0xd44", "X1"},
+      {"0xd4d", "X2"},
+      {"0xd4e", "X3"},
+      {"0xd47", "A710"},
+      {"0xd4f", "A720"},
+      {"0xd4b", "X4"},
+
+      // Efficiency Cores
+      {"0xd03", "A53"},
+      {"0xd05", "A55"},
+      {"0xd46", "A510"},
+      {"0xd4a", "A520"},
+
+      // General-Purpose Cores
+      {"0xd04", "A35"},
+      {"0xd06", "A65"}
+   };
 };
 
 extern CPUStats cpuStats;

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -445,7 +445,12 @@ void HudElements::core_load(){
             HUDElements.TextColored(HUDElements.colors.cpu, "CPU");
             ImGui::SameLine(0, 1.0f);
             ImGui::PushFont(HUDElements.sw_stats->font1);
-            HUDElements.TextColored(HUDElements.colors.cpu,"%i", cpuData.cpu_id);
+
+            if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_core_type])
+                HUDElements.TextColored(HUDElements.colors.cpu, cpuData.label.c_str());
+            else
+                HUDElements.TextColored(HUDElements.colors.cpu, "%i", cpuData.cpu_id);
+
             ImGui::PopFont();
             ImguiNextColumnOrNewRow();
             auto text_color = HUDElements.colors.text;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -32,6 +32,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(frame_timing)                  \
    OVERLAY_PARAM_BOOL(core_load)                     \
    OVERLAY_PARAM_BOOL(core_bars)                     \
+   OVERLAY_PARAM_BOOL(core_type)                     \
    OVERLAY_PARAM_BOOL(cpu_temp)                      \
    OVERLAY_PARAM_BOOL(cpu_power)                     \
    OVERLAY_PARAM_BOOL(gpu_temp)                      \


### PR DESCRIPTION
Shows P and E cores on intel and cortex model on arm. This option supports intel and most popular arm processors (defined in cpu.h at line 196). To use this option, core_load must be also enabled.

### Intel example
![core_type_intel](https://github.com/user-attachments/assets/4b71c423-6b7b-408f-b0a9-ef41322f19d9)
*There is no E-cores because I have an i5-12400F*

### ARM example
![core_type_arm](https://github.com/user-attachments/assets/ac2537f0-f7f9-490a-987b-cf735da3bd3c)

