### PR TITLE
Resize present modes vector to fit available count

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1559,6 +1559,7 @@ static VkResult overlay_CreateSwapchainKHR(
       VkResult result = fpGetPhysicalDeviceSurfacePresentModesKHR(device_data->physical_device, pCreateInfo->surface, &presentModeCount, presentModes.data());
 
       if (result == VK_SUCCESS) {
+         presentModes.resize(presentModeCount);
          if (IsPresentModeSupported(HUDElements.cur_present_mode, presentModes))
             SPDLOG_DEBUG("Present mode: {}", HUDElements.presentModeMap[HUDElements.cur_present_mode]);
          else {


### PR DESCRIPTION
The vector for available modes is initially preallocated with size 6. The issue here is that the number of available modes may be smaller. In this case, vector will be filled with zero-padding values. The value 0 is already associated with `VK_PRESENT_MODE_IMMEDIATE_KHR`, which leads to its availability check always succeeding.

It ends eventually an SEGFAULT in environments where `VK_PRESENT_MODE_IMMEDIATE_KHR` cannot actually be used and ``vsync`` value in the config is set to 1. That happened to one user on GNOME who initially reported issue, since `VK_PRESENT_MODE_IMMEDIATE_KHR` is not exposed on Wayland WSI without tearing protocol support, which is not yet supported in mutter.

vkcube also uses an approach for checking modes where it first gets number of available modes and then allocates well-sized array for them (https://github.com/KhronosGroup/Vulkan-Tools/blob/06ae73a3dc3a03466817d8370355203dac7b79b1/cube/cube.c#L1385). But I don't think that's a big deal here, since probably resize will be done only once.

Fixes: https://github.com/flightlessmango/MangoHud/commit/2bc323b2ed045e38089eca9a9d34d3853e608d3e