### PR TITLE
ftrace: add support

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `present_mode`                     | Shows current vulkan [present mode](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPresentModeKHR.html) or vsync status in opengl  |
 | `network`                          | Show network interfaces tx and rx kb/s. You can specify interface with `network=eth0` |
 | `fex_stats`                        | Show FEX-Emu statistics. Default = `status+apptype+hotthreads+jitload+sigbus+smc+softfloat` |
+| `ftrace`                           | Display information about trace events reported through ftrace                        |
 
 Example: `MANGOHUD_CONFIG=cpu_temp,gpu_temp,position=top-right,height=500,font_size=32`
 Because comma is also used as option delimiter and needs to be escaped for values with a backslash, you can use `+` like `MANGOHUD_CONFIG=fps_limit=60+30+0` instead.

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -342,6 +342,24 @@ text_outline
 ## example: mangohud-%p
 # control = -1
 
+### ftrace tracepoint display
+## Enable display of tracepoint information gathered from ftrace. MangoHud will parse
+## out the necessary data from the ftrace pipe, ftrace itself still has to be configured
+## manually (enabling the desired event, applying any filtering etc.). The user running
+## MangoHud will require permission to access the default-mounted tracefs (expected at
+## /sys/kernel/tracing/).
+##
+## When parsing ftrace output, currently only the `key=value` format for event fields is
+## expected. This is the most common format used in events, but it's not standardized.
+##
+## Three types of display are available:
+## - `histogram/drm_vblank_event`, a histogram of event occurrence
+## - `linegraph/devfreq_monitor/freq`, a line graph of an event field's numerical value
+## - `label/devfreq_frequency/dev_name`, a textual presentation of an event field's value
+##
+## The displays are set through the `ftrace` option. Multiple displays can be specified.
+# ftrace=histogram/drm_vblank_event+linegraph/devfreq_monitor/freq
+
 ################ WORKAROUNDS #################
 ### Options starting with "gl_*" are for OpenGL
 ### Specify what to use for getting display size. Options are "viewport", "scissorbox" or disabled. Defaults to using glXQueryDrawable

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,10 @@ if ['linux', 'cygwin', 'gnu'].contains(host_machine.system())
   is_unixy = true
 endif
 
+if host_machine.system() == 'linux'
+  pre_args += '-DHAVE_FTRACE'
+endif
+
 if get_option('glibcxx_asserts')
   pre_args += '-D_GLIBCXX_ASSERTIONS'
 endif

