### PR TITLE
Use cpu instead of cpu_family for mangohud.json.in

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -29,7 +29,7 @@ conf_data = configuration_data()
 
 conf_data.set('ld_libdir_mangohud_abs', libdir_mangohud)
 conf_data.set('ld_libdir_mangohud', ld_libdir_mangohud)
-conf_data.set('cpu_family', host_machine.cpu_family())
+conf_data.set('cpu_family', host_machine.cpu())
 conf_data.set('version', describe_ver)
 
 overlay_shaders = [
@@ -327,7 +327,7 @@ if is_unixy
 endif
 
 configure_file(input : 'mangohud.json.in',
-  output : '@0@.@1@.json'.format(meson.project_name(), host_machine.cpu_family()),
+  output : '@0@.@1@.json'.format(meson.project_name(), host_machine.cpu()),
   configuration : conf_data,
   install : true,
   install_dir : join_paths(get_option('datadir'), 'vulkan', 'implicit_layer.d'),


### PR DESCRIPTION
In Debian we got this warning

> There are issues with the [multiarch](https://wiki.debian.org/MultiArch) metadata for this package.
> [mangohud conflicts on /usr/share/vulkan/implicit_layer.d/MangoHud.arm.json on armel <-> armhf](https://wiki.debian.org/MultiArch/Hints#file-conflict)

If you try to install both armel and armhf packages you will get this error

> trying to overwrite shared '/usr/share/vulkan/implicit_layer.d/MangoHud.arm.json', which is different from other instances of package mangohud:armhf

After this change this will work.
To test this change I compiled for amd64, i386, armel, armhf and got this results
| arch | cpu | cpu_family |
| ------ | ---- | -------------- |
| amd64 | x86_64 | x86_64 |
| i386 | i386 | x86 |
| armel | armel | arm |
| armhf | armhf | arm |