### PR TITLE
Adds font_size_secondary parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,9 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `font_glyph_ranges`                | Specify extra font glyph ranges, comma separated: `korean`, `chinese`, `chinese_simplified`, `japanese`, `cyrillic`, `thai`, `vietnamese`, `latin_ext_a`, `latin_ext_b`. If you experience crashes or text is just squares, reduce font size or glyph ranges |
 | `font_scale=`                      | Set global font scale. Default is `1.0`                                               |
 | `font_scale_media_player`          | Change size of media player text relative to `font_size`                              |
-| `font_size=`                       | Customizable font size. Default is `24`                                              |
-| `font_size_text=`                  | Customizable font size for other text like media metadata. Default is `24`           |
+| `font_size=`                       | Customizable font size. Default is `24`                                               |
+| `font_size_secondary=`             | Customizable font size for secondary metrics. Default is `0.55 * font_size`.          |
+| `font_size_text=`                  | Customizable font size for other text like media metadata. Default is `24`            |
 | `fps_color_change`                 | Change the FPS text color depepending on the FPS value                                |
 | `fps_color=`                       | Choose the colors that the fps changes to when `fps_color_change` is enabled. Corresponds with fps_value. Default is `b22222,fdfd09,39f900`   |
 | `fps_limit_method`                 | If FPS limiter should wait before or after presenting a frame. Choose `late` (default) for the lowest latency or `early` for the smoothest frametimes |

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -307,7 +307,7 @@ int main(int, char**)
     // Setup Platform/Renderer backends
     int control_client = -1;
     parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
-    create_fonts(nullptr, params, sw_stats.font1, sw_stats.font_text);
+    create_fonts(nullptr, params, sw_stats.font_small, sw_stats.font_text, sw_stats.font_secondary);
     HUDElements.convert_colors(params);
     init_cpu_stats(params);
     notifier.params = &params;

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -5,7 +5,7 @@
 #include "IconsForkAwesome.h"
 #include "forkawesome.h"
 
