### PR TITLE
Fix GTK blacklist

### DIFF
--- a/src/blacklist.cpp
+++ b/src/blacklist.cpp
@@ -10,6 +10,7 @@
 
 namespace fs = ghc::filesystem;
 std::string global_proc_name;
+std::string global_engine_name;
 
 static std::string get_proc_name() {
    // Note: It is possible to use GNU program_invocation_short_name.
@@ -65,17 +66,16 @@ static  std::vector<std::string> blacklist {
     "vulkandriverquery",
 };
 
+static std::vector<std::string> blacklist_engine {
+    "GTK"
+};
+
 static bool check_blacklisted() {
     std::string proc_name = get_proc_name();
+    std::string engine_name = global_engine_name;
     global_proc_name = proc_name;
     bool blacklisted = std::find(blacklist.begin(), blacklist.end(), proc_name) != blacklist.end();
-
-#ifdef __linux__
-    // if the app isn't blacklisted, check if the app uses GTK and blacklist anyway
-    // unless we're using proton
-    if (!blacklisted)
-        blacklisted = lib_loaded("gtk") && !lib_loaded("proton");
-#endif
+    blacklisted |= std::find(blacklist_engine.begin(), blacklist_engine.end(), engine_name) != blacklist_engine.end();
 
     static bool printed = false;
     if(blacklisted && !printed) {

--- a/src/blacklist.h
+++ b/src/blacklist.h
@@ -5,5 +5,6 @@
 bool is_blacklisted(bool force_recheck = false);
 void add_blacklist(const std::string& proc);
 extern std::string global_proc_name;
+extern std::string global_engine_name;
 
 #endif //MANGOHUD_BLACKLIST_H

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1883,14 +1883,17 @@ static VkResult overlay_CreateInstance(
    VkLayerInstanceCreateInfo *chain_info =
       get_instance_chain_info(pCreateInfo, VK_LAYER_LINK_INFO);
 
-   std::string engineVersion,engineName;
+   std::string engineVersion, engineName;
    enum EngineTypes engine = EngineTypes::UNKNOWN;
+   const char* pEngineName = nullptr;
+   if (pCreateInfo->pApplicationInfo)
+      pEngineName = pCreateInfo->pApplicationInfo->pEngineName;
+   if (pEngineName)
+   {
+      engineName = pEngineName;
+      global_engine_name = engineName;
+   }
    if (!is_blacklisted(true)) {
-      const char* pEngineName = nullptr;
-      if (pCreateInfo->pApplicationInfo)
-         pEngineName = pCreateInfo->pApplicationInfo->pEngineName;
-      if (pEngineName)
-         engineName = pEngineName;
       if (engineName == "DXVK" || engineName == "vkd3d") {
          int engineVer = pCreateInfo->pApplicationInfo->engineVersion;
          engineVersion = to_string(VK_VERSION_MAJOR(engineVer)) + "." + to_string(VK_VERSION_MINOR(engineVer)) + "." + to_string(VK_VERSION_PATCH(engineVer));


### PR DESCRIPTION
This should fix globally enabled mangohud with GTK 4 applications. It would be nice if this could get tested as I currently have no way of testing this tho. 

Source for engine name: https://github.com/GNOME/gtk/blob/13d6c41fc56e2cfa754a85eb0116efd3db22a284/gdk/gdkvulkancontext.c#L1817C37-L1817C48