### PR TITLE
GL fixes

### DIFF
--- a/src/gl/gl.h
+++ b/src/gl/gl.h
@@ -13,8 +13,11 @@ void glXSwapIntervalEXT(void*, void*, int);
 int glXSwapIntervalSGI(int);
 int glXSwapIntervalMESA(unsigned int);
 int glXGetSwapIntervalMESA(void);
+int glXMakeContextCurrent(void*, void*, void*, void*);
 int glXMakeCurrent(void*, void*, void*);
-void* glXGetCurrentContext();
+void *glXGetCurrentContext();
+void *glXGetCurrentDrawable();
+void *glXGetCurrentReadDrawable();
 void *glXCreateContextAttribsARB(void *dpy, void *config,void *share_context, int direct, const int *attrib_list);
 
 void* glXGetProcAddress(const unsigned char*);

--- a/src/gl/gl_hud.h
+++ b/src/gl/gl_hud.h
@@ -15,10 +15,9 @@ enum gl_wsi
 };
 
 void imgui_init();
-void imgui_create(void *ctx, const gl_wsi plat);
-void imgui_shutdown();
-void imgui_set_context(void *ctx, const gl_wsi plat);
-void imgui_render(unsigned int width, unsigned int height);
+void imgui_create(gl_context *ctx, const gl_wsi plat);
+void imgui_shutdown(gl_context *ctx, bool last);
+void imgui_render(gl_context *ctx, unsigned int width, unsigned int height);
 
 }} // namespace
 

--- a/src/gl/gl_renderer.h
+++ b/src/gl/gl_renderer.h
@@ -25,16 +25,30 @@
 #ifndef MANGOHUD_IMGUI_IMPL_OPENGL3_H
 #define MANGOHUD_IMGUI_IMPL_OPENGL3_H
 
+#include <glad/glad.h>
+
 namespace MangoHud { namespace GL {
+
+struct gl_context
+{
+    void *ctx;
+    GLuint FontTexture = 0;
+    GLuint ShaderHandle = 0, VertHandle = 0, FragHandle = 0;
+    int AttribLocationTex = 0, AttribLocationProjMtx = 0;                                // Uniforms location
+    int AttribLocationVtxPos = 0, AttribLocationVtxUV = 0, AttribLocationVtxColor = 0; // Vertex attributes location
+    unsigned int VboHandle = 0, ElementsHandle = 0;
+    bool swap_interval_set = false;
+};
+
 
 void GetOpenGLVersion(int& major, int& minor, bool& isGLES);
 
 // Backend API
-IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_Init(const char* glsl_version = nullptr);
-IMGUI_IMPL_API void     ImGui_ImplOpenGL3_Shutdown();
-IMGUI_IMPL_API void     ImGui_ImplOpenGL3_NewFrame();
+IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_Init(gl_context* ctx, const char* glsl_version = nullptr);
+IMGUI_IMPL_API void     ImGui_ImplOpenGL3_Shutdown(gl_context* ctx);
+IMGUI_IMPL_API void     ImGui_ImplOpenGL3_NewFrame(gl_context* ctx);
 IMGUI_IMPL_API void     ImGui_ImplOpenGL3_RenderDrawData(ImDrawData* draw_data);
-IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_CreateFontsTexture();
+IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_CreateFontsTexture(gl_context* ctx);
 
 // (Optional) Called by Init/NewFrame/Shutdown
 //IMGUI_IMPL_API bool     ImGui_ImplOpenGL3_CreateFontsTexture();

--- a/src/loaders/loader_glx.cpp
+++ b/src/loaders/loader_glx.cpp
@@ -82,6 +82,18 @@ bool glx_loader::Load() {
     return false;
   }
 
+  GetCurrentDrawable =
+      reinterpret_cast<decltype(this->GetCurrentDrawable)>(
+          GetProcAddress((const unsigned char *)"glXGetCurrentDrawable"));
+  if (!GetCurrentDrawable) {
+    CleanUp(true);
+    return false;
+  }
+
+  GetCurrentReadDrawable =
+      reinterpret_cast<decltype(this->GetCurrentReadDrawable)>(
+          GetProcAddress((const unsigned char *)"glXGetCurrentReadDrawable"));
+
   SwapBuffers =
       reinterpret_cast<decltype(this->SwapBuffers)>(
           GetProcAddress((const unsigned char *)"glXSwapBuffers"));
@@ -118,6 +130,10 @@ bool glx_loader::Load() {
       reinterpret_cast<decltype(this->QueryDrawable)>(
           GetProcAddress((const unsigned char *)"glXQueryDrawable"));
 
+  MakeContextCurrent =
+      reinterpret_cast<decltype(this->MakeContextCurrent)>(
+          GetProcAddress((const unsigned char *)"glXMakeContextCurrent"));
+
   MakeCurrent =
       reinterpret_cast<decltype(this->MakeCurrent)>(
           GetProcAddress((const unsigned char *)"glXMakeCurrent"));
@@ -141,8 +157,8 @@ void glx_loader::CleanUp(bool unload) {
   SwapIntervalSGI = nullptr;
   SwapIntervalMESA = nullptr;
   QueryDrawable = nullptr;
+  MakeContextCurrent = nullptr;
   MakeCurrent = nullptr;
-
 }
 
 glx_loader glx;

--- a/src/loaders/loader_glx.h
+++ b/src/loaders/loader_glx.h
@@ -16,11 +16,14 @@ class glx_loader {
   decltype(&::glXCreateContextAttribsARB) CreateContextAttribs;
   decltype(&::glXCreateContextAttribsARB) CreateContextAttribsARB;
   decltype(&::glXDestroyContext) DestroyContext;
+  decltype(&::glXGetCurrentDrawable) GetCurrentDrawable;
+  decltype(&::glXGetCurrentReadDrawable) GetCurrentReadDrawable;
   decltype(&::glXSwapBuffers) SwapBuffers;
   decltype(&::glXSwapIntervalEXT) SwapIntervalEXT;
   decltype(&::glXSwapIntervalSGI) SwapIntervalSGI;
   decltype(&::glXSwapIntervalMESA) SwapIntervalMESA;
   decltype(&::glXGetSwapIntervalMESA) GetSwapIntervalMESA;
+  decltype(&::glXMakeContextCurrent) MakeContextCurrent;
   decltype(&::glXMakeCurrent) MakeCurrent;
   decltype(&::glXGetCurrentContext) GetCurrentContext;
   decltype(&::glXQueryDrawable) QueryDrawable;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -297,7 +297,7 @@ struct overlay_params {
    float round_corners;
    unsigned vsync;
    int gl_vsync;
-   int gl_bind_framebuffer {-1};
+   int gl_bind_framebuffer {0};
    enum gl_size_query gl_size_query {GL_SIZE_DRAWABLE};
    bool gl_dont_flip {false};
    int64_t log_duration, log_interval;


### PR DESCRIPTION
Current MangoHud has some issues when run on OpenGL games that use multiple GL contexts, like many older ddraw-era Wine games end up doing. This fixes them at the cost of effectively never destroying GL resources from old contexts since that's not safe to do at the moment.

The "more proper" fix, I think, would be to wrap the GL context into our own object where we can also keep track of when it's used and destroyed and we can store locally the IDs of the GL resources that are tied to that context. But before I embark into that larger change I thought I'd see how this goes with you :slightly_smiling_face: 

The impetus for all this was to fix Resident Evil 3 Classic on Proton: the overlay would disappear after showing up for just a fraction of a second, and after the first two splash screens the screen would turn entirely black (turns out the latter was because we were destroying random GL objects on the new context which happened to share the same IDs as MangoHud's resources in the old context).