### PR TITLE
wayland: improve keybinds

### DIFF
--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -17,15 +17,23 @@ typedef unsigned long KeySym;
 #if defined(HAVE_X11) || defined(HAVE_WAYLAND)
 static inline bool keys_are_pressed(const std::vector<KeySym>& keys)
 {
+    if (keys.size() == 0)
+        return false;
+
     #if defined(HAVE_WAYLAND)
     if(wl_display_ptr && wl_handle)
     {
         update_wl_queue();
 
-        if(wl_pressed_keys == keys)
-        {
-            return true;
+        if (wl_pressed_keys.size() != keys.size())
+            return false;
+
+        for (KeySym ks : keys) {
+            if (wl_pressed_keys.count(ks) == 0)
+                return false;
         }
+
+        return true;
     }
     #endif
 
@@ -47,7 +55,7 @@ static inline bool keys_are_pressed(const std::vector<KeySym>& keys)
                 pressed++;
         }
 
-        if (pressed > 0 && pressed == keys.size()) {
+        if (pressed == keys.size()) {
             return true;
         }
     }

--- a/src/wayland_hook.h
+++ b/src/wayland_hook.h
@@ -1,4 +1,5 @@
 #include <wayland-client.h>
+#include <set>
 #include <vector>
 
 #ifndef KeySym
@@ -7,7 +8,7 @@ typedef unsigned long KeySym;
 
 extern void* wl_handle;
 extern struct wl_display* wl_display_ptr;
-extern std::vector<KeySym> wl_pressed_keys;
+extern std::set<KeySym> wl_pressed_keys;
 
 void init_wayland_data();
 void update_wl_queue();

--- a/src/wayland_keybinds.cpp
+++ b/src/wayland_keybinds.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <array>
 #include <algorithm>
+#include <set>
 #include <unistd.h>
 #include <vector>
 #include <wayland-client.h>
@@ -19,7 +20,7 @@ struct xkb_context *context_xkb = nullptr;
 struct xkb_keymap *keymap_xkb = nullptr;
 struct xkb_state *state_xkb = nullptr;
 struct wl_event_queue* queue = nullptr;
-std::vector<KeySym> wl_pressed_keys {};
+std::set<KeySym> wl_pressed_keys {};
 
 static void seat_handle_capabilities(void *data, wl_seat *seat, uint32_t caps);
 static void seat_handle_name(void *data, struct wl_seat *seat, const char *name) {}
@@ -77,13 +78,11 @@ static void wl_keyboard_key(void *data, struct wl_keyboard *wl_keyboard, uint32_
 
    if(state)
    {
-      wl_pressed_keys.push_back(keysym);
+      wl_pressed_keys.insert(keysym);
    }
    else
    {
-      auto it = std::find(wl_pressed_keys.begin(), wl_pressed_keys.end(), keysym);
-      if(it != wl_pressed_keys.end())
-         wl_pressed_keys.erase(it);
+      wl_pressed_keys.erase(keysym);
    }
 }
 


### PR DESCRIPTION
Keybinds on Wayland are now unordered and do not trigger on empty keybinds. This more closely emulates the behavior on X. To preserve performance, it requires `wl_pressed_keys` to use `std::set` rather than `std::vector`.

I was having some difficulty testing this on NixOS. I think I figured it out, but it should probably receive some more testing before being merged.