### PR TITLE
Fix proc_vram for nvidia when built with system nvml.h released somewhere during version 535 

### DIFF
--- a/src/loaders/loader_nvml.h
+++ b/src/loaders/loader_nvml.h
@@ -8,6 +8,7 @@
 #include <nvml.h>
 #else
 #include "nvml.h"
+typedef nvmlProcessInfo_t nvmlProcessInfo_v1_t;
 #endif
 #define LIBRARY_LOADER_NVML_H_DLOPEN
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -121,6 +121,7 @@ if is_unixy
 
   if nvml_h_found
     pre_args += '-DHAVE_NVML'
+    pre_args += '-DNVML_NO_UNVERSIONED_FUNC_DEFS'
     vklayer_files += files(
       'loaders/loader_nvml.cpp',
     )

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -29,14 +29,14 @@ void NVIDIA::parse_token(std::string token, std::unordered_map<std::string, std:
 NVIDIA::NVIDIA(const char* pciBusId) {
 #ifdef HAVE_NVML
     if (nvml && nvml->IsLoaded()) {
-        nvmlReturn_t result = nvml->nvmlInit();
+        nvmlReturn_t result = nvml->nvmlInit_v2();
         if (NVML_SUCCESS != result) {
             SPDLOG_ERROR("Nvidia module initialization failed: {}", nvml->nvmlErrorString(result));
             nvml_available = false;
         } else {
             nvml_available = true; // NVML initialized successfully
             if (pciBusId) {
-                result = nvml->nvmlDeviceGetHandleByPciBusId(pciBusId, &device);
+                result = nvml->nvmlDeviceGetHandleByPciBusId_v2(pciBusId, &device);
                 if (NVML_SUCCESS != result) {
                     SPDLOG_ERROR("Getting device handle by PCI bus ID failed: {}", nvml->nvmlErrorString(result));
                     nvml_available = false; // Revert if getting device handle fails

--- a/src/nvidia.h
+++ b/src/nvidia.h
@@ -36,13 +36,13 @@ class NVIDIA {
 
             unsigned int infoCount = 0;
 
-            nvmlProcessInfo_t* cur_process_info = new nvmlProcessInfo_t[infoCount];
+            nvmlProcessInfo_v1_t* cur_process_info = new nvmlProcessInfo_v1_t[infoCount];
             nvmlReturn_t ret = nvml->nvmlDeviceGetGraphicsRunningProcesses(device, &infoCount, cur_process_info);
 
             if (ret != NVML_ERROR_INSUFFICIENT_SIZE)
                 return;
 
-            cur_process_info = new nvmlProcessInfo_t[infoCount];
+            cur_process_info = new nvmlProcessInfo_v1_t[infoCount];
             ret = nvml->nvmlDeviceGetGraphicsRunningProcesses(device, &infoCount, cur_process_info);
 
             if (ret != NVML_SUCCESS)
@@ -101,7 +101,7 @@ class NVIDIA {
 #ifdef HAVE_NVML
         nvmlDevice_t device;
 
-        nvmlProcessInfo_t* process_info = nullptr;
+        nvmlProcessInfo_v1_t* process_info = nullptr;
         size_t process_info_len = 0;
 
         void get_instant_metrics_nvml(struct gpu_metrics *metrics);


### PR DESCRIPTION
https://forums.developer.nvidia.com/t/nvml-12-535-43-02-breaks-backwards-compatibility/254999/2

After this update nvml.h redirects `nvmlDeviceGetGraphicsRunningProcesses` to `nvmlDeviceGetGraphicsRunningProcesses_v3` which uses different struct and it breaks `proc_vram`

using `#define NVML_NO_UNVERSIONED_FUNC_DEFS` fixes this by letting us to choose appropriate function version

When compiled with built-in nvml.h:
```
[MANGOHUD] [info] [nvidia.h:52] pid=1240   mem=137388032
[MANGOHUD] [info] [nvidia.h:52] pid=1978   mem=31051776
[MANGOHUD] [info] [nvidia.h:52] pid=2131   mem=2330624
[MANGOHUD] [info] [nvidia.h:52] pid=2375   mem=1626112
[MANGOHUD] [info] [nvidia.h:52] pid=10989  mem=81055744
[MANGOHUD] [info] [nvidia.h:52] pid=140778 mem=42651648
[MANGOHUD] [info] [nvidia.h:52] pid=226692 mem=7708672
[MANGOHUD] [info] [nvidia.h:52] pid=249323 mem=3559424
```

When compiled without patch with system nvml.h:

```
[MANGOHUD] [info] [nvidia.h:52] pid=1240 mem=126902272
[MANGOHUD] [info] [nvidia.h:52] pid=34459648 mem=2131
[MANGOHUD] [info] [nvidia.h:52] pid=2375 mem=1626112
[MANGOHUD] [info] [nvidia.h:52] pid=76468224 mem=140778
[MANGOHUD] [info] [nvidia.h:52] pid=226692 mem=7708672
[MANGOHUD] [info] [nvidia.h:52] pid=0 mem=0
[MANGOHUD] [info] [nvidia.h:52] pid=0 mem=0
```

When compiled with patch with system nvml.h:
```
[MANGOHUD] [info] [nvidia.h:52] pid=1240 mem=148922368
[MANGOHUD] [info] [nvidia.h:52] pid=1978 mem=49795072
[MANGOHUD] [info] [nvidia.h:52] pid=2131 mem=2330624
[MANGOHUD] [info] [nvidia.h:52] pid=2375 mem=1626112
[MANGOHUD] [info] [nvidia.h:52] pid=10989 mem=50581504
[MANGOHUD] [info] [nvidia.h:52] pid=140778 mem=41537536
[MANGOHUD] [info] [nvidia.h:52] pid=226692 mem=7708672
[MANGOHUD] [info] [nvidia.h:52] pid=257210 mem=6709248
```

Also fixed memory leak in `nvml_get_process_info()`