### PR TITLE
amdgpu: implement the invalid TEMP_HOTSPOT throttling workaround for RDNA 3 dGPU & some fixes

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -81,12 +81,9 @@ void AMDGPU::get_instant_metrics(struct amdgpu_common_metrics *metrics) {
 		metrics->fan_speed = amdgpu_metrics->current_fan_speed;
 
 		indep_throttle_status = amdgpu_metrics->indep_throttle_status;
-		bool temp_hotspot_flag = ((indep_throttle_status >> TEMP_HOTSPOT_BIT) & 1) == 1;
-		// ThrottlingPercentage for TEMP_HOTSPOT on RDNA 3 dGPU is almost always greater then or equal to 1.
-		// So the AMDGPU driver set the TEMP_HOTSPOT bit even in idle state.
-		if (temp_hotspot_flag && amdgpu_metrics->temperature_hotspot < 90) {
-			indep_throttle_status &= ~(1ull << TEMP_HOTSPOT_BIT);
-		}
+		// RDNA 3 almost always shows the TEMP_HOTSPOT throtting flag,
+		// so clear that bit
+		indep_throttle_status &= ~(1ull << TEMP_HOTSPOT_BIT);
 	} else if (header->format_revision == 2) {
 		// APUs
 		struct gpu_metrics_v2_3 *amdgpu_metrics = (struct gpu_metrics_v2_3 *) buf;

--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -155,7 +155,8 @@ void AMDGPU::get_instant_metrics(struct amdgpu_common_metrics *metrics) {
 			metrics->current_uclk_mhz = 0;
 		}
 
-		indep_throttle_status = amdgpu_metrics->indep_throttle_status;
+		if(header->content_revision >= 2)
+			indep_throttle_status = amdgpu_metrics->indep_throttle_status;
 	}
 
 	/* Throttling: See

--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -66,7 +66,7 @@ void AMDGPU::get_instant_metrics(struct amdgpu_common_metrics *metrics) {
 	}
 	fclose(f);
 
-	int64_t indep_throttle_status = 0;
+	uint64_t indep_throttle_status = 0;
 	if (header->format_revision == 1) {
 		// Desktop GPUs
 		struct gpu_metrics_v1_3 *amdgpu_metrics = (struct gpu_metrics_v1_3 *) buf;

--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -18,6 +18,7 @@
 #endif
 
 #define NUM_HBM_INSTANCES 4
+#define TEMP_HOTSPOT_BIT 36ull
 #define UPDATE_METRIC_AVERAGE(FIELD) do { int value_sum = 0; for (size_t s=0; s < METRICS_SAMPLE_COUNT; s++) { value_sum += metrics_buffer[s].FIELD; } amdgpu_common_metrics.FIELD = value_sum / METRICS_SAMPLE_COUNT; } while(0)
 #define UPDATE_METRIC_AVERAGE_FLOAT(FIELD) do { float value_sum = 0; for (size_t s=0; s < METRICS_SAMPLE_COUNT; s++) { value_sum += metrics_buffer[s].FIELD; } amdgpu_common_metrics.FIELD = value_sum / METRICS_SAMPLE_COUNT; } while(0)
 #define UPDATE_METRIC_MAX(FIELD) do { int cur_max = metrics_buffer[0].FIELD; for (size_t s=1; s < METRICS_SAMPLE_COUNT; s++) { cur_max = MAX(cur_max, metrics_buffer[s].FIELD); }; amdgpu_common_metrics.FIELD = cur_max; } while(0)


### PR DESCRIPTION
RDNA 3 dGPU will show invalid TEMP_HOTSPOT throttling, but as it is unlikely to be fixed on the driver side at this time, we will implement a workaround.  

<https://gitlab.freedesktop.org/drm/amd/-/issues/3251#note_2904104>

This PR also includes fixes for minor issues found during the work.  

#1243