### PR TITLE
Multiple segfaults fix

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -435,4 +435,5 @@ AMDGPU::AMDGPU(std::string pci_dev, uint32_t device_id, uint32_t vendor_id) {
 #endif
 
 	thread = std::thread(&AMDGPU::metrics_polling_thread, this);
+	pthread_setname_np(thread.native_handle(), "amdgpu");
 }

--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -256,7 +256,7 @@ void AMDGPU::metrics_polling_thread() {
 	// Set all the fields to 0 by default. Only done once as we're just replacing previous values after
 	memset(metrics_buffer, 0, sizeof(metrics_buffer));
 
-	while (1) {
+	while (!stop_thread) {
 #ifndef TEST_ONLY
 		if (HUDElements.params->no_display && !logger->is_active())
 			usleep(100000);
@@ -434,6 +434,5 @@ AMDGPU::AMDGPU(std::string pci_dev, uint32_t device_id, uint32_t vendor_id) {
 	fdinfo_helper = std::make_unique<GPU_fdinfo>("amdgpu", pci_dev, "", /*called_from_amdgpu_cpp=*/ true);
 #endif
 
-	std::thread thread(&AMDGPU::metrics_polling_thread, this);
-	thread.detach();
+	thread = std::thread(&AMDGPU::metrics_polling_thread, this);
 }

--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -290,6 +290,12 @@ class AMDGPU {
 
     	AMDGPU(std::string pci_dev, uint32_t device_id, uint32_t vendor_id);
 
+		~AMDGPU() {
+			stop_thread = true;
+			if (thread.joinable())
+				thread.join();
+		}
+
 		bool verify_metrics(const std::string& path);
 		void get_instant_metrics(struct amdgpu_common_metrics *metrics);
 		void get_samples_and_copy(struct amdgpu_common_metrics metrics_buffer[METRICS_SAMPLE_COUNT],

--- a/src/dbus.cpp
+++ b/src/dbus.cpp
@@ -459,6 +459,7 @@ void dbus_manager::start_thread() {
     stop_thread();
     m_quit = false;
     m_thread = std::thread(&dbus_manager::dbus_thread, this);
+    pthread_setname_np(m_thread.native_handle(), "dbus");
 }
 
 void dbus_manager::dbus_thread() {

--- a/src/fps_metrics.h
+++ b/src/fps_metrics.h
@@ -107,8 +107,10 @@ class fpsMetrics {
         fpsMetrics(std::vector<std::string> values){
             metrics = add_metrics_to_vector(values);
 
-            if (!thread_init)
+            if (!thread_init) {
                 thread = std::thread(&fpsMetrics::_thread, this);
+                pthread_setname_np(thread.native_handle(), "fps_metrics");
+            }
         };
 
         fpsMetrics(std::vector<std::string> values, std::vector<float> only_frametime) {

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -204,6 +204,7 @@ public:
             find_xe_gt_dir();
 
         thread = std::thread(&GPU_fdinfo::main_thread, this);
+        pthread_setname_np(thread.native_handle(), "gpu_fdinfo");
     }
 
     ~GPU_fdinfo() {

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -203,8 +203,13 @@ public:
         else if (module == "xe")
             find_xe_gt_dir();
 
-        std::thread thread(&GPU_fdinfo::main_thread, this);
-        thread.detach();
+        thread = std::thread(&GPU_fdinfo::main_thread, this);
+    }
+
+    ~GPU_fdinfo() {
+        stop_thread = true;
+        if (thread.joinable())
+            thread.join();
     }
 
     gpu_metrics copy_metrics() const

--- a/src/loaders/loader_nvctrl.cpp
+++ b/src/loaders/loader_nvctrl.cpp
@@ -1,6 +1,5 @@
 #include "loader_nvctrl.h"
 #include <iostream>
-#include <memory>
 #include <spdlog/spdlog.h>
 
 // Put these sanity checks here so that they fire at most once
@@ -12,13 +11,13 @@
 #error both LIBRARY_LOADER_NVCTRL_H_DLOPEN and LIBRARY_LOADER_NVCTRL_H_DT_NEEDED defined
 #endif
 
-static std::unique_ptr<libnvctrl_loader> libnvctrl_;
+static std::shared_ptr<libnvctrl_loader> libnvctrl_;
 
-libnvctrl_loader& get_libnvctrl_loader()
+std::shared_ptr<libnvctrl_loader> get_libnvctrl_loader()
 {
     if (!libnvctrl_)
-        libnvctrl_ = std::make_unique<libnvctrl_loader>("libXNVCtrl.so.0");
-    return *libnvctrl_.get();
+        libnvctrl_ = std::make_shared<libnvctrl_loader>("libXNVCtrl.so.0");
+    return libnvctrl_;
 }
 
 libnvctrl_loader::libnvctrl_loader() : loaded_(false) {
@@ -34,7 +33,7 @@ bool libnvctrl_loader::Load(const std::string& library_name) {
   }
 
 #if defined(LIBRARY_LOADER_NVCTRL_H_DLOPEN)
-  library_ = dlopen(library_name.c_str(), RTLD_LAZY);
+  library_ = dlopen(library_name.c_str(), RTLD_LAZY | RTLD_NODELETE);
   if (!library_) {
     SPDLOG_DEBUG("Failed to open " MANGOHUD_ARCH " {}: {}", library_name, dlerror());
     return false;

--- a/src/loaders/loader_nvctrl.h
+++ b/src/loaders/loader_nvctrl.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <dlfcn.h>
+#include <memory>
 
 class libnvctrl_loader {
  public:
@@ -41,5 +42,5 @@ class libnvctrl_loader {
   void operator=(const libnvctrl_loader&);
 };
 
-libnvctrl_loader& get_libnvctrl_loader();
+std::shared_ptr<libnvctrl_loader> get_libnvctrl_loader();
 #endif  // LIBRARY_LOADER_NVCTRL_H

--- a/src/loaders/loader_nvml.h
+++ b/src/loaders/loader_nvml.h
@@ -13,6 +13,7 @@
 
 #include <string>
 #include <dlfcn.h>
+#include <memory>
 
 class libnvml_loader {
  public:
@@ -58,5 +59,5 @@ class libnvml_loader {
   void operator=(const libnvml_loader&);
 };
 
-libnvml_loader& get_libnvml_loader();
+std::shared_ptr<libnvml_loader> get_libnvml_loader();
 #endif  // LIBRARY_LOADER_NVML_H

--- a/src/loaders/loader_x11.cpp
+++ b/src/loaders/loader_x11.cpp
@@ -14,7 +14,7 @@ bool libx11_loader::Load(const std::string& library_name) {
     return false;
   }
 
-  library_ = dlopen(library_name.c_str(), RTLD_LAZY);
+  library_ = dlopen(library_name.c_str(), RTLD_LAZY | RTLD_NODELETE);
   if (!library_) {
     SPDLOG_ERROR("Failed to open " MANGOHUD_ARCH " {}: {}", library_name, dlerror());
     return false;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -268,6 +268,7 @@ void Logger::start_logging() {
 
   if(log_interval != 0){
     std::thread log_thread(&Logger::logging, this);
+    pthread_setname_np(log_thread.native_handle(), "logging");
     log_thread.detach();
   }
 }

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -68,6 +68,7 @@ NVIDIA::NVIDIA(const char* pciBusId) {
     if (nvml_available || nvctrl_available) {
         throttling = std::make_shared<Throttling>(0x10de);
         thread = std::thread(&NVIDIA::get_samples_and_copy, this);
+        pthread_setname_np(thread.native_handle(), "nvidia");
     } else {
         SPDLOG_WARN("NVML and NVCTRL are unavailable. Unable to get NVIDIA info. User is on DFSG version of mangohud?");
     }

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -452,6 +452,7 @@ void center_text(const std::string& text)
    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2 )- (ImGui::CalcTextSize(text.c_str()).x / 2));
 }
 
+#ifdef HAVE_DBUS
 static float get_ticker_limited_pos(float pos, float tw, float& left_limit, float& right_limit)
 {
    //float cw = ImGui::GetContentRegionAvailWidth() * 3; // only table cell worth of width
@@ -473,7 +474,6 @@ static float get_ticker_limited_pos(float pos, float tw, float& left_limit, floa
    return new_pos_x;
 }
 
-#ifdef HAVE_DBUS
 void render_mpris_metadata(const struct overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing)
 {
    static const float overflow = 50.f /* 3333ms * 0.5 / 16.6667 / 2 (to edge and back) */;

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -189,6 +189,7 @@ struct hw_info_updater
    hw_info_updater()
    {
       thread = std::thread(&hw_info_updater::run, this);
+      pthread_setname_np(thread.native_handle(), "hw_info_updater");
    }
 
    ~hw_info_updater()


### PR DESCRIPTION
Down below are all commit messages in one place.

All of these are different commits for cleaner commit history and easier understanding of the changes.

- fix x11 segfault
  - when closing an application, x11 library might get unloaded while mangohud threads are still working leading to use-after-free

- fix gpu_fdinfo segfault
  - when closing an application, GPU_fdinfo will get destroyed without joining GPU_fdinfo::main_thread() leading to use-after-free

- fix amdgpu segfault
  - when closing an application AMDGPU will get destroyed without joining AMDGPU::metrics_polling_thread() leading to use-after-free

- fix compilation without dbus
  - when compiling with -Dwith_dbus=disabled, compiler complains about unused function.

- fix nvidia segfault
  - 1\) libnvml_loader might get destroyed before nvidia thread stops working leading to use-after-free.
     - fix this by using std::shared_ptr so that libnvml_loader will be destroyed only after references to libnvml_loader is zero.
     -
     - same thing goes for libxnvctrl_loader.
     -
     - also add RTLD_NODELETE just in-case.

  - 2\) NVIDIA will get destroyed without joining NVIDIA::get_samples_and_copy() leading to use-after-free.