### PR TITLE
Add decimal support for fps_limit

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1126,9 +1126,9 @@ void HudElements::resolution(){
 
 void HudElements::show_fps_limit(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_show_fps_limit]){
-        int fps = 0;
+        double fps = 0;
         if (fps_limit_stats.targetFrameTime.count())
-            fps = 1000000000 / fps_limit_stats.targetFrameTime.count();
+            fps = 1000000000. / fps_limit_stats.targetFrameTime.count();
         ImguiNextColumnFirstItem();
         ImGui::PushFont(HUDElements.sw_stats->font_secondary);
         const char* method = fps_limit_stats.method == FPS_LIMIT_METHOD_EARLY ? "early" : "late";
@@ -1136,7 +1136,7 @@ void HudElements::show_fps_limit(){
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", method);
         ImguiNextColumnOrNewRow();
-        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", fps);
+        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", fps);
         ImGui::PopFont();
     }
 }

--- a/src/keybinds.cpp
+++ b/src/keybinds.cpp
@@ -43,11 +43,11 @@ void check_keybinds(struct overlay_params& params){
        keys_are_pressed(params.toggle_fps_limit)) {
       toggle_fps_limit_press = now;
       for (size_t i = 0; i < params.fps_limit.size(); i++){
-         uint32_t fps_limit = params.fps_limit[i];
+         double fps_limit = params.fps_limit[i];
          // current fps limit equals vector entry, use next / first
          if((fps_limit > 0 && fps_limit_stats.targetFrameTime == std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(1) / params.fps_limit[i]))
                || (fps_limit == 0 && fps_limit_stats.targetFrameTime == fps_limit_stats.targetFrameTime.zero())) {
-            uint32_t newFpsLimit = i+1 == params.fps_limit.size() ? params.fps_limit[0] : params.fps_limit[i+1];
+            double newFpsLimit = i+1 == params.fps_limit.size() ? params.fps_limit[0] : params.fps_limit[i+1];
             if(newFpsLimit > 0) {
                fps_limit_stats.targetFrameTime = std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(1) / newFpsLimit);
             } else {

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -202,24 +202,29 @@ parse_fps_sampling_period(const char *str)
    return strtol(str, NULL, 0) * 1000000; /* ms to ns */
 }
 
-static std::vector<std::uint32_t>
+static std::vector<double>
 parse_fps_limit(const char *str)
 {
-   std::vector<std::uint32_t> fps_limit;
+   std::vector<double> fps_limit;
    auto fps_limit_strings = str_tokenize(str);
 
    for (auto& value : fps_limit_strings) {
       trim(value);
 
-      uint32_t as_int;
+      double as_double;
       try {
-         as_int = static_cast<uint32_t>(std::stoul(value));
+         as_double = static_cast<double>(std::stod(value));
       } catch (const std::invalid_argument&) {
          SPDLOG_ERROR("invalid fps_limit value: '{}'", value);
          continue;
       }
 
-      fps_limit.push_back(as_int);
+      if(as_double < 0){
+         SPDLOG_WARN("negative fps_limit value: '{}'", as_double);
+         continue;
+      }
+
+      fps_limit.push_back(as_double);
    }
 
    return fps_limit;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -282,7 +282,7 @@ struct overlay_params {
    enum overlay_param_position position;
    int control;
    uint32_t fps_sampling_period; /* ns */
-   std::vector<std::uint32_t> fps_limit;
+   std::vector<double> fps_limit;
    enum fps_limit_method fps_limit_method;
    bool help;
    bool no_display;


### PR DESCRIPTION
This changes how fps_limit is parsed and shown on the overlay, allowing you to use decimal values for fps_limit.