### PR TITLE
Reallow X11 keybind fallback

### DIFF
--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -25,15 +25,11 @@ static inline bool keys_are_pressed(const std::vector<KeySym>& keys)
     {
         update_wl_queue();
 
-        if (wl_pressed_keys.size() != keys.size())
-            return false;
-
-        for (KeySym ks : keys) {
-            if (wl_pressed_keys.count(ks) == 0)
-                return false;
+        if (std::all_of(std::begin(keys), std::end(keys), [&](const auto& key) {
+                return wl_pressed_keys.count(key) != 0;
+        })) {
+                return true;
         }
-
-        return true;
     }
     #endif
 


### PR DESCRIPTION
A refactor to the wayland input system in #1705 inverted some logic and didn't allow a fallthrough when keys were not detected by wayland but could still be detected by X11.

Fixes #1743

