### PR TITLE
refactor gpu detection

### DIFF
--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -346,7 +346,7 @@ int GPU_fdinfo::get_gpu_load()
 {
     if (module == "xe")
         return get_xe_load();
-    else if (module == "kgsl")
+    else if (module == "msm_drm")
         return get_kgsl_load();
 
     uint64_t now = os_time_get_nano();
@@ -705,7 +705,7 @@ void GPU_fdinfo::main_thread()
         metrics.CoreClock = get_gpu_clock();
         metrics.voltage = hwmon_sensors["voltage"].val;
 
-        if (module == "kgsl")
+        if (module == "msm_drm")
             metrics.temp = get_kgsl_temp();
         else
             metrics.temp = hwmon_sensors["temp"].val / 1000.f;

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -142,14 +142,14 @@ public:
         } else if (module == "amdgpu") {
             drm_engine_type = "drm-engine-gfx";
             drm_memory_type = "drm-memory-vram";
-        } else if (module == "msm") {
+        } else if (module == "msm_dpu") {
             // msm driver does not report vram usage
             drm_engine_type = "drm-engine-gpu";
+        } else if (module == "msm_drm") {
+            init_kgsl();
         } else if (module == "panfrost") {
             drm_engine_type = "drm-engine-fragment";
             drm_memory_type = "drm-resident-memory";
-        } else if (module == "kgsl") {
-            init_kgsl();
         }
 
         if (fdinfo_data.size() > 0 &&


### PR DESCRIPTION
Also fixes #1693

I'm suggesting to not rely on vendor id anymore since we know vendor by querying driver name. Device id is still needed because it is used in amdgpu.cpp to distinguish steam deck.

For example, different mali gpus all have different vendor ids:

Example 1 (https://github.com/Oblomov/clinfo/issues/46):
```
Number of devices                                 1
  Device Name                                     Mali-G71
  Device Vendor                                   ARM
  Device Vendor ID                                0x60a00002
```

Example 2 (https://github.com/termux/termux-packages/issues/13821):
```
Number of devices                                 1
  Device Name                                     Mali-G610 MC6 r0p0
  Device Vendor                                   ARM
  Device Vendor ID                                0xa8670000
```

Example 3 (https://magazine.odroid.com/article/clinfo-compiling-the-essential-opencl-gpu-tuning-utility-for-the-odroid-xu4/):
```
Number of devices 2
Device Name Mali-T628
Device Vendor ARM
Device Vendor ID 0x6200010
```