### PR TITLE
Show CPU efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `cpu_power`<br>`gpu_power`         | Display CPU/GPU draw in watts                                                         |
 | `cpu_temp`<br>`gpu_temp`<br>`gpu_junction_temp`<br>`gpu_mem_temp`           | Display current CPU/GPU temperature                                                  |
 | `cpu_text`<br>`gpu_text`           | Override CPU and GPU text. `gpu_text` is a list in case of multiple GPUs              |
+| `cpu_efficiency`                   | Display CPU efficiency in frames per joule                                            |
 | `custom_text_center`               | Display a custom text centered useful for a header e.g `custom_text_center=FlightLessMango Benchmarks` |
 | `custom_text`                      | Display a custom text e.g `custom_text=Fsync enabled`                                 |
 | `debug`                            | Shows the graph of gamescope app frametimes and latency (only on gamescope obviously) |
@@ -408,7 +409,6 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `gpu_voltage`                      | Display GPU voltage                                                                   |
 | `gpu_list`                         | List GPUs to display `gpu_list=0,1`                                                   |
 | `gpu_efficiency`                   | Display GPU efficiency in frames per joule                                            |
-| `flip_efficiency`                  | Flips GPU efficiency to joules per frame                                              |
 | `gpu_power_limit`                  | Display GPU power limit                                                               |
 | `hide_fsr_sharpness`               | Hides the sharpness info for the `fsr` option (only available in gamescope)           |
 | `histogram`                        | Change FPS graph to histogram                                                         |
@@ -472,6 +472,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `network`                          | Show network interfaces tx and rx kb/s. You can specify interface with `network=eth0` |
 | `fex_stats`                        | Show FEX-Emu statistics. Default = `status+apptype+hotthreads+jitload+sigbus+smc+softfloat` |
 | `ftrace`                           | Display information about trace events reported through ftrace                        |
+| `flip_efficiency`                  | Flips CPU and GPU efficiency to joules per frame                                      |
 
 Example: `MANGOHUD_CONFIG=cpu_temp,gpu_temp,position=top-right,height=500,font_size=32`
 Because comma is also used as option delimiter and needs to be escaped for values with a backslash, you can use `+` like `MANGOHUD_CONFIG=fps_limit=60+30+0` instead.

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -95,7 +95,6 @@ gpu_stats
 ## Select list of GPUs to display
 # gpu_list=0,1
 # gpu_efficiency
-# flip_efficiency
 
 ### Display the current CPU information
 cpu_stats
@@ -106,6 +105,7 @@ cpu_stats
 # cpu_load_change
 # cpu_load_value=60,90
 # cpu_load_color=39F900,FDFD09,B22222
+# cpu_efficiency
 
 ### Display the current CPU load & frequency for each core
 # core_load
@@ -215,6 +215,9 @@ frame_timing
 
 ### Display temperature in fahrenheit
 # temp_fahrenheit
+
+## Display efficiency in joules per frame
+# flip_efficiency
 
 ### Display custom text
 # custom_text=

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -484,6 +484,24 @@ void HudElements::cpu_stats(){
             HUDElements.TextColored(HUDElements.colors.text, "W");
             ImGui::PopFont();
         }
+
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_efficiency]) {
+            ImguiNextColumnOrNewRow();
+            float efficiency;
+            const char* efficiency_unit;
+            if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_flip_efficiency]) {
+                efficiency=cpuStats.GetCPUDataTotal().power/HUDElements.sw_stats->fps;
+                efficiency_unit="J/F";
+            } else {
+                efficiency=HUDElements.sw_stats->fps/cpuStats.GetCPUDataTotal().power;
+                efficiency_unit="F/J";
+            }
+            right_aligned_text(text_color, HUDElements.ralign_width, "%.2f", efficiency);
+            ImGui::SameLine(0, 1.0f);
+            ImGui::PushFont(HUDElements.sw_stats->font1);
+            HUDElements.TextColored(HUDElements.colors.text, efficiency_unit);
+            ImGui::PopFont();
+        }
     }
 }
 

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -123,6 +123,7 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(present_mode)                  \
    OVERLAY_PARAM_BOOL(time_no_label)                 \
    OVERLAY_PARAM_BOOL(display_server)                \
+   OVERLAY_PARAM_BOOL(cpu_efficiency)                \
    OVERLAY_PARAM_BOOL(gpu_efficiency)                \
    OVERLAY_PARAM_BOOL(flip_efficiency)               \
    OVERLAY_PARAM_BOOL(gpu_power_limit)               \


### PR DESCRIPTION
CPU analog of #1622.

Adds a HUD element that displays CPU efficiency in frames per joule (F/J).

I would be interested in adding a CPU power limit indicator like in #1623, but AFAIK, CPUs don't seem to report that without poking at the MSRs and such.

![image](https://github.com/user-attachments/assets/90481c22-8afe-4fe1-9b2d-48b296da9aeb)