--- a/src/ftrace.cpp
+++ b/src/ftrace.cpp
@@ -1,0 +1,253 @@
+#include "ftrace.h"
+
+#ifdef HAVE_FTRACE
+
+#include <algorithm>
+#include <climits>
+#include <fcntl.h>
+#include <poll.h>
+#include <unistd.h>
+#include "mesa/util/macros.h"
+#include "string_utils.h"
+
+namespace FTrace {
+
+FTrace::FTrace(const overlay_params::ftrace_options& options) {
+   assert(options.enabled);
+
+   trace_pipe_fd = open("/sys/kernel/tracing/trace_pipe", O_RDONLY | O_NONBLOCK);
+   if (trace_pipe_fd == -1) {
+       SPDLOG_ERROR("could not open ftrace pipe: {}", strerror(errno));
+       return;
+   }
+
+   thread = std::thread(&FTrace::ftrace_thread, this);
+   pthread_setname_np(thread.native_handle(), "mangohud-ftrace");
+
+   for (auto& tp : options.tracepoints) {
+      data.tracepoints.push_back(tp);
+      collection.map.emplace(tp, Tracepoint::CollectionValue { });
+
+      switch (tp->type) {
+      case TracepointType::Histogram:
+         SPDLOG_DEBUG("ftrace: will collect tracepoint '{}' for histogram display",
+                      tp->name);
+         break;
+      case TracepointType::LineGraph:
+         SPDLOG_DEBUG("ftrace: will collect tracepoint '{}' (parameter '{}') for line graph display",
+                      tp->name, tp->field_name);
+         break;
+      case TracepointType::Label:
+         SPDLOG_DEBUG("ftrace: will collect tracepoint '{}' (parameter '{}') for label display",
+                      tp->name, tp->field_name);
+         break;
+      default:
+         SPDLOG_ERROR("ftrace: unknown tracepoint type for tracepoint '{}'",
+                      tp->name);
+      }
+   }
+}
+
+FTrace::~FTrace()
+{
+    stop_thread = true;
+    if (thread.joinable())
+        thread.join();
+
+    if (trace_pipe_fd != -1)
+        close(trace_pipe_fd);
+}
+
+void FTrace::ftrace_thread()
+{
+    struct {
+        std::array<char, 4096> data;
+        unsigned size { 0 };
+    } buffer;
+
+    while (!stop_thread) {
+        struct pollfd fd = {
+            .fd = trace_pipe_fd,
+            .events = POLLIN,
+            .revents = 0,
+        };
+        int ret = poll(&fd, 1, 500);
+        if (ret < 0) {
+            SPDLOG_ERROR("FTrace: polling on trace_pipe failed: {}", strerror(errno));
+            break;
+        }
+
+        if (!(fd.revents & POLLIN))
+            continue;
+
+        ssize_t size_read = read(trace_pipe_fd, &buffer.data[buffer.size], buffer.data.size() - buffer.size);
+        if (size_read < 0) {
+            SPDLOG_ERROR("FTrace: reading from trace_pipe failed: {}", strerror(errno));
+            break;
+        }
+        buffer.size += unsigned(size_read);
+
+        {
+            char *it = buffer.data.begin();
+            char *end_it = std::next(it, buffer.size);
+
+            while (std::distance(it, end_it)) {
+                char *newline_it = std::find(it, end_it, '\n');
+                if (newline_it == end_it)
+                    break;
+
+                handle_ftrace_entry(std::string { it, size_t(std::distance(it, newline_it)) });
+                it = std::next(newline_it, 1);
+            }
+
+            buffer.size = std::distance(it, end_it);
+            if (buffer.size)
+                std::move(it, end_it, buffer.data.begin());
+        }
+    }
+}
+
+static std::string get_field_value(std::string fields_str, std::string target_field_name)
+{
+   // Parsing print-formatted ftrace entries isn't ideal because there's no standardized
+   // way of reporting trace event fields. ftrace will also print out numerical values
+   // in both decimal and hexadecimal. It's still the simplest approach as otherwise we'd
+   // have to wrangle with raw trace data that we don't have access to, and trace event
+   // field formats that are hard to define and apply.
+
+   // Most common print format is `field=value`, with `value` possibly containing spaces.
+   // Iteration below accounts for that and returns the field value for the desired name,
+   // if present.
+
+   auto fields_data = str_tokenize(fields_str, " ");
+   for (auto it = fields_data.begin(); it != fields_data.end();) {
+      auto assign_pos = it->find('=');
+      if (assign_pos == std::string::npos) {
+         ++it;
+         continue;
+      }
+
+      auto field_name = it->substr(0, assign_pos);
+      auto field_value = it->substr(std::min(it->size(), assign_pos + 1));
+
+      ++it;
+      while (it != fields_data.end()) {
+         if (it->find('=') != std::string::npos)
+            break;
+
+         field_value += " " + *it;
+         ++it;
+      }
+
+      if (field_name == target_field_name)
+         return field_value;
+   }
+
+   return { };
+}
+
+void FTrace::handle_ftrace_entry(std::string entry)
+{
+   std::unique_lock<std::mutex> lock(collection.mutex);
+
+   for (auto& collection_entry : collection.map) {
+      auto& tp = collection_entry.first;
+
+      // Search for the tracepoint name in the entry. It's expected either
+      // at the beginning of string or with a space before it.
+      auto name_pos = entry.find(tp->name + ":");
+      if (name_pos == std::string::npos)
+         continue;
+      if (!(name_pos == 0 || (name_pos > 0 && entry[name_pos - 1] == ' ')))
+         continue;
+
+      // Remainder of entry is field data. We use it as necessary,
+      // depending on the tracepoint type.
+      auto fields_str = entry.substr(name_pos + tp->name.size() + 1);
+
+      switch (tp->type) {
+      case TracepointType::Histogram:
+         collection_entry.second.f += 1;
+         break;
+      case TracepointType::LineGraph:
+      {
+         auto field_value = get_field_value(fields_str, tp->field_name);
+         if (!field_value.empty()) {
+            char *value_end;
+            uint64_t value = strtoull(field_value.c_str(), &value_end, 16);
+
+            if (value != ULLONG_MAX)
+               collection_entry.second.f += (float) value;
+         }
+        break;
+      }
+      case TracepointType::Label:
+      {
+         auto field_value = get_field_value(fields_str, tp->field_name);
+         if (!field_value.empty())
+            collection_entry.second.field_value = field_value;
+         break;
+      }
+      default:
+         unreachable("invalid tracepoint type");
+      }
+   }
+}
+
+void FTrace::update()
+{
+   auto update_index = ++data.update_index % Tracepoint::PLOT_DATA_CAPACITY;
+   for (auto& tp : data.tracepoints) {
+      tp->update_index = update_index;
+
+      // Iterate over the stored plot values often enough to keep
+      // the data range updated and plot presentation visually useful.
+      if (!(update_index % (Tracepoint::PLOT_DATA_CAPACITY / 4))) {
+         auto max = tp->data.plot.values[0];
+         for (auto v : tp->data.plot.values)
+            max = std::max(max, v);
+
+         tp->data.plot.range = { 0, max };
+      }
+   }
+
+   std::unique_lock<std::mutex> lock(collection.mutex);
+
+   for (auto& it : collection.map) {
+      auto& tp = it.first;
+      auto& value = it.second;
+
+      switch (tp->type) {
+      case TracepointType::Histogram:
+      case TracepointType::LineGraph:
+      {
+         tp->data.plot.values[tp->update_index] = value.f;
+         auto max = std::max(tp->data.plot.range.max, value.f);
+         tp->data.plot.range = { 0, max };
+         break;
+      }
+      case TracepointType::Label:
+      {
+         if (!value.field_value.empty())
+            tp->data.field_value = value.field_value;
+         break;
+      }
+      default:
+         unreachable("invalid tracepoint type");
+      }
+
+      value = { };
+   }
+}
+
+float FTrace::get_plot_values(void *data, int index)
+{
+   const Tracepoint& tp = *((const Tracepoint *) data);
+   return tp.data.plot.values[(index + tp.update_index + 1) % Tracepoint::PLOT_DATA_CAPACITY];
+}
+
+std::unique_ptr<FTrace> object = nullptr;
+
+} // namespace FTrace
+
+#endif // HAVE_FTRACE

