### PR TITLE
WIP: Add option to export metrics in a otel endpoint

### DIFF
--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -234,93 +234,6 @@ struct gpu_metrics_v2_4 {
 	uint16_t			average_gfx_current;
 };
 
-struct gpu_metrics_v3_0 {
-	struct metrics_table_header	common_header;
-
-	/* Temperature */
-	/* gfx temperature on APUs */
-	uint16_t			temperature_gfx;
-	/* soc temperature on APUs */
-	uint16_t			temperature_soc;
-	/* CPU core temperature on APUs */
-	uint16_t			temperature_core[16];
-	/* skin temperature on APUs */
-	uint16_t			temperature_skin;
-
-	/* Utilization */
-	/* time filtered GFX busy % [0-100] */
-	uint16_t			average_gfx_activity;
-	/* time filtered VCN busy % [0-100] */
-	uint16_t			average_vcn_activity;
-	/* time filtered IPU per-column busy % [0-100] */
-	uint16_t			average_ipu_activity[8];
-	/* time filtered per-core C0 residency % [0-100]*/
-	uint16_t			average_core_c0_activity[16];
-	/* time filtered DRAM read bandwidth [MB/sec] */
-	uint16_t			average_dram_reads;
-	/* time filtered DRAM write bandwidth [MB/sec] */
-	uint16_t			average_dram_writes;
-	/* time filtered IPU read bandwidth [MB/sec] */
-	uint16_t			average_ipu_reads;
-	/* time filtered IPU write bandwidth [MB/sec] */
-	uint16_t			average_ipu_writes;
-
-	/* Driver attached timestamp (in ns) */
-	uint64_t			system_clock_counter;
-
-	/* Power/Energy */
-	/* time filtered power used for PPT/STAPM [APU+dGPU] [mW] */
-	uint32_t			average_socket_power;
-	/* time filtered IPU power [mW] */
-	uint16_t			average_ipu_power;
-	/* time filtered APU power [mW] */
-	uint32_t			average_apu_power;
-	/* time filtered GFX power [mW] */
-	uint32_t			average_gfx_power;
-	/* time filtered dGPU power [mW] */
-	uint32_t			average_dgpu_power;
-	/* time filtered sum of core power across all cores in the socket [mW] */
-	uint32_t			average_all_core_power;
-	/* calculated core power [mW] */
-	uint16_t			average_core_power[16];
-	/* time filtered total system power [mW] */
-	uint16_t			average_sys_power;
-	/* maximum IRM defined STAPM power limit [mW] */
-	uint16_t			stapm_power_limit;
-	/* time filtered STAPM power limit [mW] */
-	uint16_t			current_stapm_power_limit;
-
-	/* time filtered clocks [MHz] */
-	uint16_t			average_gfxclk_frequency;
-	uint16_t			average_socclk_frequency;
-	uint16_t			average_vpeclk_frequency;
-	uint16_t			average_ipuclk_frequency;
-	uint16_t			average_fclk_frequency;
-	uint16_t			average_vclk_frequency;
-	uint16_t			average_uclk_frequency;
-	uint16_t			average_mpipu_frequency;
-
-	/* Current clocks */
-	/* target core frequency [MHz] */
-	uint16_t			current_coreclk[16];
-	/* CCLK frequency limit enforced on classic cores [MHz] */
-	uint16_t			current_core_maxfreq;
-	/* GFXCLK frequency limit enforced on GFX [MHz] */
-	uint16_t			current_gfx_maxfreq;
-
-	/* Throttle Residency (ASIC dependent) */
-	uint32_t			throttle_residency_prochot;
-	uint32_t			throttle_residency_spl;
-	uint32_t			throttle_residency_fppt;
-	uint32_t			throttle_residency_sppt;
-	uint32_t			throttle_residency_thm_core;
-	uint32_t			throttle_residency_thm_gfx;
-	uint32_t			throttle_residency_thm_soc;
-
-	/* Metrics table alpha filter time constant [us] */
-	uint32_t			time_filter_alphavalue;
-};
-
 struct amdgpu_files
 {
     FILE *vram_total;
@@ -384,6 +297,7 @@ class AMDGPU {
 				thread.join();
 		}
 
+		bool verify_metrics(const std::string& path);
 		void get_instant_metrics(struct amdgpu_common_metrics *metrics);
 		void get_samples_and_copy(struct amdgpu_common_metrics metrics_buffer[METRICS_SAMPLE_COUNT],
 								  bool &gpu_load_needs_dividing);

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -291,12 +291,13 @@ bool CPUStats::ReadcpuTempFile(int& temp) {
 }
 
 bool CPUStats::UpdateCpuTemp() {
-    if (gpus) {
-        for (auto gpu : gpus->available_gpus) {
-            if (gpu->is_apu()) {
-                m_cpuDataTotal.temp = gpu->metrics.apu_cpu_temp;
-                return true;
-            }
+    if (!gpus)
+        gpus = std::make_unique<GPUS>(&HUDElements.params);
+
+    for (auto gpu : gpus->available_gpus) {
+        if (gpu->is_apu()) {
+            m_cpuDataTotal.temp = gpu->metrics.apu_cpu_temp;
+            return true;
         }
     }
 

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -276,8 +276,11 @@ void HudElements::version(){
 }
 
 void HudElements::gpu_stats(){
+    if (!gpus)
+        gpus = std::make_unique<GPUS>(&HUDElements.params);
+
     size_t i = 0;
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] && gpus){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats]){
         for (auto& gpu : gpus->selected_gpus()) {
             ImguiNextColumnFirstItem();
             HUDElements.TextColored(HUDElements.colors.gpu, "%s", gpu->gpu_text().c_str());
@@ -627,7 +630,10 @@ void HudElements::io_stats(){
 }
 
 void HudElements::vram(){
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vram] && gpus){
+    if (!gpus)
+        gpus = std::make_unique<GPUS>(&HUDElements.params);
+
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_vram]){
         size_t i = 0;
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats]){
             for (auto& gpu : gpus->selected_gpus()) {
@@ -692,9 +698,10 @@ void HudElements::proc_vram() {
         return;
 
     if (!gpus)
-        return;
+        gpus = std::make_unique<GPUS>(&HUDElements.params);
 
     auto gpu = gpus->active_gpu();
+
     if (!gpu)
         return;
 
@@ -958,6 +965,9 @@ static inline double TransformInverse_Custom(double v, void*) {
 
 void HudElements::frame_timing(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_frame_timing]){
+        if (!gpus)
+            gpus = std::make_unique<GPUS>(&HUDElements.params);
+
         ImguiNextColumnFirstItem();
         ImGui::PushFont(HUDElements.sw_stats->font_small);
         if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
@@ -1029,7 +1039,7 @@ void HudElements::frame_timing(){
                         ImPlot::SetNextLineStyle(HUDElements.colors.frametime, 1.5);
                         ImPlot::PlotLine("frametime line", frametime_data.data(), frametime_data.size());
                         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_throttling_status_graph] &&
-                            gpus && gpus->active_gpu() && gpus->active_gpu()->throttling()){
+                            gpus->active_gpu() && gpus->active_gpu()->throttling()){
                             ImPlot::SetNextLineStyle(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), 1.5);
                             ImPlot::PlotLine("power line", gpus->active_gpu()->throttling()->power.data(), gpus->active_gpu()->throttling()->power.size());
                             ImPlot::SetNextLineStyle(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), 1.5);
@@ -1044,7 +1054,7 @@ void HudElements::frame_timing(){
         ImGui::EndChild();
 #ifdef __linux__
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_throttling_status_graph] &&
-            gpus && gpus->active_gpu() && gpus->active_gpu()->throttling()){
+            gpus->active_gpu() && gpus->active_gpu()->throttling()){
             ImGui::Dummy(ImVec2(0.0f, real_font_size.y / 2));
 
             if (gpus->active_gpu()->throttling()->power_throttling()) {
@@ -1456,7 +1466,10 @@ void HudElements::fan(){
 }
 
 void HudElements::throttling_status(){
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_throttling_status] && gpus){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_throttling_status]){
+        if (!gpus)
+            gpus = std::make_unique<GPUS>(&HUDElements.params);
+
         auto gpu = gpus->active_gpu();
         if (!gpu)
             return;

--- a/src/meson.build
+++ b/src/meson.build
@@ -62,7 +62,8 @@ vklayer_files = files(
   'file_utils.cpp',
   'nvidia.cpp',
   'gpu_fdinfo.cpp',
-  'amdgpu.cpp'
+  'amdgpu.cpp',
+  'otel_exporter.cpp'
 )
 
 opengl_files  = []

--- a/src/otel_exporter.cpp
+++ b/src/otel_exporter.cpp
@@ -1,0 +1,311 @@
+#include "otel_exporter.h"
+#include "overlay_params.h"
+#include "logging.h"
+#include "config.h"
+#include "gpu.h"
+#include "memory.h"
+#include "cpu.h"
+#include "overlay.h"
+
+#include <spdlog/spdlog.h>
+
+#include <sstream>
+#include <iomanip>
+#include <cstring>
+#include <cstdlib>
+
+#ifdef _WIN32
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
+  #pragma comment(lib, "Ws2_32.lib")
+#else
+  #include <sys/types.h>
+  #include <sys/socket.h>
+  #include <netinet/in.h>
+  #include <netdb.h>
+  #include <arpa/inet.h>
+  #include <unistd.h>
+#endif
+
+// Globals from elsewhere
+extern double fps;            // logging.cpp
+extern float frametime;       // logging.cpp
+extern logData currentLogData;// logging.cpp
+
+static uint64_t monotonic_ns() {
+    using namespace std::chrono;
+    return duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count();
+}
+
+OTelExporter& OTelExporter::instance() {
+    static OTelExporter inst;
+    return inst;
+}
+
+OTelExporter::~OTelExporter() {
+    stop();
+}
+
+void OTelExporter::stop() {
+    bool expected = true;
+    if (!m_running.compare_exchange_strong(expected, false)) {
+        m_should_run = false;
+        return; // Already stopped
+    }
+    m_should_run = false;
+    if (m_collect_thread.joinable()) m_collect_thread.join();
+    if (m_server_thread.joinable()) m_server_thread.join();
+}
+
+void OTelExporter::reconfigure(const overlay_params* params) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    m_params_ref = params;
+    if (!params->enabled[OVERLAY_PARAM_ENABLED_otel]) {
+        stop();
+        return;
+    }
+    m_listen_cached = params->otel_listen;
+    m_interval_cached = params->otel_interval > 0 ? params->otel_interval : 1000;
+    m_startup_delay_cached = params->otel_startup_delay;
+    m_rebuild = true; // Rebuild metrics string ASAP
+}
+
+bool OTelExporter::parse_listen(const std::string& listen, std::string& host, std::string& port) {
+    auto pos = listen.find(':');
+    if (pos == std::string::npos) return false;
+    host = listen.substr(0, pos);
+    port = listen.substr(pos + 1);
+    if (host.empty() || port.empty()) return false;
+    return true;
+}
+
+void OTelExporter::maybe_start(const overlay_params* params, uint32_t /*vendorID*/) {
+    if (!params) return;
+    if (!params->enabled[OVERLAY_PARAM_ENABLED_otel]) {
+        // If previously running, stop.
+        if (m_running) stop();
+        return;
+    }
+
+    if (!m_should_run) {
+        // First time we see it enabled.
+        m_should_run = true;
+        m_first_enable_call = std::chrono::steady_clock::now();
+        m_pid = getpid();
+        m_exec_name = get_program_name();
+    }
+
+    // Respect startup delay before launching threads
+    if (!m_running.load()) {
+        auto elapsed = std::chrono::steady_clock::now() - m_first_enable_call;
+        if (elapsed < std::chrono::seconds(params->otel_startup_delay)) {
+            return; // Wait
+        }
+        {
+            std::lock_guard<std::mutex> lk(m_mutex);
+            m_params_ref = params;
+            m_listen_cached = params->otel_listen;
+            m_interval_cached = params->otel_interval > 0 ? params->otel_interval : 1000;
+            m_startup_delay_cached = params->otel_startup_delay;
+        }
+        start_locked();
+    } else {
+        // Already running; detect config changes that require rebuild or restart
+        if (m_listen_cached != params->otel_listen || m_interval_cached != params->otel_interval) {
+            // For simplicity: full restart if listen address changed; interval change only updated atomically
+            bool need_restart = (m_listen_cached != params->otel_listen);
+            {
+                std::lock_guard<std::mutex> lk(m_mutex);
+                m_params_ref = params;
+                m_interval_cached = params->otel_interval > 0 ? params->otel_interval : 1000;
+                if (need_restart) {
+                    m_listen_cached = params->otel_listen;
+                }
+                m_rebuild = true;
+            }
+            if (need_restart) {
+                stop();
+                start_locked();
+            }
+        }
+    }
+}
+
+void OTelExporter::start_locked() {
+    if (m_running.load()) return;
+    m_running = true;
+    try {
+        start_threads_unlocked();
+        SPDLOG_INFO("OTel metrics exporter started on {} (interval={}ms, delay={}s)", m_listen_cached, m_interval_cached, m_startup_delay_cached);
+    } catch (const std::exception& e) {
+        SPDLOG_ERROR("Failed to start OTEL exporter: {}", e.what());
+        m_running = false;
+        m_should_run = false;
+    }
+}
+
+void OTelExporter::start_threads_unlocked() {
+    m_collect_thread = std::thread(&OTelExporter::collection_loop, this);
+    pthread_setname_np(m_collect_thread.native_handle(), "mangohud-otelc");
+    m_server_thread = std::thread(&OTelExporter::server_loop, this);
+    pthread_setname_np(m_server_thread.native_handle(), "mangohud-otels");
+}
+
+void OTelExporter::collection_loop() {
+    while (m_running.load()) {
+        if (!m_should_run.load()) break;
+        build_metrics_string();
+        std::this_thread::sleep_for(std::chrono::milliseconds(m_interval_cached));
+    }
+}
+
+void OTelExporter::build_metrics_string() {
+    // Snapshot global values; rely on MangoHud update threads to keep globals fresh.
+    Sample s;
+    s.fps = fps;
+    s.frametime = frametime; // ms
+    s.cpu_load = currentLogData.cpu_load;
+    s.gpu_load = currentLogData.gpu_load;
+    s.cpu_temp = currentLogData.cpu_temp;
+    s.gpu_temp = currentLogData.gpu_temp;
+    s.cpu_power = currentLogData.cpu_power;
+    s.gpu_power = currentLogData.gpu_power;
+    s.ram_used = currentLogData.ram_used;     // MiB/GiB? In log it is MiB? Keep as MiB -> rename MB.
+    s.vram_used = currentLogData.gpu_vram_used; // MB
+    s.timestamp_ns = monotonic_ns();
+
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        m_latest = s;
+        std::ostringstream out;
+        // Common labels
+        out << "# HELP mangohud_fps Current frames per second\n";
+        out << "# TYPE mangohud_fps gauge\n";
+        out << "mangohud_fps{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.fps << "\n";
+
+        out << "# HELP mangohud_frametime_ms Frame time in milliseconds (most recent frame)\n";
+        out << "# TYPE mangohud_frametime_ms gauge\n";
+        out << "mangohud_frametime_ms{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.frametime << "\n";
+
+        out << "# HELP mangohud_cpu_load_percent Average CPU load percent\n";
+        out << "# TYPE mangohud_cpu_load_percent gauge\n";
+        out << "mangohud_cpu_load_percent{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.cpu_load << "\n";
+
+        out << "# HELP mangohud_gpu_load_percent Average GPU load percent\n";
+        out << "# TYPE mangohud_gpu_load_percent gauge\n";
+        out << "mangohud_gpu_load_percent{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.gpu_load << "\n";
+
+        out << "# HELP mangohud_cpu_temp_celsius CPU temperature in Celsius\n";
+        out << "# TYPE mangohud_cpu_temp_celsius gauge\n";
+        out << "mangohud_cpu_temp_celsius{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.cpu_temp << "\n";
+
+        out << "# HELP mangohud_gpu_temp_celsius GPU temperature in Celsius\n";
+        out << "# TYPE mangohud_gpu_temp_celsius gauge\n";
+        out << "mangohud_gpu_temp_celsius{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.gpu_temp << "\n";
+
+        out << "# HELP mangohud_cpu_power_watts CPU package power draw (W)\n";
+        out << "# TYPE mangohud_cpu_power_watts gauge\n";
+        out << "mangohud_cpu_power_watts{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.cpu_power << "\n";
+
+        out << "# HELP mangohud_gpu_power_watts GPU power draw (W)\n";
+        out << "# TYPE mangohud_gpu_power_watts gauge\n";
+        out << "mangohud_gpu_power_watts{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.gpu_power << "\n";
+
+        out << "# HELP mangohud_ram_used_mb System RAM used (MB)\n";
+        out << "# TYPE mangohud_ram_used_mb gauge\n";
+        out << "mangohud_ram_used_mb{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.ram_used << "\n";
+
+        out << "# HELP mangohud_vram_used_mb GPU VRAM used (MB)\n";
+        out << "# TYPE mangohud_vram_used_mb gauge\n";
+        out << "mangohud_vram_used_mb{pid=\"" << m_pid << "\",exec=\"" << m_exec_name << "\"} " << s.vram_used << "\n";
+
+        m_metrics_text = out.str();
+    }
+}
+
+void OTelExporter::server_loop() {
+#ifdef _WIN32
+    WSADATA wsaData;
+    WSAStartup(MAKEWORD(2,2), &wsaData);
+#endif
+
+    std::string host, port;
+    if (!parse_listen(m_listen_cached, host, port)) {
+        SPDLOG_ERROR("OTEL exporter: invalid listen address '{}'", m_listen_cached);
+        return;
+    }
+
+    struct addrinfo hints = {};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    struct addrinfo *res = nullptr;
+    int err = getaddrinfo(host.c_str(), port.c_str(), &hints, &res);
+    if (err != 0) {
+        SPDLOG_ERROR("OTEL exporter: getaddrinfo failed: {}", gai_strerror(err));
+        return;
+    }
+
+    int listen_fd = -1;
+    for (auto p = res; p; p = p->ai_next) {
+        listen_fd = (int)socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+        if (listen_fd < 0) continue;
+        int yes = 1;
+        setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, (char*)&yes, sizeof(yes));
+        if (bind(listen_fd, p->ai_addr, p->ai_addrlen) == 0) {
+            if (listen(listen_fd, 8) == 0) break;
+        }
+#ifdef _WIN32
+        closesocket(listen_fd);
+#else
+        close(listen_fd);
+#endif
+        listen_fd = -1;
+    }
+    freeaddrinfo(res);
+
+    if (listen_fd < 0) {
+        SPDLOG_ERROR("OTEL exporter: failed to bind {}", m_listen_cached);
+        return;
+    }
+
+    m_server_ready = true;
+
+    while (m_running.load()) {
+        struct sockaddr_storage their_addr;
+        socklen_t addr_size = sizeof(their_addr);
+        int fd = (int)accept(listen_fd, (struct sockaddr*)&their_addr, &addr_size);
+        if (fd < 0) {
+            if (!m_running.load()) break;
+            continue;
+        }
+        std::string payload;
+        {
+            std::lock_guard<std::mutex> lk(m_mutex);
+            payload = m_metrics_text;
+        }
+        std::ostringstream http;
+        http << "HTTP/1.1 200 OK\r\n";
+        http << "Content-Type: text/plain; version=0.0.4\r\n";
+        http << "Content-Length: " << payload.size() << "\r\n";
+        http << "Connection: close\r\n\r\n";
+        http << payload;
+        auto txt = http.str();
+#ifdef _WIN32
+        send(fd, txt.c_str(), (int)txt.size(), 0);
+        closesocket(fd);
+#else
+        ::send(fd, txt.c_str(), txt.size(), 0);
+        close(fd);
+#endif
+    }
+
+#ifdef _WIN32
+    if (listen_fd >= 0) closesocket(listen_fd);
+    WSACleanup();
+#else
+    if (listen_fd >= 0) close(listen_fd);
+#endif
+}
+

