### PR TITLE
cpu: attempt to use RAPL on non-Intel CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Because comma is also used as option delimiter and needs to be escaped for value
 
 *Note: Width and Height are set automatically based on the font_size, but can be overridden.*
 
-*Note: RAPL is currently used for Intel CPUs to show power draw with `cpu_power` which may be unreadable for non-root users due to [vulnerability](https://platypusattack.com/). The corresponding `energy_uj` file has to be readable by corresponding user, e.g. by running `chmod o+r /sys/class/powercap/intel-rapl\:0/energy_uj` as root, else the power shown will be **0 W**, though having the file readable may potentially be a security vulnerability persisting until system reboots.*
+*Note: RAPL is currently used for Intel and AMD Zen CPUs to show power draw with `cpu_power` which may be unreadable for non-root users due to [vulnerability](https://platypusattack.com/). The corresponding `energy_uj` file has to be readable by corresponding user, e.g. by running `chmod o+r /sys/class/powercap/intel-rapl\:0/energy_uj` as root, else the power shown will be **0 W**, though having the file readable may potentially be a security vulnerability persisting until system reboots.*
 
 *Note: The [zenpower3](https://git.exozy.me/a/zenpower3) or [zenergy](https://github.com/boukehaarsma23/zenergy) kernel driver must be installed to show the power draw of Ryzen CPUs.*
 

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -650,7 +650,6 @@ bool CPUStats::InitCpuPowerData() {
 
     std::string name, path;
     std::string hwmon = "/sys/class/hwmon/";
-    bool intel = false;
 
     CPUPowerData* cpuPowerData = nullptr;
 
@@ -668,12 +667,10 @@ bool CPUStats::InitCpuPowerData() {
         } else if (name == "zenergy") {
             cpuPowerData = (CPUPowerData*)init_cpu_power_data_zenergy(path);
             break;
-        } else if (name == "coretemp") {
-            intel = true;
         }
     }
 
-    if (!cpuPowerData && intel) {
+    if (!cpuPowerData) {
         std::string powercap = "/sys/class/powercap/";
         auto powercap_dirs = ls(powercap.c_str());
         for (auto& dir : powercap_dirs) {
@@ -686,7 +683,7 @@ bool CPUStats::InitCpuPowerData() {
             }
         }
     }
-    if (!cpuPowerData && !intel) {
+    if (!cpuPowerData) {
         auto powerData = std::make_unique<CPUPowerData_amdgpu>();
         cpuPowerData = (CPUPowerData*)powerData.release();
     }


### PR DESCRIPTION
Despite the strong association with Intel, RAPL is not actually Intel specific and works for AMD Zen processors. In fact, it seems like new processors do not report power consumption in any way except RAPL.

So, simply attempt to use RAPL for any CPU.

Tested on a 9950x3D