--- a/src/ftrace.h
+++ b/src/ftrace.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#ifdef HAVE_FTRACE
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <thread>
+#include <unordered_map>
+
+#include <spdlog/spdlog.h>
+
+#include "overlay_params.h"
+
+namespace FTrace {
+
+enum class TracepointType {
+    Histogram,
+    LineGraph,
+    Label,
+};
+
+struct Tracepoint {
+    uint32_t update_index { 0 };
+    std::string name;
+    TracepointType type;
+    std::string field_name;
+
+    static constexpr unsigned PLOT_DATA_CAPACITY = 256;
+
+    struct CollectionValue {
+        float f { 0 };
+        std::string field_value;
+    };
+
+    struct {
+        struct {
+            std::array<float, PLOT_DATA_CAPACITY> values;
+            struct {
+                float min { 0 };
+                float max { 0 };
+            } range;
+        } plot;
+        std::string field_value;
+    } data;
+};
+
+class FTrace {
+private:
+    int trace_pipe_fd { -1 };
+
+    std::thread thread;
+    std::atomic<bool> stop_thread { false };
+
+    void ftrace_thread();
+    void handle_ftrace_entry(std::string entry);
+
+    struct {
+        std::mutex mutex;
+        std::unordered_map<std::shared_ptr<Tracepoint>, Tracepoint::CollectionValue> map;
+    } collection;
+
+    struct {
+        std::vector<std::shared_ptr<Tracepoint>> tracepoints;
+        uint32_t update_index { 0 };
+    } data;
+
+public:
+    FTrace(const overlay_params::ftrace_options& options);
+    ~FTrace();
+
+    void update();
+
+    const std::vector<std::shared_ptr<Tracepoint>>& tracepoints() { return data.tracepoints; }
+
+    static float get_plot_values(void *data, int index);
+};
+
+extern std::unique_ptr<FTrace> object;
+
+} // namespace FTrace
+
+#endif // HAVE_FTRACE

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -119,6 +119,7 @@ class HudElements{
         static void network();
         static void _display_session();
         static void fex_stats();
+        static void ftrace();
 
         void convert_colors(const struct overlay_params& params);
         void convert_colors(bool do_conv, const struct overlay_params& params);

--- a/src/meson.build
+++ b/src/meson.build
@@ -94,6 +94,7 @@ if is_unixy
     'device.cpp',
     'net.cpp',
     'shell.cpp',
+    'ftrace.cpp',
   )
 
   if get_option('with_fex')

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -26,6 +26,7 @@
 #include "fps_metrics.h"
 #include "net.h"
 #include "fex.h"