--- a/src/otel_exporter.h
+++ b/src/otel_exporter.h
@@ -1,0 +1,100 @@
+#pragma once
+// Simple OpenTelemetry-style metrics exporter for MangoHud
+// This implementation avoids external dependencies and exposes a very small
+// HTTP endpoint that returns a Prometheus-compatible text exposition which
+// can be scraped by collectors and converted to OTLP if desired.
+//
+// The exporter is intentionally lightweight: it periodically samples the
+// already collected MangoHud metric globals and serves the most recent
+// values. It is independent of the HUD visibility or logging state.
+//
+// Configuration is driven through overlay_params (see overlay_params.h):
+//  - otel (boolean) : Enable / disable exporter
+//  - otel_listen (string host:port) : Listen interface and port (default 0.0.0.0:16969)
+//  - otel_interval (uint, ms) : Internal sampling interval (default 1000)
+//  - otel_startup_delay (uint, seconds) : Delay before starting server (default 0)
+//
+// All exported metrics include two constant labels:
+//   pid   = current process id
+//   exec  = executable (process name)
+//
+// Thread model:
+//  - Collection thread wakes up every otel_interval ms and snapshots globals
+//  - Server thread is a simple blocking accept loop; each connection gets
+//    a copy of the last prepared metrics string and is closed immediately.
+//
+// This is a best-effort facility; failures to bind or accept are logged once
+// and retried only on config changes.
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <vector>
+
+struct overlay_params; // forward decl
+
+class OTelExporter {
+public:
+    static OTelExporter& instance();
+
+    // Called frequently from the render/update path; will start exporter
+    // once enabled and startup delay elapsed. Safe to call many times.
+    void maybe_start(const overlay_params* params, uint32_t vendorID);
+
+    // Force a shutdown (e.g. on program exit) – idempotent.
+    void stop();
+
+    // For explicit config reload handling.
+    void reconfigure(const overlay_params* params);
+
+private:
+    OTelExporter() = default;
+    ~OTelExporter();
+    OTelExporter(const OTelExporter&) = delete;
+    OTelExporter& operator=(const OTelExporter&) = delete;
+
+    void start_locked();
+    void start_threads_unlocked();
+    void collection_loop();
+    void server_loop();
+    void build_metrics_string();
+    bool parse_listen(const std::string& listen, std::string& host, std::string& port);
+
+    std::atomic<bool> m_running{false};
+    std::atomic<bool> m_should_run{false};
+    std::atomic<bool> m_server_ready{false};
+    std::atomic<bool> m_rebuild{false};
+
+    const overlay_params* m_params_ref = nullptr;
+    std::mutex m_mutex;
+    std::thread m_collect_thread;
+    std::thread m_server_thread;
+
+    std::chrono::steady_clock::time_point m_first_enable_call{};
+    std::string m_listen_cached;
+    uint32_t m_interval_cached = 1000; // ms
+    uint32_t m_startup_delay_cached = 0; // seconds
+
+    pid_t m_pid = 0;
+    std::string m_exec_name;
+
+    // Snapshot values
+    struct Sample {
+        double fps = 0.0;
+        float frametime = 0.f; // ms
+        float cpu_load = 0.f;
+        float gpu_load = 0.f;
+        float cpu_temp = 0.f;
+        float gpu_temp = 0.f;
+        float cpu_power = 0.f;
+        float gpu_power = 0.f;
+        double ram_used = 0.0; // MB
+        double vram_used = 0.0; // MB
+        uint64_t timestamp_ns = 0; // monotonic
+    } m_latest;
+
+    std::string m_metrics_text;
+};
+

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -27,6 +27,7 @@
 #include "net.h"
 #include "fex.h"
 #include "ftrace.h"