-void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*& small_font, ImFont*& text_font)
+void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*& small_font, ImFont*& text_font, ImFont*& secondary_font)
 {
    auto& io = ImGui::GetIO();
    if (!font_atlas)
@@ -20,6 +20,11 @@ void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*
    float font_size_text = params.font_size_text;
    if (font_size_text < FLT_EPSILON)
       font_size_text = font_size;
+
+   float font_size_secondary = params.font_size_secondary;
+   if (font_size_secondary > font_size || font_size_secondary < FLT_EPSILON)
+      font_size_secondary = font_size;
+
    static const ImWchar default_range[] =
    {
       0x0020, 0x00FF, // Basic Latin + Latin Supplement
@@ -65,17 +70,24 @@ void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*
    builder.BuildRanges(&glyph_ranges);
 
    bool same_font = (params.font_file == params.font_file_text || params.font_file_text.empty());
-   bool same_size = (font_size == font_size_text);
+   bool text_same_size = (font_size == font_size_text);
+   bool secondary_same_size = (font_size == font_size_secondary);
 
    // ImGui takes ownership of the data, no need to free it
    if (!params.font_file.empty() && file_exists(params.font_file)) {
-      font_atlas->AddFontFromFileTTF(params.font_file.c_str(), font_size, nullptr, same_font && same_size ? glyph_ranges.Data : default_range);
+      font_atlas->AddFontFromFileTTF(params.font_file.c_str(), font_size, nullptr, same_font && text_same_size ? glyph_ranges.Data : default_range);
       font_atlas->AddFontFromMemoryCompressedBase85TTF(forkawesome_compressed_data_base85, font_size, &config, icon_ranges);
       if (params.no_small_font)
          small_font = font_atlas->Fonts[0];
       else {
          small_font = font_atlas->AddFontFromFileTTF(params.font_file.c_str(), font_size * 0.55f, nullptr, default_range);
          font_atlas->AddFontFromMemoryCompressedBase85TTF(forkawesome_compressed_data_base85, font_size * 0.55f, &config, icon_ranges);
+      }
+      if (secondary_same_size) {
+         secondary_font = font_atlas->Fonts[0];
+      } else {
+         secondary_font = font_atlas->AddFontFromFileTTF(params.font_file.c_str(), font_size_secondary, nullptr, default_range);
+         font_atlas->AddFontFromMemoryCompressedBase85TTF(forkawesome_compressed_data_base85, font_size_secondary, &config, icon_ranges);
       }
    } else {
       const char* ttf_compressed_base85 = GetDefaultCompressedFontDataTTFBase85();
@@ -87,13 +99,19 @@ void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*
          small_font = font_atlas->AddFontFromMemoryCompressedBase85TTF(ttf_compressed_base85, font_size * 0.55f, nullptr, default_range);
          font_atlas->AddFontFromMemoryCompressedBase85TTF(forkawesome_compressed_data_base85, font_size * 0.55f, &config, icon_ranges);
       }
+      if (secondary_same_size) {
+         secondary_font = font_atlas->Fonts[0];
+      } else {
+         secondary_font = font_atlas->AddFontFromMemoryCompressedBase85TTF(ttf_compressed_base85, font_size_secondary, nullptr, default_range);
+         font_atlas->AddFontFromMemoryCompressedBase85TTF(forkawesome_compressed_data_base85, font_size_secondary, &config, icon_ranges);
+      }
    }
 
    auto font_file_text = params.font_file_text;
    if (font_file_text.empty())
       font_file_text = params.font_file;
 
-   if ((!same_font || !same_size) && file_exists(font_file_text))
+   if ((!same_font || !text_same_size) && file_exists(font_file_text))
       text_font = font_atlas->AddFontFromFileTTF(font_file_text.c_str(), font_size_text, nullptr, glyph_ranges.Data);
    else
       text_font = font_atlas->Fonts[0];

--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -181,7 +181,7 @@ void imgui_create(void *ctx, const gl_wsi plat)
 
     ImGui_ImplOpenGL3_Init();
 
-    create_fonts(nullptr, params, sw_stats.font1, sw_stats.font_text);
+    create_fonts(nullptr, params, sw_stats.font_small, sw_stats.font_text, sw_stats.font_secondary);
     sw_stats.font_params_hash = params.font_params_hash;
 
     // Restore global context or ours might clash with apps that use Dear ImGui
@@ -229,7 +229,7 @@ void imgui_render(unsigned int width, unsigned int height)
     if (sw_stats.font_params_hash != params.font_params_hash)
     {
         sw_stats.font_params_hash = params.font_params_hash;
-        create_fonts(nullptr, params, sw_stats.font1, sw_stats.font_text);
+        create_fonts(nullptr, params, sw_stats.font_small, sw_stats.font_text, sw_stats.font_secondary);
         ImGui_ImplOpenGL3_CreateFontsTexture();
     }
 

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -157,6 +157,10 @@ static void ImguiNextColumnOrNewRow(int column = -1)
     }
 }
 
+static bool ImGuiTextOverflow(const char* text) {
+    return ImGui::CalcTextSize(text).x > ImGui::CalcItemWidth() + HUDElements.ralign_width / 2;
+}
+
 static void ImGuiTableSetColumnIndex(int column)
 {
     ImGui::TableSetColumnIndex(std::max(0, std::min(column, ImGui::TableGetColumnCount() - 1)));
@@ -247,7 +251,7 @@ void HudElements::gpu_stats(){
                 else
                     HUDElements.TextColored(HUDElements.colors.text, "°C");
                 ImGui::SameLine(0, 1.0f);
-                ImGui::PushFont(HUDElements.sw_stats->font1);
+                ImGui::PushFont(HUDElements.sw_stats->font_small);
                 HUDElements.TextColored(HUDElements.colors.text, "Jnc");
                 ImGui::PopFont();
             }
@@ -257,11 +261,11 @@ void HudElements::gpu_stats(){
                 right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.fan_speed);
                 ImGui::SameLine(0, 1.0f);
                 if (gpu->metrics.fan_rpm) {
-                    ImGui::PushFont(HUDElements.sw_stats->font1);
+                    ImGui::PushFont(HUDElements.sw_stats->font_small);
                     HUDElements.TextColored(HUDElements.colors.text, "RPM");
                 } else {
                     HUDElements.TextColored(HUDElements.colors.text, "%%");
-                    ImGui::PushFont(HUDElements.sw_stats->font1);
+                    ImGui::PushFont(HUDElements.sw_stats->font_small);
                     ImGui::SameLine(0, 1.0f);
                     HUDElements.TextColored(HUDElements.colors.text, "FAN");
                 }
@@ -272,7 +276,7 @@ void HudElements::gpu_stats(){
                 ImguiNextColumnOrNewRow();
                 right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.CoreClock);
                 ImGui::SameLine(0, 1.0f);
-                ImGui::PushFont(HUDElements.sw_stats->font1);
+                ImGui::PushFont(HUDElements.sw_stats->font_small);
                 HUDElements.TextColored(HUDElements.colors.text, "MHz");
                 ImGui::PopFont();
             }
