### PR TITLE
Detect proton on wow64 as well

### DIFF
--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -799,7 +799,11 @@ void init_system_info(){
       string preloader = wineProcess.substr(n + 1);
       if (preloader == "wine-preloader" || preloader == "wine64-preloader") {
          // Check if using Proton
-         if (wineProcess.find("/dist/bin/wine") != std::string::npos || wineProcess.find("/files/bin/wine") != std::string::npos) {
+         if (wineProcess.find("/dist/bin/wine") != std::string::npos
+            || wineProcess.find("/files/bin/wine") != std::string::npos
+            || wineProcess.find("/dist/bin-wow64/wine") != std::string::npos
+            || wineProcess.find("/files/bin-wow64/wine") != std::string::npos)
+         {
             stringstream ss;
             ss << dirname((char*)wineProcess.c_str()) << "/../../version";
             string protonVersion = ss.str();


### PR DESCRIPTION
When using wow64 with proton this allows mangohud to detect the proton version