### PR TITLE
vulkan: Implement conversions for HDR10 and extended SRGB colorspaces.

### DIFF
--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -258,6 +258,16 @@ enum overlay_param_enabled {
    OVERLAY_PARAM_ENABLED_MAX
 };
 
+/* avoid importing vulkan headers
+ * also combine colorspaces that use the same transfer function
+ */
+enum overlay_transfer_function {
+   NONE = 0,
+   SRGB = (1 << 0),
+   PQ = (1 << 1), /* HDR10 ST2084 */
+   HLG = (1 << 2) /* HDR10 */
+};
+
 struct overlay_params {
    bool enabled[OVERLAY_PARAM_ENABLED_MAX];
    enum overlay_param_position position;
@@ -335,6 +345,7 @@ struct overlay_params {
    std::vector<std::string> fps_metrics;
    std::vector<std::string> network;
    std::vector<unsigned> gpu_list;
+   int transfer_function;
 
    struct fex_stats_options {
       bool enabled {false};

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1263,51 +1263,68 @@ static void setup_swapchain_data_pipeline(struct swapchain_data *data)
 //      update_image_descriptor(data, data->font_image_view[0], data->descriptor_set);
 }
 
-// TODO probably needs colorspace check too
-static void convert_colors_vk(VkFormat format, struct swapchain_stats& sw_stats, struct overlay_params& params)
+static void convert_colors_vk(VkFormat format, VkColorSpaceKHR colorspace, struct swapchain_stats& sw_stats, struct overlay_params& params)
 {
-   bool do_conv = false;
-   switch (format) {
-      case VK_FORMAT_R8_SRGB:
-      case VK_FORMAT_R8G8_SRGB:
-      case VK_FORMAT_R8G8B8_SRGB:
-      case VK_FORMAT_B8G8R8_SRGB:
-      case VK_FORMAT_R8G8B8A8_SRGB:
-      case VK_FORMAT_B8G8R8A8_SRGB:
-      case VK_FORMAT_A8B8G8R8_SRGB_PACK32:
-      case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
-      case VK_FORMAT_BC1_RGBA_SRGB_BLOCK:
-      case VK_FORMAT_BC2_SRGB_BLOCK:
-      case VK_FORMAT_BC3_SRGB_BLOCK:
-      case VK_FORMAT_BC7_SRGB_BLOCK:
-      case VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
-      case VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
-      case VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_4x4_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_5x4_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_5x5_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_6x5_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_6x6_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_8x5_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_8x6_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_8x8_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_10x5_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_10x6_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_10x8_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_10x10_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_12x10_SRGB_BLOCK:
-      case VK_FORMAT_ASTC_12x12_SRGB_BLOCK:
-      case VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG:
-      case VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG:
-      case VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG:
-      case VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG:
-         do_conv = true;
+   /* TODO: Support more colorspacess */
+   switch (colorspace) {
+      case VK_COLOR_SPACE_HDR10_ST2084_EXT:
+         params.transfer_function = PQ;
          break;
+      case VK_COLOR_SPACE_HDR10_HLG_EXT:
+         params.transfer_function = HLG;
+         break;
+      case VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT:
+         params.transfer_function = SRGB;
+         break;
+      /* use no conversion for rest of the colorspaces */
       default:
+         params.transfer_function = NONE;
          break;
    }
 
-   HUDElements.convert_colors(do_conv, params);
+   if (params.transfer_function == NONE)
+   {
+      switch (format) {
+         case VK_FORMAT_R8_SRGB:
+         case VK_FORMAT_R8G8_SRGB:
+         case VK_FORMAT_R8G8B8_SRGB:
+         case VK_FORMAT_B8G8R8_SRGB:
+         case VK_FORMAT_R8G8B8A8_SRGB:
+         case VK_FORMAT_B8G8R8A8_SRGB:
+         case VK_FORMAT_A8B8G8R8_SRGB_PACK32:
+         case VK_FORMAT_BC1_RGB_SRGB_BLOCK:
+         case VK_FORMAT_BC1_RGBA_SRGB_BLOCK:
+         case VK_FORMAT_BC2_SRGB_BLOCK:
+         case VK_FORMAT_BC3_SRGB_BLOCK:
+         case VK_FORMAT_BC7_SRGB_BLOCK:
+         case VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK:
+         case VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK:
+         case VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_4x4_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_5x4_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_5x5_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_6x5_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_6x6_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_8x5_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_8x6_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_8x8_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_10x5_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_10x6_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_10x8_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_10x10_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_12x10_SRGB_BLOCK:
+         case VK_FORMAT_ASTC_12x12_SRGB_BLOCK:
+         case VK_FORMAT_PVRTC1_2BPP_SRGB_BLOCK_IMG:
+         case VK_FORMAT_PVRTC1_4BPP_SRGB_BLOCK_IMG:
+         case VK_FORMAT_PVRTC2_2BPP_SRGB_BLOCK_IMG:
+         case VK_FORMAT_PVRTC2_4BPP_SRGB_BLOCK_IMG:
+            params.transfer_function = SRGB;
+            break;
+         default: break;
+      }
+   }
+
+   HUDElements.convert_colors(params.transfer_function != NONE, params);
 }
 
 static void setup_swapchain_data(struct swapchain_data *data,
@@ -1326,7 +1343,7 @@ static void setup_swapchain_data(struct swapchain_data *data,
 
    ImGui::GetIO().IniFilename = NULL;
    ImGui::GetIO().DisplaySize = ImVec2((float)data->width, (float)data->height);
-   convert_colors_vk(pCreateInfo->imageFormat, data->sw_stats, device_data->instance->params);
+   convert_colors_vk(pCreateInfo->imageFormat, pCreateInfo->imageColorSpace, data->sw_stats, device_data->instance->params);
 
    /* Render pass */
    VkAttachmentDescription attachment_desc = {};


### PR DESCRIPTION
~~Not a perfect implementation, in ST2084 colors are a bit saturated, but it's still a massive improvement over not tonemapping.~~ (fixed) The other commonly used format is linear extended SRGB, and that works by just using the SRGB transfer function unconditionally. (nonlinear extended srgb should already work as is) I haven't tested the HLG tonemapping, but that should probably work as well. 

By tone mapping I mean the opposite of tone mapping since we are taking SRGB colors and then converting them into their appropriate color space. 