+#include "ftrace.h"
 
 #ifdef __linux__
 #include <libgen.h>
@@ -255,6 +256,13 @@ void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, const stru
 #endif
 #ifdef HAVE_FEX
    fex::update_fex_stats();
+#endif
+#ifdef HAVE_FTRACE
+   if (params.ftrace.enabled) {
+      if (!FTrace::object)
+         FTrace::object = std::make_unique<FTrace::FTrace>(params.ftrace);
+      FTrace::object->update();
+   }
 #endif
    frametime = frametime_ms;
    fps = double(1000 / frametime_ms);

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -21,6 +21,12 @@ extern "C" {
 typedef unsigned long KeySym;
 #endif
 
+#ifdef HAVE_FTRACE
+namespace FTrace {
+struct Tracepoint;
+}
+#endif
+
 #define RGBGetBValue(rgb)   (rgb & 0x000000FF)
 #define RGBGetGValue(rgb)   ((rgb >> 8) & 0x000000FF)
 #define RGBGetRValue(rgb)   ((rgb >> 16) & 0x000000FF)
@@ -207,6 +213,7 @@ typedef unsigned long KeySym;
    OVERLAY_PARAM_CUSTOM(network)                     \
    OVERLAY_PARAM_CUSTOM(gpu_list)                    \
    OVERLAY_PARAM_CUSTOM(fex_stats)                   \
+   OVERLAY_PARAM_CUSTOM(ftrace)                      \
 
 enum overlay_param_position {
    LAYER_POSITION_TOP_LEFT,
@@ -353,6 +360,14 @@ struct overlay_params {
       bool softfloat_counts {true};
    };
    fex_stats_options fex_stats{};
+
+   struct ftrace_options {
+      bool enabled {false};
+#ifdef HAVE_FTRACE
+      std::vector<std::shared_ptr<FTrace::Tracepoint>> tracepoints;
+#endif
+   };
+   ftrace_options ftrace {};
 };
 
 const extern char *overlay_param_names[];


### PR DESCRIPTION
Add the ability to display information gathered from ftrace events using the 'ftrace' option. Currently this information can be displayed in three ways:
- histograms, displaying the number of occurrences of a given event. Example: 'histogram/drm_vblank_event'
- line graphs, plotting value of a given event parameter. Example: 'linegraph/devfreq_monitor/freq' will plot the value of the renderpasses parameter as reported through the devfreq_monitor event.
- labels, simply displaying the value of a given tracepoint parameter. Example: 'label/devfreq_frequency/dev_name'

More than one point of information can be displayed by combining them in the 'ftrace' option:
  ftrace=histogram/start_cmd_buffer+label/start_cmd_buffer/IR3debugFlags

Usage of this feature has certain conditions and limitations:
- tracefs has to be mounted so that the user running MangoHud has the necessary permissions to access ftrace interface,
- ftrace still has to be configured manually, e.g. the observed events have to be enabled, can be filtered etc.,
- only one instance of MangoHud can parse and display these events because only one consumer can read from tracefs' trace_pipe,
- current parsing logic depends on fields to be formatted in the `key=value` fashion, which isn't standardized but is most common formatting choice.