### PR TITLE
Improve wayland display tracking

### DIFF
--- a/src/gl/gl.h
+++ b/src/gl/gl.h
@@ -27,6 +27,7 @@ unsigned int eglSwapBuffers( void*, void* );
 void* eglGetPlatformDisplay( unsigned int, void*, const intptr_t* );
 void* eglGetDisplay( void* );
 void* eglGetProcAddress( const char* );
+int eglTerminate( void* );
 
 #ifdef __cplusplus
 }

--- a/src/gl/shim.c
+++ b/src/gl/shim.c
@@ -161,6 +161,7 @@ CREATE_FWD(void*, eglGetPlatformDisplay,
      platform, native_display, attrib_list)
 CREATE_FWD(unsigned int, eglSwapBuffers, (void* dpy, void* surf), dpy, surf)
 CREATE_FWD(void*, eglGetProcAddress, (const char* procName), procName)
+CREATE_FWD(int, eglTerminate, (void *display), display)
 
 #undef CREATE_FWD
 #undef CREATE_FWD_VOID
@@ -181,7 +182,8 @@ static struct func_ptr hooks[] = {
     ADD_HOOK(eglSwapBuffers),
     ADD_HOOK(eglGetPlatformDisplay),
     ADD_HOOK(eglGetDisplay),
-    ADD_HOOK(eglGetProcAddress)
+    ADD_HOOK(eglGetProcAddress),
+    ADD_HOOK(eglTerminate)
 };
 #undef ADD_HOOK
 

--- a/src/keybinds.cpp
+++ b/src/keybinds.cpp
@@ -9,28 +9,22 @@
 #include "keybinds.h"
 #include "fps_metrics.h"
 