+#include "otel_exporter.h"
 
 #ifdef __linux__
 #include <libgen.h>
@@ -319,9 +320,15 @@ void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, const stru
 }
 
 void update_hud_info(struct swapchain_stats& sw_stats, const struct overlay_params& params, uint32_t vendorID){
+   // Ensure OTEL exporter starts regardless of HUD visibility
+#ifdef HAVE_OTEL
+   OTelExporter::instance().maybe_start(&params, vendorID);
+#else
+   OTelExporter::instance().maybe_start(&params, vendorID);
+#endif
    uint64_t now = os_time_get_nano(); /* ns */
    uint64_t frametime_ns = now - sw_stats.last_present_time;
-   if (!params.no_display || logger->is_active())
+   if (!params.no_display || logger->is_active() || params.enabled[OVERLAY_PARAM_ENABLED_otel])
       update_hud_info_with_frametime(sw_stats, params, vendorID, frametime_ns);
 }
 

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -216,6 +216,10 @@ struct Tracepoint;
    OVERLAY_PARAM_CUSTOM(gpu_list)                    \
    OVERLAY_PARAM_CUSTOM(fex_stats)                   \
    OVERLAY_PARAM_CUSTOM(ftrace)                      \
+   OVERLAY_PARAM_BOOL(otel)                          \
+   OVERLAY_PARAM_CUSTOM(otel_listen)                 \
+   OVERLAY_PARAM_CUSTOM(otel_interval)               \
+   OVERLAY_PARAM_CUSTOM(otel_startup_delay)          \
 
 enum overlay_param_position {
    LAYER_POSITION_TOP_LEFT,
@@ -355,6 +359,9 @@ struct overlay_params {
    std::vector<std::string> network;
    std::vector<unsigned> gpu_list;
    int transfer_function;
+   std::string otel_listen; // Listen interface:port for OTEL metrics, e.g. 0.0.0.0:16969
+   uint32_t otel_interval;  // Metric update interval in milliseconds
+   uint32_t otel_startup_delay; // Delay before starting OTEL server in seconds
 
    struct fex_stats_options {
       bool enabled {false};


### PR DESCRIPTION
Export MangoHud metrics as a Prometheus endpoint, this is pretty much a WIP
currently these are the exported metrics:
```
# HELP mangohud_fps Current frames per second
# TYPE mangohud_fps gauge
mangohud_fps{pid="17126",exec="vkcube"} 164.777
# HELP mangohud_frametime_ms Frame time in milliseconds (most recent frame)
# TYPE mangohud_frametime_ms gauge
mangohud_frametime_ms{pid="17126",exec="vkcube"} 6.06881
# HELP mangohud_cpu_load_percent Average CPU load percent
# TYPE mangohud_cpu_load_percent gauge
mangohud_cpu_load_percent{pid="17126",exec="vkcube"} 3.80795
# HELP mangohud_gpu_load_percent Average GPU load percent
# TYPE mangohud_gpu_load_percent gauge
mangohud_gpu_load_percent{pid="17126",exec="vkcube"} 6
# HELP mangohud_cpu_temp_celsius CPU temperature in Celsius
# TYPE mangohud_cpu_temp_celsius gauge
mangohud_cpu_temp_celsius{pid="17126",exec="vkcube"} 0
# HELP mangohud_gpu_temp_celsius GPU temperature in Celsius
# TYPE mangohud_gpu_temp_celsius gauge
mangohud_gpu_temp_celsius{pid="17126",exec="vkcube"} 0
# HELP mangohud_cpu_power_watts CPU package power draw (W)
# TYPE mangohud_cpu_power_watts gauge
mangohud_cpu_power_watts{pid="17126",exec="vkcube"} 0
# HELP mangohud_gpu_power_watts GPU power draw (W)
# TYPE mangohud_gpu_power_watts gauge
mangohud_gpu_power_watts{pid="17126",exec="vkcube"} 0
# HELP mangohud_ram_used_mb System RAM used (MB)
# TYPE mangohud_ram_used_mb gauge
mangohud_ram_used_mb{pid="17126",exec="vkcube"} 0
# HELP mangohud_vram_used_mb GPU VRAM used (MB)
# TYPE mangohud_vram_used_mb gauge
mangohud_vram_used_mb{pid="17126",exec="vkcube"} 0
```
<img width="2548" height="817" alt="image" src="https://github.com/user-attachments/assets/fed790bb-eea5-404a-b811-c74e5eb499c4" />

Recommended settings:
```
otel=1
otel_listen=0.0.0.0:16969
otel_interval=500
```

Example Prometheus scrape config:
```
apiVersion: monitoring.coreos.com/v1alpha1
kind: ScrapeConfig
metadata:
  name: desktop-scrape-config-mangohud
  namespace: monitoring
  labels:
    app: desktop-scrape-config-mangohud
spec:
  scrapeInterval: 1s
  staticConfigs:
    - labels:
        job: desktop-mangohud
      targets:
        - 192.168.1.247:16969
```