@@ -286,7 +290,7 @@ void HudElements::gpu_stats(){
                 else
                     right_aligned_text(text_color, HUDElements.ralign_width, "%.1f", gpu->metrics.powerUsage);
                 ImGui::SameLine(0, 1.0f);
-                ImGui::PushFont(HUDElements.sw_stats->font1);
+                ImGui::PushFont(HUDElements.sw_stats->font_small);
                 if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_power_limit])
                     HUDElements.TextColored(HUDElements.colors.text, "/%.0fW", gpu->metrics.powerLimit);
                 else
@@ -307,7 +311,7 @@ void HudElements::gpu_stats(){
                 }
                 right_aligned_text(text_color, HUDElements.ralign_width, "%.2f", efficiency);
                 ImGui::SameLine(0, 1.0f);
-                ImGui::PushFont(HUDElements.sw_stats->font1);
+                ImGui::PushFont(HUDElements.sw_stats->font_small);
                 HUDElements.TextColored(HUDElements.colors.text, efficiency_unit);
                 ImGui::PopFont();
             }
@@ -316,7 +320,7 @@ void HudElements::gpu_stats(){
                 ImguiNextColumnOrNewRow();
                 right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.voltage);
                 ImGui::SameLine(0, 1.0f);
-                ImGui::PushFont(HUDElements.sw_stats->font1);
+                ImGui::PushFont(HUDElements.sw_stats->font_small);
                 HUDElements.TextColored(HUDElements.colors.text, "mV");
                 ImGui::PopFont();
             }
@@ -380,7 +384,7 @@ void HudElements::cpu_stats(){
             ImguiNextColumnOrNewRow();
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", cpuStats.GetCPUDataTotal().cpu_mhz);
             ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "MHz");
             ImGui::PopFont();
         }
@@ -394,7 +398,7 @@ void HudElements::cpu_stats(){
             else
                 right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", cpuStats.GetCPUDataTotal().power);
             ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "W");
             ImGui::PopFont();
         }
@@ -413,7 +417,7 @@ void HudElements::core_load(){
 
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_core_bars]){
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
             ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
             HUDElements.TextColored(HUDElements.colors.cpu, "CPU Cores");
@@ -448,7 +452,7 @@ void HudElements::core_load(){
             ImguiNextColumnFirstItem();
             HUDElements.TextColored(HUDElements.colors.cpu, "CPU");
             ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
 
             if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_core_type])
                 HUDElements.TextColored(HUDElements.colors.cpu, cpuData.label.c_str());
@@ -481,7 +485,7 @@ void HudElements::core_load(){
             }
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", cpuData.mhz);
             ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "MHz");
             ImGui::PopFont();
         }
@@ -504,7 +508,7 @@ void HudElements::io_stats(){
             const float val = g_io_stats.per_second.read;
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, val < 100 ? "%.1f" : "%.f", val);
             ImGui::SameLine(0,1.0f);
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "MiB/s");
             ImGui::PopFont();
         }
@@ -513,7 +517,7 @@ void HudElements::io_stats(){
             const float val = g_io_stats.per_second.write;
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, val < 100 ? "%.1f" : "%.f", val);
             ImGui::SameLine(0,1.0f);
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "MiB/s");
             ImGui::PopFont();
         }
