### PR TITLE
nvidia: fix power usage and limit reporting by ensuring float division

### DIFF
--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -120,8 +120,8 @@ void NVIDIA::get_instant_metrics_nvml(struct gpu_metrics *metrics) {
             unsigned int power, limit;
             nvml.nvmlDeviceGetPowerUsage(device, &power);
             nvml.nvmlDeviceGetPowerManagementLimit(device, &limit);
-            metrics->powerUsage = power / 1000;
-            metrics->powerLimit = limit / 1000;
+            metrics->powerUsage = power / 1000.0f;
+            metrics->powerLimit = limit / 1000.0f;
         }
 
         if (params->enabled[OVERLAY_PARAM_ENABLED_throttling_status]) {


### PR DESCRIPTION
my game's gpu power usage is below 0.09W, and magohud sometimes displays the wrong power usage with a large value

<div align="center">

![2025-04-14_19-59](https://github.com/user-attachments/assets/38417fd9-9840-4d4e-abe2-c07b2cfff297)

</div>