### PR TITLE
shim: Capture dlerror from at start of dlsym to restore later

### DIFF
--- a/src/real_dlsym.h
+++ b/src/real_dlsym.h
@@ -10,6 +10,7 @@ extern "C" {
 void *real_dlopen(const char *filename, int flag);
 void* real_dlsym( void*, const char* );
 void* get_proc_address(const char* name);
+char* real_dlerror(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
If `real_dlsym(handle, name)` succeded but earlier dlsym on eglStreamPostD3DTextureANGLE failed it
will create non conforming behaviour due dlsym won't clear the error message.

An example of real issue is Minecraft lost audio when MangoHud is used due OpenAL's perfectly
conformance usage like below

```cpp
    dlerror();
    auto *sym = dlsym(handle, name);
    // Obviously OpenAL only loads audio libraries so eglStreamPostD3DTextureANGLE obviously fails
    // and erronously sets error message even if 'name' exists
    if(auto *err = dlerror(); err != nullptr)
        sym = nullptr;
    return sym;
```
Quoted from https://github.com/kcat/openal-soft/blob/7f56dcdfbce02bea96894c688d48be574a55a41d/common/dynload.cpp#L38-L45
and added comment

This is perfectly valid as first call clear the error message, then perform dlsym. If it succeded
error message won't be set but not be cleared either. The standard only describes that error will be
set if there is any error not if there successes.

Therefore MangoHud indirectly/directly through dlsym breaks OpenAL and other dlsym users which follows
similar pattern assumption.

~~Side notes:
There is still conformance issue when there was an error before hook is called but may be
overwritten by dlsym for eglStreamPostD3DTextureANGLE but it is ignored for now due then
need a way to set dlerror message to restore the erorr message but I haven't found example
that new problem causing issues.~~ (fixed this)

dlerror reference: https://pubs.opengroup.org/onlinepubs/009604299/functions/dlerror.html