### PR TITLE
overlay_params: add additional known handhelds to exclusion list

### DIFF
--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -1210,14 +1210,18 @@ void presets(int preset, struct overlay_params *params, bool inherit) {
          if (!gpus)
             gpus = std::make_unique<GPUS>(params);
          
-         // Disable some options if steamdeck
+         // Disable some options if steamdeck / other known handhelds
          for (auto gpu : gpus->available_gpus) {
-            if (gpu->device_id == 0x1435 || gpu->device_id == 0x163f){
+            if (gpu->device_id == 0x1435 || gpu->device_id == 0x163f || gpu->device_id == 0x1681 || gpu->device_id == 0x15bf){
                add_to_options(params, "gpu_fan", "0");
                add_to_options(params, "gpu_junction_temp", "0");
                add_to_options(params, "gpu_voltage", "0");
                add_to_options(params, "gpu_mem_temp", "0");
                add_to_options(params, "gpu_efficiency", "0");
+            }
+            // Rembrandt and Phoenix APUs (Z1, Z1E, Z2 Go)
+            if (gpu->device_id == 0x1681 || gpu->device_id == 0x15bf){
+               add_to_options(params, "gpu_power_limit", "0");
             }
          }
 


### PR DESCRIPTION
Cleans up case 4 (full) on known handhelds like the Legion Go S, Legion Go, and ROG Ally.

| Before | After |
|--------|--------|
|![go-s-full-unpatched-20250511123452](https://github.com/user-attachments/assets/ac09e64f-7613-49f9-a39e-13e236cdec57)|![go-s-full-patched-20250511123620](https://github.com/user-attachments/assets/7ddb7b67-85a4-4c54-98a8-e3b4e66770ba)|
|![go-full-unpatched-20250511123946](https://github.com/user-attachments/assets/e5958b87-a28f-450f-8c0a-fc0299419688)|![go-full-patched-20250511124011](https://github.com/user-attachments/assets/dbfa391a-33bf-4170-8469-ba455e6275e8)|

I removed `gpu_power_limit` since it didn't seem to be working on Rembrandt or Phoenix, but that could possibly be a bug. Not sure.