### PR TITLE
overlay_params: don't enable core_type with full

### DIFF
--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -644,6 +644,7 @@ set_parameters_from_options(struct overlay_params *params)
       params->enabled[OVERLAY_PARAM_ENABLED_core_bars] = false;
       params->enabled[OVERLAY_PARAM_ENABLED_read_cfg] = read_cfg;
       params->enabled[OVERLAY_PARAM_ENABLED_time_no_label] = false;
+      params->enabled[OVERLAY_PARAM_ENABLED_core_type] = false;
       params->options.erase("full");
    }
    for (auto& it : params->options) {


### PR DESCRIPTION
fixes #1632 