### PR TITLE
shim: Avoid exporting unintended symbols

### DIFF
--- a/src/gl/shim.c
+++ b/src/gl/shim.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include "gl.h"
+#include "mesa/util/macros.h"
 #include "real_dlsym.h"
 #include <string.h>
 #include <stdbool.h>
@@ -180,10 +181,6 @@ static struct func_ptr hooks[] = {
     ADD_HOOK(eglGetProcAddress)
 };
 #undef ADD_HOOK
-
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(arr) sizeof(arr)/sizeof(arr[0])
-#endif
 
 void* dlsym(void *handle, const char *name)
 {

--- a/src/gl/shim.c
+++ b/src/gl/shim.c
@@ -132,13 +132,13 @@ static void loadMangoHud() {
 }
 
 #define CREATE_FWD_VOID(name, params, ...) \
-    void name params { \
+    PUBLIC void name params { \
         loadMangoHud(); \
         void (*p##name) params = real_dlsym(handle, #name); \
         if (p##name) p##name(__VA_ARGS__); \
     }
 #define CREATE_FWD(ret_type, name, params, ...) \
-    ret_type name params { \
+    PUBLIC ret_type name params { \
         loadMangoHud(); \
         ret_type (*p##name) params = real_dlsym(handle, #name); \
         if (p##name) return p##name(__VA_ARGS__); \

--- a/src/gl/shim.c
+++ b/src/gl/shim.c
@@ -182,7 +182,7 @@ static struct func_ptr hooks[] = {
 };
 #undef ADD_HOOK
 
-void* dlsym(void *handle, const char *name)
+PUBLIC void* dlsym(void *handle, const char *name)
 {
     const char* dlsym_enabled = getenv("MANGOHUD_DLSYM");
     void* is_angle = real_dlsym(handle, "eglStreamPostD3DTextureANGLE");

--- a/src/meson.build
+++ b/src/meson.build
@@ -312,6 +312,7 @@ if is_unixy
     dependencies : [
       dep_dl
     ],
+    gnu_symbol_visibility : 'hidden',
     include_directories : [inc_common],
     install_dir : libdir_mangohud,
     install: true

--- a/src/meson.build
+++ b/src/meson.build
@@ -248,6 +248,7 @@ mangohud_opengl_shared_lib = shared_library(
     dep_vulkan,
     windows_deps,
     implot_dep],
+  gnu_symbol_visibility : 'hidden',
   include_directories : [inc_common],
   link_args : link_args,
   link_with: mangohud_static_lib,

--- a/src/real_dlsym.c
+++ b/src/real_dlsym.c
@@ -11,8 +11,8 @@
 #include "real_dlsym.h"
 #include "elfhacks.h"
 
-void *(*__dlopen)(const char *, int) = NULL;
-void *(*__dlsym)(void *, const char *) = NULL;
+static void *(*__dlopen)(const char *, int) = NULL;
+static void *(*__dlsym)(void *, const char *) = NULL;
 static bool print_dlopen;
 static bool print_dlsym;
 


### PR DESCRIPTION
* shim: Reuse Mesa's macros instead of open-coding
    
    We'll want macros.h for PUBLIC, and it defines an ARRAY_SIZE that we
    can use.

* shim: Explicitly export forwarding functions
    
    This will allow us to control exports with -fvisibility=hidden.

* shim: Explicitly export our dlsym() reimplementation
    
    This is intended to be hooked in the process that loaded MangoHud.

* shim: Hide all symbols that are not explicitly public
    
    This avoids accidentally interposing symbols like __dlsym() and
    eh_hash_elf().
    
    Resolves: https://github.com/flightlessmango/MangoHud/issues/1667

* real_dlsym: Make local variables static
    
    There's no need for these to be referenced outside this translation unit.