@@ -548,7 +552,7 @@ void HudElements::vram(){
                     right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", gpu->metrics.sys_vram_used);
                 if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
                     ImGui::SameLine(0,1.0f);
-                    ImGui::PushFont(HUDElements.sw_stats->font1);
+                    ImGui::PushFont(HUDElements.sw_stats->font_small);
                     HUDElements.TextColored(HUDElements.colors.text, "GiB");
                     ImGui::PopFont();
                 }
@@ -570,7 +574,7 @@ void HudElements::vram(){
                     ImguiNextColumnOrNewRow();
                     right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", gpu->metrics.MemClock);
                     ImGui::SameLine(0, 1.0f);
-                    ImGui::PushFont(HUDElements.sw_stats->font1);
+                    ImGui::PushFont(HUDElements.sw_stats->font_small);
                     HUDElements.TextColored(HUDElements.colors.text, "MHz");
                     ImGui::PopFont();
                 }
@@ -607,14 +611,14 @@ void HudElements::proc_vram() {
 
     if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]) {
         ImGui::SameLine(0, 1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "GiB");
         ImGui::PopFont();
     }
 
     // show only if vram is not enabled
     if (
-        !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vram] && 
+        !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vram] &&
         HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_mem_temp]
     ) {
         ImguiNextColumnOrNewRow();
@@ -650,7 +654,7 @@ void HudElements::ram(){
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", memused);
         if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
             ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "GiB");
             ImGui::PopFont();
         }
@@ -660,7 +664,7 @@ void HudElements::ram(){
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", swapused);
         ImGui::SameLine(0, 1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "GiB");
         ImGui::PopFont();
     }
@@ -680,7 +684,7 @@ void HudElements::procmem()
     ImguiNextColumnOrNewRow();
     right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", format_units(proc_mem_resident, unit));
     ImGui::SameLine(0, 1.0f);
-    ImGui::PushFont(HUDElements.sw_stats->font1);
+    ImGui::PushFont(HUDElements.sw_stats->font_small);
     HUDElements.TextColored(HUDElements.colors.text, "%s", unit);
     ImGui::PopFont();
 
@@ -688,7 +692,7 @@ void HudElements::procmem()
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", format_units(proc_mem_shared, unit));
         ImGui::SameLine(0,1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "%s", unit);
         ImGui::PopFont();
     }
@@ -697,7 +701,7 @@ void HudElements::procmem()
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", format_units(proc_mem_virt, unit));
         ImGui::SameLine(0, 1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "%s", unit);
         ImGui::PopFont();
     }
@@ -740,7 +744,7 @@ void HudElements::fps(){
         }
         ImGui::SameLine(0, 1.0f);
         if(!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal]){
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "FPS");
             ImGui::PopFont();
         }
@@ -748,7 +752,7 @@ void HudElements::fps(){
             ImguiNextColumnOrNewRow();
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", 1000 / HUDElements.sw_stats->fps);
             ImGui::SameLine(0, 1.0f);
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "ms");
             ImGui::PopFont();
         }
