### PR TITLE
blacklist: remove wine-preloader (improve WoW64 support)

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -62,7 +62,6 @@ static  std::vector<std::string> blacklist {
     "UplayWebCore.exe",
     "vrcompositor",
     "vulkandriverquery",
-    "wine-preloader",
 };
 
 static bool check_blacklisted() {


### PR DESCRIPTION
## Workaround for some games in WoW64 mode.

The `wine64-preloader` was un-blacklisted on 50989b7, but it's now named just `wine-preloader` on WoW64 mode (`PROTON_USE_WOW64=1` in Proton 10+). 

- Fixes #1695

Here's it working on Mass Effect Legendary Edition:

![1328670_20250524150948_1](https://github.com/user-attachments/assets/726f3d6c-3e12-4ecf-b6d6-b25dd18ed9c2)
