### PR TITLE
Minor fix for display_server in hud_elements.cpp

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1743,13 +1743,9 @@ void HudElements::_display_session() {
     ImGui::PushFont(HUDElements.sw_stats->font_secondary);
     ImguiNextColumnFirstItem();
 
-    const char* title = "Displat server";
+    const char* title = "Display Server";
     HUDElements.TextColored(HUDElements.colors.engine, "%s", title);
     ImguiNextColumnOrNewRow();
-
-    // Jump a column if title is overflowing
-    if (ImGuiTextOverflow(title))
-        ImguiNextColumnOrNewRow();
 
     static std::map<display_servers, std::string> servers {
         {WAYLAND, {"WAYLAND"}},


### PR DESCRIPTION
Before commit 9658717
![image-01](https://github.com/user-attachments/assets/5021ae9d-089b-4ff3-a86a-8a6a78b4bab9)

After commit 9658717
![image](https://github.com/user-attachments/assets/0241fe4f-4647-4559-879b-6db5fb5ce3f8)

With this merge request
![image](https://github.com/user-attachments/assets/1024d286-34c9-4171-9486-72d15b73fce4)

Just corrected the grammar mistake and removed these lines, which fixes it.

https://github.com/flightlessmango/MangoHud/blob/663801328b40af64decaa6b3a72fec07c7753175/src/hud_elements.cpp#L1750-L1752

Don't really know if it breaks anything else. Seems to be fine.