### PR TITLE
GPUS: Ensure gpu is not null

### DIFF
--- a/src/gpu.h
+++ b/src/gpu.h
@@ -190,7 +190,7 @@ class GPUS {
 
             if (!params->pci_dev.empty()) {
                 for (auto &gpu : available_gpus) {
-                    if (gpu->pci_dev == params->pci_dev) {
+                    if (gpu && gpu->pci_dev == params->pci_dev) {
                         vec.push_back(gpu);
                         return vec;
                     }


### PR DESCRIPTION
fixes constant exception spam in logs when using winewayland, which makes the game refuse to boot.