### PR TITLE
add proc_vram option

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `position=`                        | Location of the HUD: `top-left` (default), `top-right`, `middle-left`, `middle-right`, `bottom-left`, `bottom-right`, `top-center`, `bottom-center` |
 | `preset=`                          | Comma separated list of one or more presets. Default is `-1,0,1,2,3,4`. Available presets:<br>`0` (No Hud)<br> `1` (FPS Only)<br> `2` (Horizontal)<br> `3` (Extended)<br> `4` (Detailed)<br>User defined presets can be created by using a [presets.conf](data/presets.conf) file in `~/.config/MangoHud/`.                      |
 | `procmem`<br>`procmem_shared`, `procmem_virt`| Displays process' memory usage: resident, shared and/or virtual. `procmem` (resident) also toggles others off if disabled |
+| `proc_vram`                        | Display process' VRAM usage                                                           |
 | `ram`<br>`vram`                    | Display system RAM/VRAM usage                                                         |
 | `read_cfg`                         | Add to MANGOHUD_CONFIG as first parameter to also load config file. Otherwise only `MANGOHUD_CONFIG` parameters are used |
 | `reload_cfg=`                      | Change keybind for reloading the config. Default = `Shift_L+F4`                       |
@@ -595,7 +596,7 @@ Example output:
 		<td>🔴</td>
 	</tr>
 	<tr>
-		<td>Memory Used</td>
+		<td>Process VRAM</td>
 		<td>🟢</td>
 		<td>🟢</td>
 		<td>🟢</td>
@@ -604,7 +605,16 @@ Example output:
 		<td>🟢</td>
 	</tr>
 	<tr>
-		<td>Memory Total</td>
+		<td>System VRAM</td>
+		<td>🟢</td>
+		<td>🟢</td>
+		<td>🔴</td>
+		<td>🔴</td>
+		<td>🔴</td>
+		<td>🔴</td>
+	</tr>
+	<tr>
+		<td>Total VRAM</td>
 		<td>🟢</td>
 		<td>🟢</td>
 		<td>🔴</td>

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -127,6 +127,7 @@ cpu_stats
 # procmem
 # procmem_shared
 # procmem_virt
+# proc_vram
 
 ### Display battery information
 # battery

--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -13,6 +13,10 @@
 #include <thread>
 #include "gpu_metrics_util.h"
 
+#ifndef TEST_ONLY
+#include "gpu_fdinfo.h"
+#endif
+
 #define NUM_HBM_INSTANCES 4
 #define UPDATE_METRIC_AVERAGE(FIELD) do { int value_sum = 0; for (size_t s=0; s < METRICS_SAMPLE_COUNT; s++) { value_sum += metrics_buffer[s].FIELD; } amdgpu_common_metrics.FIELD = value_sum / METRICS_SAMPLE_COUNT; } while(0)
 #define UPDATE_METRIC_AVERAGE_FLOAT(FIELD) do { float value_sum = 0; for (size_t s=0; s < METRICS_SAMPLE_COUNT; s++) { value_sum += metrics_buffer[s].FIELD; } amdgpu_common_metrics.FIELD = value_sum / METRICS_SAMPLE_COUNT; } while(0)
@@ -321,7 +325,11 @@ class AMDGPU {
 		std::mutex metrics_mutex;
 		gpu_metrics metrics;
 		struct amdgpu_common_metrics amdgpu_common_metrics;
-	
+
+#ifndef TEST_ONLY
+		std::unique_ptr<GPU_fdinfo> fdinfo_helper;
+#endif
+
 		void get_sysfs_metrics();
 		void metrics_polling_thread();
 };

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -116,7 +116,10 @@ private:
         std::vector<std::ifstream> &throttle_reason_streams);
 
 public:
-    GPU_fdinfo(const std::string module, const std::string pci_dev, const std::string drm_node)
+    GPU_fdinfo(
+        const std::string module, const std::string pci_dev, const std::string drm_node,
+        const bool called_from_amdgpu_cpp=false
+    )
         : module(module)
         , pci_dev(pci_dev)
         , drm_node(drm_node)
@@ -164,6 +167,9 @@ public:
             drm_engine_type, drm_memory_type
         );
 
+        if (called_from_amdgpu_cpp)
+            return;
+
         hwmon_sensors["voltage"]   = { .rx = std::regex("in(\\d+)_input") };
         hwmon_sensors["fan_speed"] = { .rx = std::regex("fan(\\d+)_input") };
         hwmon_sensors["temp"]      = { .rx = std::regex("temp(\\d+)_input") };
@@ -200,4 +206,6 @@ public:
         paused = false;
         cond_var.notify_one();
     }
+
+    float amdgpu_helper_get_proc_vram();
 };

