### PR TITLE
independent fps_superscript and engine_names hiding

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -816,14 +816,14 @@ void HudElements::fps(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fps] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fps_only]){
         ImguiNextColumnFirstItem();
         if (HUDElements.params->fps_text.empty()){
-            if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact] || HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal])
-                if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_engine_short_names])
-                    HUDElements.TextColored(HUDElements.colors.engine, "%s", engines_short[HUDElements.sw_stats->engine]);
-                else
+            if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_engine_short_names])
+                if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hide_engine_names])
                     HUDElements.TextColored(HUDElements.colors.engine, "%s", "FPS");
-            else
-                if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_engine_short_names])
+                else
                     HUDElements.TextColored(HUDElements.colors.engine, "%s", engines_short[HUDElements.sw_stats->engine]);
+            else
+                if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hide_engine_names])
+                    HUDElements.TextColored(HUDElements.colors.engine, "%s", "FPS");
                 else
                     HUDElements.TextColored(HUDElements.colors.engine, "%s", engines[HUDElements.sw_stats->engine]);
         } else {
@@ -847,7 +847,7 @@ void HudElements::fps(){
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.0f", HUDElements.sw_stats->fps);
         }
         ImGui::SameLine(0, 1.0f);
-        if(!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal]){
+        if(!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hide_fps_superscript]){
             ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "FPS");
             ImGui::PopFont();

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -703,6 +703,8 @@ set_parameters_from_options(struct overlay_params *params)
       params->enabled[OVERLAY_PARAM_ENABLED_retro] = 0;
       params->enabled[OVERLAY_PARAM_ENABLED_debug] = 0;
       params->enabled[OVERLAY_PARAM_ENABLED_engine_short_names] = 0;
+      params->enabled[OVERLAY_PARAM_ENABLED_hide_engine_names] = 0;
+      params->enabled[OVERLAY_PARAM_ENABLED_hide_fps_superscript] = 0;
       params->enabled[OVERLAY_PARAM_ENABLED_dynamic_frame_timing] = 0;
       params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit] = 0;
       params->enabled[OVERLAY_PARAM_ENABLED_duration] = false;
@@ -814,6 +816,8 @@ static void set_param_defaults(struct overlay_params *params){
    params->enabled[OVERLAY_PARAM_ENABLED_fcat] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_horizontal_stretch] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_engine_short_names] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_hide_engine_names] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_hide_fps_superscript] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_text_outline] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_dynamic_frame_timing] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit] = false;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -111,6 +111,8 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(gpu_fan)                       \
    OVERLAY_PARAM_BOOL(gpu_voltage)                   \
    OVERLAY_PARAM_BOOL(engine_short_names)            \
+   OVERLAY_PARAM_BOOL(hide_engine_names)             \
+   OVERLAY_PARAM_BOOL(hide_fps_superscript)          \
    OVERLAY_PARAM_BOOL(text_outline)                  \
    OVERLAY_PARAM_BOOL(temp_fahrenheit)               \
    OVERLAY_PARAM_BOOL(dynamic_frame_timing)          \


### PR DESCRIPTION
Closes https://github.com/flightlessmango/MangoHud/issues/1045

Implemented two new parameters: `hide_fps_superscript` and `hide_engine_names`. 
Engine name and fps superscript appearance are no longer dependent on `hud_compact` and `horizontal` parameters.

This allows for these previously impossible configurations:
- Vertical non-compact with no engine name and no superscript
<img width="575" height="201" alt="Screenshot From 2025-07-11 04-06-39" src="https://github.com/user-attachments/assets/c6a0abf6-71bd-497a-b3ee-ab4ac06718e3" />  

- Horizontal compact with FPS superscript
<img width="809" height="72" alt="Screenshot From 2025-07-11 04-08-09" src="https://github.com/user-attachments/assets/d10f88ec-b679-4dc2-898a-c0198a72a80d" />

- Horizontal compact short name with FPS superscript
<img width="782" height="72" alt="Screenshot From 2025-07-11 04-07-42" src="https://github.com/user-attachments/assets/94c99385-6115-42f1-a263-475cf6c3c416" />  


Obviously all previous configurations can also be achieved by setting these parameters accordingly.