### PR TITLE
When setting thread names, give a hint that they are for MangoHud

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -435,5 +435,5 @@ AMDGPU::AMDGPU(std::string pci_dev, uint32_t device_id, uint32_t vendor_id) {
 #endif
 
 	thread = std::thread(&AMDGPU::metrics_polling_thread, this);
-	pthread_setname_np(thread.native_handle(), "amdgpu");
+	pthread_setname_np(thread.native_handle(), "mangohud-amdgpu");
 }

--- a/src/dbus.cpp
+++ b/src/dbus.cpp
@@ -459,7 +459,7 @@ void dbus_manager::start_thread() {
     stop_thread();
     m_quit = false;
     m_thread = std::thread(&dbus_manager::dbus_thread, this);
-    pthread_setname_np(m_thread.native_handle(), "dbus");
+    pthread_setname_np(m_thread.native_handle(), "mangohud-dbus");
 }
 
 void dbus_manager::dbus_thread() {

--- a/src/fps_metrics.h
+++ b/src/fps_metrics.h
@@ -109,7 +109,8 @@ class fpsMetrics {
 
             if (!thread_init) {
                 thread = std::thread(&fpsMetrics::_thread, this);
-                pthread_setname_np(thread.native_handle(), "fps_metrics");
+                // "mangohud-fpsmetrics" wouldn't fit in the 15 byte limit
+                pthread_setname_np(thread.native_handle(), "mangohud-fpsmet");
             }
         };
 

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -204,7 +204,8 @@ public:
             find_xe_gt_dir();
 
         thread = std::thread(&GPU_fdinfo::main_thread, this);
-        pthread_setname_np(thread.native_handle(), "gpu_fdinfo");
+        // "mangohud-gpufdinfo" wouldn't fit in the 15 byte limit
+        pthread_setname_np(thread.native_handle(), "mangohud-gpufd");
     }
 
     ~GPU_fdinfo() {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -268,7 +268,8 @@ void Logger::start_logging() {
 
   if(log_interval != 0){
     std::thread log_thread(&Logger::logging, this);
-    pthread_setname_np(log_thread.native_handle(), "logging");
+    // "mangohud-logging" wouldn't fit in the 15 byte limit
+    pthread_setname_np(log_thread.native_handle(), "mangohud-log");
     log_thread.detach();
   }
 }

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -68,7 +68,7 @@ NVIDIA::NVIDIA(const char* pciBusId) {
     if (nvml_available || nvctrl_available) {
         throttling = std::make_shared<Throttling>(0x10de);
         thread = std::thread(&NVIDIA::get_samples_and_copy, this);
-        pthread_setname_np(thread.native_handle(), "nvidia");
+        pthread_setname_np(thread.native_handle(), "mangohud-nvidia");
     } else {
         SPDLOG_WARN("NVML and NVCTRL are unavailable. Unable to get NVIDIA info. User is on DFSG version of mangohud?");
     }

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -189,7 +189,8 @@ struct hw_info_updater
    hw_info_updater()
    {
       thread = std::thread(&hw_info_updater::run, this);
-      pthread_setname_np(thread.native_handle(), "hw_info_updater");
+      // Anything longer than this wouldn't fit in the 15 byte limit
+      pthread_setname_np(thread.native_handle(), "mangohud-hwinfo");
    }
 
    ~hw_info_updater()


### PR DESCRIPTION
* When setting thread names, give a hint that they are for MangoHud
    
    Because MangoHud is a LD_PRELOAD module or a Vulkan layer, its threads
    run as part of some host process, typically a game. Putting a common
    prefix on the threads means they can be distinguished from threads
    created by some other library loaded into the same host process.
    
    For instance, renaming the D-Bus thread from dbus to mangohud-dbus allows
    it to be distinguished from some other library also using a thread to
    access D-Bus.
    
    Thread names are limited to 15 bytes + '\0', so some of them needed to be
    abbreviated appropriately.