-Clock::time_point last_f2_press, toggle_fps_limit_press, toggle_preset_press, last_f12_press, reload_cfg_press, last_upload_press;
+bool prev_toggle_logging = false;
+bool prev_toggle_fps_limit = false;
+bool prev_toggle_preset = false;
+bool prev_toggle_hud = false;
+bool prev_reload_cfg = false;
+bool prev_upload_log = false;
+bool prev_upload_logs = false;
+bool prev_toggle_hud_position = false;
+bool prev_reset_fps_metrics = false;
 
 void check_keybinds(struct overlay_params& params){
    using namespace std::chrono_literals;
-   auto now = Clock::now(); /* us */
-   auto elapsedF2 = now - last_f2_press;
-   auto elapsedFpsLimitToggle = now - toggle_fps_limit_press;
-   auto elapsedPresetToggle = now - toggle_preset_press;
-   auto elapsedF12 = now - last_f12_press;
-   auto elapsedReloadCfg = now - reload_cfg_press;
-   auto elapsedUpload = now - last_upload_press;
 
-   static Clock::time_point last_check;
-   if (now - last_check < 100ms)
-      return;
-   last_check = now;
+   bool value;
 
-   const auto keyPressDelay = 400ms;
-
-   if (elapsedF2 >= keyPressDelay &&
-       keys_are_pressed(params.toggle_logging)) {
-      last_f2_press = now;
+   if ((value = keys_are_pressed(params.toggle_logging)) && value != prev_toggle_logging) {
       if (logger->is_active()) {
          logger->stop_logging();
       } else {
@@ -39,9 +33,9 @@ void check_keybinds(struct overlay_params& params){
       }
    }
 
-   if (elapsedFpsLimitToggle >= keyPressDelay &&
-       keys_are_pressed(params.toggle_fps_limit)) {
-      toggle_fps_limit_press = now;
+   prev_toggle_logging = value;
+
+   if ((value = keys_are_pressed(params.toggle_fps_limit)) && value != prev_toggle_fps_limit) {
       for (size_t i = 0; i < params.fps_limit.size(); i++){
          uint32_t fps_limit = params.fps_limit[i];
          // current fps limit equals vector entry, use next / first
@@ -58,9 +52,9 @@ void check_keybinds(struct overlay_params& params){
       }
    }
 
-   if (elapsedPresetToggle >= keyPressDelay &&
-       keys_are_pressed(params.toggle_preset)) {
-     toggle_preset_press = now;
+   prev_toggle_fps_limit = value;
+
+   if ((value = keys_are_pressed(params.toggle_preset)) && value != prev_toggle_preset) {
      size_t size = params.preset.size();
      for (size_t i = 0; i < size; i++){
        if(params.preset[i] == current_preset) {
@@ -71,41 +65,43 @@ void check_keybinds(struct overlay_params& params){
      }
    }
 
-   if (elapsedF12 >= keyPressDelay &&
-       keys_are_pressed(params.toggle_hud)) {
-      last_f12_press = now;
+   prev_toggle_preset = value;
+
+   if ((value = keys_are_pressed(params.toggle_hud)) && value != prev_toggle_hud) {
       params.no_display = !params.no_display;
    }
 
-   if (elapsedReloadCfg >= keyPressDelay &&
-       keys_are_pressed(params.reload_cfg)) {
+   prev_toggle_hud = value;
+
+   if ((value = keys_are_pressed(params.reload_cfg)) && value != prev_reload_cfg) {
       parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
       _params = &params;
-      reload_cfg_press = now;
    }
 
-   if (params.permit_upload && elapsedUpload >= keyPressDelay &&
-       keys_are_pressed(params.upload_log)) {
-      last_upload_press = now;
+   prev_reload_cfg = value;
+
+   if ((value = keys_are_pressed(params.upload_log)) && params.permit_upload && value != prev_upload_log) {
       logger->upload_last_log();
    }
 
-   if (params.permit_upload && elapsedUpload >= keyPressDelay &&
-       keys_are_pressed(params.upload_logs)) {
-      last_upload_press = now;
+   prev_upload_log = value;
+
+   if ((value = keys_are_pressed(params.upload_logs)) && params.permit_upload && value != prev_upload_logs) {
       logger->upload_last_logs();
    }
 
-   if (elapsedF12 >= keyPressDelay &&
-       keys_are_pressed(params.toggle_hud_position)) {
+   prev_upload_logs = value;
+
+   if ((value = keys_are_pressed(params.toggle_hud_position)) && value != prev_toggle_hud_position) {
       next_hud_position(params);
-      last_f12_press = now;
    }
 
-   if (elapsedF12 >= keyPressDelay &&
-       keys_are_pressed(params.reset_fps_metrics)) {
-      last_f12_press = now;
+   prev_toggle_hud_position = value;
+
+   if ((value = keys_are_pressed(params.reset_fps_metrics)) && value != prev_reset_fps_metrics) {
       if (fpsmetrics)
          fpsmetrics->reset_metrics();
    }
+
+   prev_reset_fps_metrics = value;
 }

--- a/src/keybinds.h
+++ b/src/keybinds.h
@@ -21,19 +21,12 @@ static inline bool keys_are_pressed(const std::vector<KeySym>& keys)
         return false;
 
     #if defined(HAVE_WAYLAND)
-    if(wl_display_ptr && wl_handle)
+    if (wl_handle)
     {
         update_wl_queue();
 
-        if (wl_pressed_keys.size() != keys.size())
-            return false;
-
-        for (KeySym ks : keys) {
-            if (wl_pressed_keys.count(ks) == 0)
-                return false;
-        }
-
-        return true;
+        if (wayland_has_keys_pressed(keys))
+           return true;
     }
     #endif
 

--- a/src/wayland_hook.h
+++ b/src/wayland_hook.h
@@ -7,8 +7,9 @@ typedef unsigned long KeySym;
 #endif
 
 extern void* wl_handle;
-extern struct wl_display* wl_display_ptr;
-extern std::set<KeySym> wl_pressed_keys;
 
-void init_wayland_data();
+bool has_wayland_display(struct wl_display *display);
+bool wayland_has_keys_pressed(const std::vector<KeySym>& keys);
+void init_wayland_data(struct wl_display *display, void *vk_surface);
+void wayland_data_unref(struct wl_display *display, void *vk_surface);
 void update_wl_queue();

--- a/src/wayland_keybinds.cpp
+++ b/src/wayland_keybinds.cpp
@@ -1,137 +1,287 @@
 #include <cstdint>
 #include <cstring>
-#include <array>
-#include <algorithm>
 #include <set>
 #include <unistd.h>
-#include <vector>
+#include <map>
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
 #include <sys/mman.h>
+#include <dlfcn.h>
+
 #include "wayland_hook.h"
-#include "timing.hpp"
+#include "real_dlsym.h"
 #include "keybinds.h"
 
-void* wl_handle = nullptr;
-struct wl_display* wl_display_ptr = nullptr;
-struct wl_seat* seat = nullptr;
-struct wl_keyboard* keyboard = nullptr;
-struct xkb_context *context_xkb = nullptr;
-struct xkb_keymap *keymap_xkb = nullptr;
-struct xkb_state *state_xkb = nullptr;
-struct wl_event_queue* queue = nullptr;
-std::set<KeySym> wl_pressed_keys {};
+void* wl_handle = NULL;
+struct xkb_context *context_xkb = NULL;
 
-static void seat_handle_capabilities(void *data, wl_seat *seat, uint32_t caps);
+struct wayland_display
+{
+    int ref;
+    struct wl_event_queue *queue;
+    struct wl_seat *seat;
+    struct wl_keyboard *keyboard;
+    struct xkb_keymap *keymap_xkb;
+    struct xkb_state *state_xkb;
+    std::set<void *> vk_surfaces;
+    std::set<KeySym> wl_pressed_keys;
+
+    wayland_display()
+    {
+        ref = 1;
+        queue = NULL;
+        keyboard = NULL;
+        keymap_xkb = NULL;
+        state_xkb = NULL;
+        seat = NULL;
+    }
+
+    ~wayland_display()
+    {
+        wl_pressed_keys.clear();
+        vk_surfaces.clear();
+        wl_seat_destroy(this->seat);
+        wl_keyboard_destroy(this->keyboard);
+        wl_event_queue_destroy(this->queue);
+        if (this->keymap_xkb)
+            xkb_keymap_unref(this->keymap_xkb);
+        if (this->state_xkb)
+            xkb_state_unref(this->state_xkb);
+    }
+};
+
+std::map<struct wl_display *, wayland_display> displays;
+
+// fixes wl_array_for_each with C++
+#ifdef wl_array_for_each
+#undef wl_array_for_each
+#define wl_array_for_each(pos, array)					\
+for (pos = (decltype(pos)) (array)->data;				\
+    (array)->size != 0 &&					\
+    (const char *) pos < ((const char *) (array)->data + (array)->size); \
+    (pos)++)
+#endif
+
+static void seat_handle_capabilities(void *data, struct wl_seat *seat, uint32_t caps);
 static void seat_handle_name(void *data, struct wl_seat *seat, const char *name) {}
 
 struct wl_seat_listener seat_listener {
-   .capabilities = seat_handle_capabilities,
-   .name = seat_handle_name,
+    .capabilities = seat_handle_capabilities,
+    .name = seat_handle_name,
 };
 
 static void registry_handle_global(void *data, struct wl_registry* registry, uint32_t name, const char *interface, uint32_t version)
 {
-   if(strcmp(interface, wl_seat_interface.name) == 0 && !seat)
-   {
-      seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, 5);
-      wl_seat_add_listener(seat, &seat_listener, NULL);
-   }
+    if (!data) return;
+    struct wayland_display *wayland = (wayland_display *)data;
+    if (strcmp(interface, wl_seat_interface.name) == 0 && !wayland->seat)
+    {
+        wayland->seat = (struct wl_seat*)wl_registry_bind(registry, name, &wl_seat_interface, version < 5 ? version : 5);
+        wl_seat_add_listener(wayland->seat, &seat_listener, data);
+    }
 }
 
 static void registry_handle_global_remove(void *data, struct wl_registry *registry, uint32_t name){}
 
 static void wl_keyboard_keymap(void *data, struct wl_keyboard *wl_keyboard, uint32_t format, int32_t fd, uint32_t size)
 {
-   char* map_shm = (char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+    wayland_display *wayland = (wayland_display *)data;
+    char* map_shm = (char*)mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
 
-   if(!context_xkb)
-      context_xkb = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!context_xkb)
+        context_xkb = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 
-   if(keymap_xkb && state_xkb)
-   {
-      xkb_keymap_unref(keymap_xkb);
-      xkb_state_unref(state_xkb);
-   }
+    if (wayland->keymap_xkb && wayland->state_xkb)
+    {
+        xkb_keymap_unref(wayland->keymap_xkb);
+        xkb_state_unref(wayland->state_xkb);
+        wayland->keymap_xkb = NULL;
+        wayland->state_xkb = NULL;
+    }
 
-   keymap_xkb = xkb_keymap_new_from_string(
-        context_xkb, map_shm, XKB_KEYMAP_FORMAT_TEXT_V1,
-        XKB_KEYMAP_COMPILE_NO_FLAGS);
+    wayland->keymap_xkb = xkb_keymap_new_from_string(
+            context_xkb, map_shm, XKB_KEYMAP_FORMAT_TEXT_V1,
+            XKB_KEYMAP_COMPILE_NO_FLAGS);
 
-   state_xkb = xkb_state_new(keymap_xkb);
+    wayland->state_xkb = xkb_state_new(wayland->keymap_xkb);
 
-   munmap((void*)map_shm, size);
-   close(fd);
+    munmap((void*)map_shm, size);
+    close(fd);
 }
 
-static void wl_keyboard_enter(void *user_data, struct wl_keyboard *wl_keyboard, uint32_t serial, struct wl_surface *surface, struct wl_array *keys){}
+static void wl_keyboard_enter(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, struct wl_surface *surface, struct wl_array *keys)
+{
+    if (!data) return;
+
+    wayland_display *wayland = (wayland_display *)data;
+
+    if (!wayland->state_xkb) return;
+
+    uint32_t *key;
+    wl_array_for_each(key, keys)
+    {
+        xkb_keycode_t keycode = *key + 8;
+        xkb_keysym_t keysym = xkb_state_key_get_one_sym(wayland->state_xkb, keycode);
+        wayland->wl_pressed_keys.insert(keysym);
+    }
+}
 
 static void wl_keyboard_leave(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, struct wl_surface *surface)
 {
-   wl_pressed_keys.clear();
+    wayland_display *wayland = (wayland_display *)data;
+    wayland->wl_pressed_keys.clear();
 }
 
 static void wl_keyboard_key(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, uint32_t time, uint32_t key, uint32_t state)
 {
-   xkb_keycode_t keycode = key + 8;
-   xkb_keysym_t keysym = xkb_state_key_get_one_sym(state_xkb, keycode);
+    if (!data) return;
 
-   if(state)
-   {
-      wl_pressed_keys.insert(keysym);
-   }
-   else
-   {
-      wl_pressed_keys.erase(keysym);
-   }
+    wayland_display *wayland = (wayland_display *)data;
+
+    if (!wayland->state_xkb) return;
+
+    xkb_keycode_t keycode = key + 8;
+    xkb_keysym_t keysym = xkb_state_key_get_one_sym(wayland->state_xkb, keycode);
+
+    if (state) wayland->wl_pressed_keys.insert(keysym);
+    else wayland->wl_pressed_keys.erase(keysym);
 }
 
-static void wl_keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, uint32_t mods_depressed, uint32_t mods_latched, uint32_t mods_locked, uint32_t group){}
+static void wl_keyboard_modifiers(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial,
+                                  uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group)
+{
+    if (!data) return;
+
+    wayland_display *wayland = (wayland_display *)data;
+
+    if (!wayland->state_xkb) return;
+
+    xkb_state_update_mask(wayland->state_xkb, depressed, latched, locked, 0, 0, group);
+}
 
 static void wl_keyboard_repeat_info(void *data, struct wl_keyboard *wl_keyboard, int32_t rate, int32_t delay){}
 
 struct wl_registry_listener registry_listener {
-   .global = registry_handle_global,
-   .global_remove = registry_handle_global_remove
+    .global = registry_handle_global,
+    .global_remove = registry_handle_global_remove
 };
 
 struct wl_keyboard_listener keyboard_listener {
-   .keymap = wl_keyboard_keymap,
-   .enter = wl_keyboard_enter,
-   .leave = wl_keyboard_leave,
-   .key = wl_keyboard_key,
-   .modifiers = wl_keyboard_modifiers,
-   .repeat_info = wl_keyboard_repeat_info
+    .keymap = wl_keyboard_keymap,
+    .enter = wl_keyboard_enter,
+    .leave = wl_keyboard_leave,
+    .key = wl_keyboard_key,
+    .modifiers = wl_keyboard_modifiers,
+    .repeat_info = wl_keyboard_repeat_info
 };
 
-static void seat_handle_capabilities(void *data, wl_seat *seat, uint32_t caps)
+static void seat_handle_capabilities(void *data, struct wl_seat *seat, uint32_t caps)
 {
-   if(caps & WL_SEAT_CAPABILITY_KEYBOARD)
-   {
-      if(!keyboard)
-      {
-         keyboard = wl_seat_get_keyboard(seat);
-         wl_keyboard_add_listener(keyboard, &keyboard_listener, NULL);
-      }
-   }
+    if (!data) return;
+    wayland_display *wayland = (wayland_display *)data;
+
+    if (caps & WL_SEAT_CAPABILITY_KEYBOARD)
+    {
+        if (!wayland->keyboard)
+        {
+            wayland->keyboard = wl_seat_get_keyboard(seat);
+            wl_keyboard_add_listener(wayland->keyboard, &keyboard_listener, data);
+        }
+    }
 }
 
 void update_wl_queue()
 {
-   wl_display_dispatch_queue_pending(wl_display_ptr, queue);
+    for (const auto& display : displays)
+        wl_display_dispatch_queue_pending(display.first, display.second.queue);
 }
 
-void init_wayland_data()
+// Track vk_surface for reference counting
+void init_wayland_data(struct wl_display *display, void *vk_surface)
 {
-   if (!wl_display_ptr)
-      return;
+    if (!display)
+        return;
 
-   queue = wl_display_create_queue(wl_display_ptr);
-   struct wl_display *display_wrapped = (struct wl_display*)wl_proxy_create_wrapper(wl_display_ptr);
-   wl_proxy_set_queue((struct wl_proxy*)display_wrapped, queue);
-   wl_registry *registry = wl_display_get_registry(display_wrapped);
-   wl_proxy_wrapper_destroy(display_wrapped);
-   wl_registry_add_listener(registry, &registry_listener, NULL);
-   wl_display_roundtrip_queue(wl_display_ptr, queue);
-   wl_display_roundtrip_queue(wl_display_ptr, queue);
+    if (!wl_handle)
+        wl_handle = real_dlopen("libwayland-client.so.0", RTLD_LAZY);
+
+    // failed to load
+    if (!wl_handle)
+        return;
+
+    // if we already have the display then just increase its reference count
+    // and add its vk_surface
+    if (has_wayland_display(display))
+    {
+        displays[display].ref++;
+        if (vk_surface)
+            displays[display].vk_surfaces.insert(vk_surface);
+        return;
+    }
+
+    // create a new element
+    displays[display].ref = 1;
+    displays[display].queue = wl_display_create_queue(display);
+    if (vk_surface)
+        displays[display].vk_surfaces.insert(vk_surface);
+    struct wl_display *display_wrapped = (struct wl_display*)wl_proxy_create_wrapper(display);
+    wl_proxy_set_queue((struct wl_proxy*)display_wrapped, displays[display].queue);
+    struct wl_registry *registry = wl_display_get_registry(display_wrapped);
+    wl_proxy_wrapper_destroy(display_wrapped);
+    wl_registry_add_listener(registry, &registry_listener, &displays[display]);
+    wl_display_roundtrip_queue(display, displays[display].queue);
+    wl_display_roundtrip_queue(display, displays[display].queue);
+    wl_registry_destroy(registry);
+}
+
+void wayland_data_unref(struct wl_display *display, void *vk_surface)
+{
+    if (has_wayland_display(display))
+    {
+        displays[display].ref--;
+    }
+    // use the VkSurface to remove reference count
+    else if (vk_surface)
+    {
+        for (auto& display : displays)
+        {
+            if (display.second.vk_surfaces.count(vk_surface))
+                display.second.ref--;
+        }
+    }
+
+    // clear out all displays with 0 ref count
+    for (auto it = displays.begin(); it != displays.end(); it++)
+    {
+        if (it->second.ref == 0)
+            it = displays.erase(it);
+
+        if (it == displays.end())
+            break;
+    }
+}
+
+bool has_wayland_display(struct wl_display *display)
+{
+    return displays.find(display) != displays.end();
+}
+
+bool wayland_has_keys_pressed(const std::vector<KeySym>& keys)
+{
+    std::map<struct wl_display *, size_t> counter;
+    for (const auto& display : displays)
+    {
+        for (const KeySym& k : keys)
+            if (display.second.wl_pressed_keys.count(k))
+                counter[display.first]++;
+    }
+
+    /* if any of the displays has count == keys.size
+        then it has all required keys pressed */
+    for (const auto& count : counter)
+    {
+        if (count.second == keys.size()) return true;
+    }
+
+    return false;
 }


### PR DESCRIPTION
- Adds support for multiple wl_display objects
- Refcounting wl_display objects to ensure that there aren't any left over when the process terminates
- Implement support for wl_keyboard::enter & wl_keyboard::modifiers event (because why not I guess)

~~I need to test the vulkan version~~ working fine, Doom eternal keybinds now working :)