--- a/src/gpu_metrics_util.h
+++ b/src/gpu_metrics_util.h
@@ -5,7 +5,8 @@ struct gpu_metrics {
     int temp;
     int junction_temp {-1};
     int memory_temp {-1};
-    float memoryUsed;
+    float sys_vram_used;
+    float proc_vram_used;
     float memoryTotal;
     int MemClock;
     int CoreClock;
@@ -24,7 +25,7 @@ struct gpu_metrics {
 
     gpu_metrics()
         : load(0), temp(0), junction_temp(0), memory_temp(0),
-          memoryUsed(0.0f), memoryTotal(0.0f), MemClock(0), CoreClock(0),
+          sys_vram_used(0.0f), proc_vram_used(0.0f), memoryTotal(0.0f), MemClock(0), CoreClock(0),
           powerUsage(0.0f), powerLimit(0.0f), apu_cpu_power(0.0f), apu_cpu_temp(0),
           is_power_throttled(false), is_current_throttled(false),
           is_temp_throttled(false), is_other_throttled(false),

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -543,9 +543,9 @@ void HudElements::vram(){
                 ImguiNextColumnOrNewRow();
                 // Add gtt_used to vram usage for APUs
                 if (gpu->is_apu())
-                    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", gpu->metrics.memoryUsed + gpu->metrics.gtt_used);
+                    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", gpu->metrics.sys_vram_used + gpu->metrics.gtt_used);
                 else
-                    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", gpu->metrics.memoryUsed);
+                    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", gpu->metrics.sys_vram_used);
                 if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
                     ImGui::SameLine(0,1.0f);
                     ImGui::PushFont(HUDElements.sw_stats->font1);
@@ -580,6 +580,33 @@ void HudElements::vram(){
             }
         }
     }
+}
+
+void HudElements::proc_vram() {
+    if (
+        !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_proc_vram] ||
+        !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats]
+    )
+        return;
+
+    if (!gpus)
+        gpus = std::make_unique<GPUS>(HUDElements.params);
+
+    ImguiNextColumnFirstItem();
+    HUDElements.TextColored(HUDElements.colors.vram, "PVRAM");
+    ImguiNextColumnOrNewRow();
+
+    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", gpus->active_gpu()->metrics.proc_vram_used);
+
+    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]) {
+        ImGui::SameLine(0, 1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font1);
+        HUDElements.TextColored(HUDElements.colors.text, "GiB");
+        ImGui::PopFont();
+    }
+
+    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal])
+        ImGui::TableNextRow();
 }
 
 void HudElements::ram(){
@@ -1790,6 +1817,8 @@ void HudElements::legacy_elements(){
         ordered_functions.push_back({io_stats, "io_stats", value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_vram])
         ordered_functions.push_back({vram, "vram", value});
+    if (params->enabled[OVERLAY_PARAM_ENABLED_proc_vram])
+        ordered_functions.push_back({proc_vram, "proc_vram", value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_ram])
         ordered_functions.push_back({ram, "ram", value});
     if (params->enabled[OVERLAY_PARAM_ENABLED_procmem])

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -82,6 +82,7 @@ class HudElements{
         static void core_load();
         static void io_stats();
         static void vram();
+        static void proc_vram();
         static void ram();
         static void procmem();
         static void fps();

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -153,7 +153,7 @@ void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
       currentLogData.gpu_temp = gpus->active_gpu()->metrics.temp;
       currentLogData.gpu_core_clock = gpus->active_gpu()->metrics.CoreClock;
       currentLogData.gpu_mem_clock = gpus->active_gpu()->metrics.MemClock;
-      currentLogData.gpu_vram_used = gpus->active_gpu()->metrics.memoryUsed;
+      currentLogData.gpu_vram_used = gpus->active_gpu()->metrics.sys_vram_used;
       currentLogData.gpu_power = gpus->active_gpu()->metrics.powerUsage;
    }
 #ifdef __linux__

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -43,6 +43,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_BOOL(ram)                           \
    OVERLAY_PARAM_BOOL(swap)                          \
    OVERLAY_PARAM_BOOL(vram)                          \
+   OVERLAY_PARAM_BOOL(proc_vram)                     \
    OVERLAY_PARAM_BOOL(procmem)                       \
    OVERLAY_PARAM_BOOL(procmem_shared)                \
    OVERLAY_PARAM_BOOL(procmem_virt)                  \


### PR DESCRIPTION
Closes issue #1237

this option shows vram usage by the current process

#### NVIDIA
![Screenshot from 2025-03-27 04-37-47](https://github.com/user-attachments/assets/505144f8-10af-42df-ada0-b753ae37812b)

#### AMD
![Screenshot from 2025-03-27 07-18-25](https://github.com/user-attachments/assets/983a8a80-8339-4018-8bb6-74ac5592f9e7)

#### Intel, panfrost, msm
they already read vram this way, i just moved readings from vram to pvram