@@ -780,7 +784,7 @@ void HudElements::fps_only(){
 void HudElements::gpu_name(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_name] && !HUDElements.sw_stats->gpuName.empty()){
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         HUDElements.TextColored(HUDElements.colors.engine,
             "%s", HUDElements.sw_stats->gpuName.c_str());
         ImGui::PopFont();
@@ -790,7 +794,7 @@ void HudElements::gpu_name(){
 void HudElements::engine_version(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_engine_version]){
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         if (HUDElements.is_vulkan) {
             if ((HUDElements.sw_stats->engine == EngineTypes::DXVK || HUDElements.sw_stats->engine == EngineTypes::VKD3D)){
                 HUDElements.TextColored(HUDElements.colors.engine,
@@ -817,7 +821,7 @@ void HudElements::engine_version(){
 void HudElements::vulkan_driver(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vulkan_driver] && !HUDElements.sw_stats->driverName.empty()){
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         HUDElements.TextColored(HUDElements.colors.engine,
             "%s", HUDElements.sw_stats->driverName.c_str());
         ImGui::PopFont();
@@ -827,7 +831,7 @@ void HudElements::vulkan_driver(){
 void HudElements::arch(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_arch]){
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "" MANGOHUD_ARCH);
         ImGui::PopFont();
     }
@@ -837,7 +841,7 @@ void HudElements::wine(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_wine]){
         ImguiNextColumnFirstItem();
         if (!wineVersion.empty()){
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_secondary);
             HUDElements.TextColored(HUDElements.colors.wine, "%s", wineVersion.c_str());
             ImGui::PopFont();
         }
@@ -861,7 +865,7 @@ void HudElements::frame_timing(){
             gpus = std::make_unique<GPUS>(HUDElements.params);
 
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
             ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
             HUDElements.TextColored(HUDElements.colors.engine, "%s", "Frametime");
@@ -1002,9 +1006,15 @@ void HudElements::resolution(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_resolution]){
         ImguiNextColumnFirstItem();
         const auto res  = ImGui::GetIO().DisplaySize;
-        ImGui::PushFont(HUDElements.sw_stats->font1);
-        HUDElements.TextColored(HUDElements.colors.engine, "Resolution");
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
+        const char * title = "Resolution";
+        HUDElements.TextColored(HUDElements.colors.engine, title);
         ImguiNextColumnOrNewRow();
+
+        // Jump a column if title is overflowing
+        if (ImGuiTextOverflow(title))
+            ImguiNextColumnOrNewRow();
+
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width * 1.3, "%.0fx%.0f", res.x, res.y);
         ImGui::PopFont();
     }
@@ -1016,9 +1026,11 @@ void HudElements::show_fps_limit(){
         if (fps_limit_stats.targetFrameTime.count())
             fps = 1000000000 / fps_limit_stats.targetFrameTime.count();
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         const char* method = fps_limit_stats.method == FPS_LIMIT_METHOD_EARLY ? "early" : "late";
-        HUDElements.TextColored(HUDElements.colors.engine, "%s (%s)","FPS limit",method);
+        HUDElements.TextColored(HUDElements.colors.engine, "%s","FPS limit");
+        ImguiNextColumnOrNewRow();
+        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", method);
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", fps);
         ImGui::PopFont();
@@ -1029,12 +1041,12 @@ void HudElements::custom_text_center(){
     if (HUDElements.place >= 0 &&
         static_cast<size_t>(HUDElements.place) < HUDElements.ordered_functions.size()) {
 
-        if (!HUDElements.sw_stats || !HUDElements.sw_stats->font1) {
+        if (!HUDElements.sw_stats || !HUDElements.sw_stats->font_secondary) {
             return;
         }
 
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
 
         const std::string& value = HUDElements.ordered_functions[HUDElements.place].value;
 
@@ -1048,7 +1060,7 @@ void HudElements::custom_text_center(){
 
 void HudElements::custom_text(){
     ImguiNextColumnFirstItem();
-    ImGui::PushFont(HUDElements.sw_stats->font1);
+    ImGui::PushFont(HUDElements.sw_stats->font_secondary);
     const char* value;
     if (size_t(HUDElements.place) < HUDElements.ordered_functions.size())
         value = HUDElements.ordered_functions[HUDElements.place].value.c_str();
@@ -1062,7 +1074,7 @@ void HudElements::custom_text(){
 
 void HudElements::_exec(){
     //const std::string& value = HUDElements.ordered_functions[HUDElements.place].second;
-    ImGui::PushFont(HUDElements.sw_stats->font1);
+    ImGui::PushFont(HUDElements.sw_stats->font_secondary);
     ImguiNextColumnFirstItem();
     for (auto& item : HUDElements.exec_list){
         if (item.pos == HUDElements.place){
@@ -1078,7 +1090,7 @@ void HudElements::_exec(){
 void HudElements::gamemode(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gamemode]){
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "GAMEMODE");
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", HUDElements.gamemode_bol ? "ON" : "OFF");
@@ -1089,7 +1101,7 @@ void HudElements::gamemode(){
 void HudElements::vkbasalt(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vkbasalt]){
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "VKBASALT");
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", HUDElements.vkbasalt_bol ? "ON" : "OFF");
@@ -1136,7 +1148,7 @@ void HudElements::battery(){
                     else
                         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", Battery_Stats.current_watt);
                     ImGui::SameLine(0,1.0f);
-                    ImGui::PushFont(HUDElements.sw_stats->font1);
+                    ImGui::PushFont(HUDElements.sw_stats->font_small);
                     HUDElements.TextColored(HUDElements.colors.text, "W");
                     ImGui::PopFont();
                 }
@@ -1151,7 +1163,7 @@ void HudElements::battery(){
                     if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
                         ImGui::TableNextRow();
                         ImGui::NextColumn();
-                        ImGui::PushFont(HUDElements.sw_stats->font1);
+                        ImGui::PushFont(HUDElements.sw_stats->font_small);
                         ImGuiTableSetColumnIndex(0);
                         HUDElements.TextColored(HUDElements.colors.text, "%s", "Remaining Time");
                         ImGui::PopFont();
@@ -1198,7 +1210,7 @@ void HudElements::gamescope_fsr(){
                 ImguiNextColumnOrNewRow();
                 right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", HUDElements.g_fsrSharpness);
                 ImGui::SameLine(0,1.0f);
-                ImGui::PushFont(HUDElements.sw_stats->font1);
+                ImGui::PushFont(HUDElements.sw_stats->font_small);
                 HUDElements.TextColored(HUDElements.colors.text, "Sharp");
                 ImGui::PopFont();
             }
@@ -1217,7 +1229,7 @@ void HudElements::gamescope_frame_timing(){
             auto max = std::max_element(HUDElements.gamescope_debug_app.begin(),
                                         HUDElements.gamescope_debug_app.end());
 
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
             HUDElements.TextColored(HUDElements.colors.engine, "%s", "App");
             ImGui::TableSetColumnIndex(ImGui::TableGetColumnCount() - 1);
@@ -1243,7 +1255,7 @@ void HudElements::gamescope_frame_timing(){
         if (HUDElements.gamescope_debug_latency.size() > 0 && HUDElements.gamescope_debug_latency.back() > -1){
             ImguiNextColumnOrNewRow();
             ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
-            ImGui::PushFont(HUDElements.sw_stats->font1);
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.engine, "%s", "Latency");
             ImGui::TableNextRow();
             ImGui::Dummy(ImVec2(0.0f, real_font_size.y));
@@ -1282,7 +1294,7 @@ void HudElements::device_battery()
                 bool charging = device_data[i].is_charging;
 
                 ImguiNextColumnFirstItem();
-                ImGui::PushFont(HUDElements.sw_stats->font1);
+                ImGui::PushFont(HUDElements.sw_stats->font_secondary);
                 HUDElements.TextColored(HUDElements.colors.engine, "%s", name.c_str());
                 ImguiNextColumnOrNewRow();
                 if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_device_battery_icon]) {
@@ -1328,7 +1340,7 @@ void HudElements::device_battery()
 void HudElements::frame_count(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_frame_count]){
         ImguiNextColumnFirstItem();
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         HUDElements.TextColored(HUDElements.colors.engine, "Frame Count");
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%" PRIu64, HUDElements.sw_stats->n_frames);
@@ -1343,7 +1355,7 @@ void HudElements::fan(){
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text,HUDElements.ralign_width, "%i", fan_speed);
         ImGui::SameLine(0, 1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "RPM");
         ImGui::PopFont();
     }
@@ -1376,7 +1388,7 @@ void HudElements::throttling_status(){
 }
 
 void HudElements::duration(){
-    ImGui::PushFont(HUDElements.sw_stats->font1);
+    ImGui::PushFont(HUDElements.sw_stats->font_secondary);
     ImguiNextColumnFirstItem();
     HUDElements.TextColored(HUDElements.colors.engine, "%s", "Duration");
     ImguiNextColumnOrNewRow();
@@ -1401,7 +1413,7 @@ void HudElements::graphs(){
     assert(kMaxGraphEntries >= graph_data.size());
     std::vector<float> arr(kMaxGraphEntries - graph_data.size());
 
-    ImGui::PushFont(HUDElements.sw_stats->font1);
+    ImGui::PushFont(HUDElements.sw_stats->font_small);
     if (value == "cpu_load"){
         for (auto& it : graph_data){
             arr.push_back(float(it.cpu_load));
@@ -1516,7 +1528,7 @@ void HudElements::graphs(){
 
 void HudElements::exec_name(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_exec_name]){
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         ImguiNextColumnFirstItem();
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "Exe name");
         ImguiNextColumnOrNewRow();
@@ -1533,7 +1545,7 @@ void HudElements::fps_metrics(){
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.0f", metric.value);
         ImGui::SameLine(0, 1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "FPS");
         ImGui::PopFont();
         ImguiNextColumnOrNewRow();
@@ -1552,7 +1564,7 @@ void HudElements::hdr() {
 
 void HudElements::refresh_rate() {
     if (HUDElements.refresh > 0) {
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         ImguiNextColumnFirstItem();
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "Display Hz");
         ImguiNextColumnOrNewRow();
@@ -1566,7 +1578,7 @@ void HudElements::winesync() {
         HUDElements.winesync_ptr = std::make_unique<WineSync>();
 
     if (HUDElements.winesync_ptr->valid()) {
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         ImguiNextColumnFirstItem();
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "WSYNC");
         ImguiNextColumnOrNewRow();
@@ -1577,12 +1589,21 @@ void HudElements::winesync() {
 
 void HudElements::present_mode() {
     ImguiNextColumnFirstItem();
-    ImGui::PushFont(HUDElements.sw_stats->font1);
+    ImGui::PushFont(HUDElements.sw_stats->font_secondary);
+    const char* title;
+
     if (HUDElements.is_vulkan)
-        HUDElements.TextColored(HUDElements.colors.engine, "%s", "Present Mode");
+        title = "Present Mode";
     else
-        HUDElements.TextColored(HUDElements.colors.engine, "%s", "VSYNC");
+        title = "VSYNC";
+
+    HUDElements.TextColored(HUDElements.colors.engine, "%s", title);
     ImguiNextColumnOrNewRow();
+
+    // Jump a column if title is overflowing
+    if (ImGuiTextOverflow(title))
+        ImguiNextColumnOrNewRow();
+
     HUDElements.TextColored(HUDElements.colors.text, "%s\n", HUDElements.get_present_mode().c_str());
     ImGui::PopFont();
 }
@@ -1601,13 +1622,13 @@ void HudElements::network() {
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.0f", iface.txBps / 1000.f);
         ImGui::SameLine(0,1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "KB/s %s", ICON_FK_ARROW_UP);
         ImGui::PopFont();
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.0f", iface.rxBps / 1000.f);
         ImGui::SameLine(0,1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "KB/s %s", ICON_FK_ARROW_DOWN);
         ImGui::PopFont();
     }
@@ -1615,10 +1636,17 @@ void HudElements::network() {
 }
 
 void HudElements::_display_session() {
-    ImGui::PushFont(HUDElements.sw_stats->font1);
+    ImGui::PushFont(HUDElements.sw_stats->font_secondary);
     ImguiNextColumnFirstItem();
-    HUDElements.TextColored(HUDElements.colors.engine, "%s", "Display server");
+
+    const char* title = "Displat server";
+    HUDElements.TextColored(HUDElements.colors.engine, "%s", title);
     ImguiNextColumnOrNewRow();
+
+    // Jump a column if title is overflowing
+    if (ImGuiTextOverflow(title))
+        ImguiNextColumnOrNewRow();
+
     static std::map<display_servers, std::string> servers {
         {WAYLAND, {"WAYLAND"}},
         {XWAYLAND, {"XWAYLAND"}},
@@ -1635,7 +1663,7 @@ void HudElements::fex_stats()
         return;
     }
 
-    ImGui::PushFont(HUDElements.sw_stats->font1);
+    ImGui::PushFont(HUDElements.sw_stats->font_small);
 
     if (HUDElements.params->fex_stats.status) {
         ImguiNextColumnFirstItem();
@@ -1708,7 +1736,7 @@ void HudElements::fex_stats()
             }
         }
 
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "FEX JIT top loaded threads");
         ImGui::PopFont();
 
@@ -1725,7 +1753,7 @@ void HudElements::fex_stats()
     }
 
     if (HUDElements.params->fex_stats.jit_load) {
-        ImGui::PushFont(HUDElements.sw_stats->font1);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "FEX JIT Load");
         ImGui::PopFont();
 

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -28,8 +28,9 @@ struct swapchain_stats {
    struct frame_stat stats_min, stats_max;
    struct frame_stat frames_stats[200];
 
-   ImFont* font1 = nullptr;
+   ImFont* font_small = nullptr;
    ImFont* font_text = nullptr;
+   ImFont* font_secondary = nullptr;
    size_t font_params_hash = 0;
    std::string time;
    double fps;
@@ -106,7 +107,7 @@ void check_keybinds(overlay_params& params);
 void init_system_info(void);
 void check_for_vkbasalt_and_gamemode();
 void FpsLimiter(struct fps_limit& stats);
-void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*& small_font, ImFont*& text_font);
+void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*& small_font, ImFont*& text_font, ImFont*& secondary_font);
 void right_aligned_text(ImVec4& col, float off_x, const char *fmt, ...);
 void center_text(const std::string& text);
 ImVec4 change_on_load_temp(LOAD_DATA& data, unsigned current);

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -476,6 +476,7 @@ parse_fex_stats(const char *str) {
 #define parse_fps_text(s) parse_str(s)
 #define parse_log_interval(s) parse_unsigned(s)
 #define parse_font_size(s) parse_float(s)
+#define parse_font_size_secondary(s) parse_float(s)
 #define parse_font_size_text(s) parse_float(s)
 #define parse_font_scale(s) parse_float(s)
 #define parse_background_alpha(s) parse_float(s)
@@ -975,12 +976,18 @@ parse_overlay_config(struct overlay_params *params,
          params->width += 7 * params->font_size * params->font_scale;
    }
 
+   // If secondary font size not set, compute it from main font_size
+   if (!params->font_size_secondary)
+      params->font_size_secondary = params->font_size * 0.55f;
+
    params->font_params_hash = get_hash(params->font_size,
                                  params->font_size_text,
                                  params->no_small_font,
                                  params->font_file,
                                  params->font_file_text,
-                                 params->font_glyph_ranges
+                                 params->font_glyph_ranges,
+                                 params->font_scale,
+                                 params->font_size_secondary
                                 );
 
    // set frametime limit

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -129,6 +129,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(no_small_font)               \
    OVERLAY_PARAM_CUSTOM(font_size)                   \
    OVERLAY_PARAM_CUSTOM(font_size_text)              \
+   OVERLAY_PARAM_CUSTOM(font_size_secondary)         \
    OVERLAY_PARAM_CUSTOM(font_scale)                  \
    OVERLAY_PARAM_CUSTOM(font_scale_media_player)     \
    OVERLAY_PARAM_CUSTOM(position)                    \
@@ -293,7 +294,7 @@ struct overlay_params {
    unsigned table_columns;
    bool no_small_font;
    float font_size, font_scale;
-   float font_size_text;
+   float font_size_text, font_size_secondary;
    float font_scale_media_player;
    float background_alpha, alpha;
    float cellpadding_y;

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -719,7 +719,7 @@ static void check_fonts(struct swapchain_data* data)
    {
       SPDLOG_DEBUG("Recreating font image");
       VkDescriptorSet desc_set = (VkDescriptorSet)data->font_atlas->TexID;
-      create_fonts(data->font_atlas, instance_data->params, data->sw_stats.font1, data->sw_stats.font_text);
+      create_fonts(data->font_atlas, instance_data->params, data->sw_stats.font_small, data->sw_stats.font_text, data->sw_stats.font_secondary);
       unsigned char* pixels;
       int width, height;
       data->font_atlas->GetTexDataAsAlpha8(&pixels, &width, &height);


### PR DESCRIPTION
Creates a font_size_secondary parameter to allow to chose font size for the "less important" metrics like resolution, present mode, device battery...

Those metrics were displayed with the same small font than the units, which can become very small as the main font size goes down.

If font_size_secondary isn't supplied, it is computed as `0.55 * font_size` which is the same ratio applied to the existing small font.