### PR TITLE
Cleanup and unify reading values from sysfs files

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -6,11 +6,11 @@
 #include "amdgpu.h"
 #include "gpu.h"
 #include "cpu.h"
+#include "file_utils.h"
 #include "overlay.h"
 #include "hud_elements.h"
 #include "logging.h"
 #include "mesa/util/macros.h"
-
 
 #define IS_VALID_METRIC(FIELD) (FIELD != 0xffff)
 void AMDGPU::get_instant_metrics(struct amdgpu_common_metrics *metrics) {
@@ -373,24 +373,11 @@ void AMDGPU::metrics_polling_thread() {
 }
 
 void AMDGPU::get_sysfs_metrics() {
-    int64_t value = 0;
-	if (sysfs_nodes.busy) {
-		rewind(sysfs_nodes.busy);
-		fflush(sysfs_nodes.busy);
-		int value = 0;
-		if (fscanf(sysfs_nodes.busy, "%d", &value) != 1)
-			value = 0;
-		metrics.load = value;
-	}
+	if (sysfs_nodes.busy)
+		metrics.load = read_as<int>(sysfs_nodes.busy).value_or(0);
 
-	if (sysfs_nodes.memory_clock) {
-		rewind(sysfs_nodes.memory_clock);
-		fflush(sysfs_nodes.memory_clock);
-		if (fscanf(sysfs_nodes.memory_clock, "%" PRId64, &value) != 1)
-			value = 0;
-
-		metrics.MemClock = value / 1000000;
-	}
+	if (sysfs_nodes.memory_clock)
+		metrics.MemClock = read_as<int64_t>(sysfs_nodes.memory_clock).value_or(0) / 1000000;
 
 	// TODO: on some gpus this will use the power1_input instead
 	// this value is instantaneous and should be averaged over time
@@ -402,14 +389,8 @@ void AMDGPU::get_sysfs_metrics() {
 		metrics.powerUsage = 0;
 	} else
 #endif
-	if (sysfs_nodes.power_usage) {
-		rewind(sysfs_nodes.power_usage);
-		fflush(sysfs_nodes.power_usage);
-		if (fscanf(sysfs_nodes.power_usage, "%" PRId64, &value) != 1)
-			value = 0;
-
-		metrics.powerUsage = value / 1000000;
-	}
+	if (sysfs_nodes.power_usage)
+		metrics.powerUsage = read_as<int64_t>(sysfs_nodes.power_usage).value_or(0) / 1000000;
 
 #ifndef TEST_ONLY
 	if (!get_params()->enabled[OVERLAY_PARAM_ENABLED_gpu_power_limit]) {
@@ -418,92 +399,39 @@ void AMDGPU::get_sysfs_metrics() {
 		metrics.powerLimit = 0;
 	} else
 #endif
-	if (sysfs_nodes.power_limit) {
-		rewind(sysfs_nodes.power_limit);
-		fflush(sysfs_nodes.power_limit);
-		if (fscanf(sysfs_nodes.power_limit, "%" PRId64, &value) != 1)
-			value = 0;
-
-		metrics.powerLimit = value / 1000000;
-	}
+	if (sysfs_nodes.power_limit)
+		metrics.powerLimit = read_as<int64_t>(sysfs_nodes.power_limit).value_or(0) / 1000000;
 
 	if (sysfs_nodes.fan) {
-		rewind(sysfs_nodes.fan);
-		fflush(sysfs_nodes.fan);
-		if (fscanf(sysfs_nodes.fan, "%" PRId64, &value) != 1)
-			value = 0;
-		metrics.fan_speed = value;
+		metrics.fan_speed = read_as<int64_t>(sysfs_nodes.fan).value_or(0);
 		metrics.fan_rpm = true;
 	}
 
-	if (sysfs_nodes.vram_total) {
-		rewind(sysfs_nodes.vram_total);
-		fflush(sysfs_nodes.vram_total);
-		if (fscanf(sysfs_nodes.vram_total, "%" PRId64, &value) != 1)
-			value = 0;
-		metrics.memoryTotal = float(value) / (1024 * 1024 * 1024);
-	}
+	if (sysfs_nodes.vram_total)
+		metrics.memoryTotal = float(read_as<int64_t>(sysfs_nodes.vram_total).value_or(0)) / (1024 * 1024 * 1024);
 
-	if (sysfs_nodes.vram_used) {
-		rewind(sysfs_nodes.vram_used);
-		fflush(sysfs_nodes.vram_used);
-		if (fscanf(sysfs_nodes.vram_used, "%" PRId64, &value) != 1)
-			value = 0;
-		metrics.sys_vram_used = float(value) / (1024 * 1024 * 1024);
-	}
+	if (sysfs_nodes.vram_used)
+		metrics.sys_vram_used = float(read_as<int64_t>(sysfs_nodes.vram_used).value_or(0)) / (1024 * 1024 * 1024);
+
 	// On some GPUs SMU can sometimes return the wrong temperature.
 	// As HWMON is way more visible than the SMU metrics, let's always trust it as it is the most likely to work
-	if (sysfs_nodes.core_clock) {
-		rewind(sysfs_nodes.core_clock);
-		fflush(sysfs_nodes.core_clock);
-		if (fscanf(sysfs_nodes.core_clock, "%" PRId64, &value) != 1)
-			value = 0;
+	if (sysfs_nodes.core_clock)
+		metrics.CoreClock = read_as<int64_t>(sysfs_nodes.core_clock).value_or(0) / 1000000;
 
-		metrics.CoreClock = value / 1000000;
-	}
+	if (sysfs_nodes.temp)
+		metrics.temp = read_as<int>(sysfs_nodes.temp).value_or(0) / 1000;
 
-	if (sysfs_nodes.temp){
-		rewind(sysfs_nodes.temp);
-		fflush(sysfs_nodes.temp);
-		int value = 0;
-		if (fscanf(sysfs_nodes.temp, "%d", &value) != 1)
-			value = 0;
-		metrics.temp = value / 1000;
-	}
+	if (sysfs_nodes.junction_temp)
+		metrics.junction_temp = read_as<int>(sysfs_nodes.junction_temp).value_or(0) / 1000;
 
-	if (sysfs_nodes.junction_temp){
-		rewind(sysfs_nodes.junction_temp);
-		fflush(sysfs_nodes.junction_temp);
-		int value = 0;
-		if (fscanf(sysfs_nodes.junction_temp, "%d", &value) != 1)
-			value = 0;
-		metrics.junction_temp = value / 1000;
-	}
+	if (sysfs_nodes.memory_temp)
+		metrics.memory_temp = read_as<int>(sysfs_nodes.memory_temp).value_or(0) / 1000;
 
-	if (sysfs_nodes.memory_temp){
-		rewind(sysfs_nodes.memory_temp);
-		fflush(sysfs_nodes.memory_temp);
-		int value = 0;
-		if (fscanf(sysfs_nodes.memory_temp, "%d", &value) != 1)
-			value = 0;
-		metrics.memory_temp = value / 1000;
-	}
+	if (sysfs_nodes.gtt_used)
+		metrics.gtt_used = float(read_as<int64_t>(sysfs_nodes.gtt_used).value_or(0)) / (1024 * 1024 * 1024);
 
-	if (sysfs_nodes.gtt_used) {
-		rewind(sysfs_nodes.gtt_used);
-		fflush(sysfs_nodes.gtt_used);
-		if (fscanf(sysfs_nodes.gtt_used, "%" PRId64, &value) != 1)
-			value = 0;
-		metrics.gtt_used = float(value) / (1024 * 1024 * 1024);
-	}
-
-	if (sysfs_nodes.gpu_voltage_soc) {
-		rewind(sysfs_nodes.gpu_voltage_soc);
-		fflush(sysfs_nodes.gpu_voltage_soc);
-		if (fscanf(sysfs_nodes.gpu_voltage_soc, "%" PRId64, &value) != 1)
-			value = 0;
-		metrics.voltage = value;
-	}
+	if (sysfs_nodes.gpu_voltage_soc)
+		metrics.voltage = read_as<int64_t>(sysfs_nodes.gpu_voltage_soc).value_or(0);
 }
 
 AMDGPU::AMDGPU(std::string pci_dev, uint32_t device_id, uint32_t vendor_id) {

--- a/src/file_utils.cpp
+++ b/src/file_utils.cpp
@@ -1,18 +1,24 @@
 #include "file_utils.h"
 #include "string_utils.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
+
+#include <cstring>
+#include <fstream>
+#include <regex>
+#include <string>
+
 #include <dirent.h>
 #include <limits.h>
-#include <fstream>
-#include <cstring>
-#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #include <spdlog/spdlog.h>
 
 #ifndef PROCDIR
 #define PROCDIR "/proc"
 #endif
+
+namespace fs = ghc::filesystem;
 
 std::string read_line(const std::string& filename)
 {


### PR DESCRIPTION
# Why  
While browsing the code for some info how MangoHud does obtain certain GPU parameters, I notice that there is a lot of duplicated code, which ultimately lead to this PR.

# What  
This PR introduces new helper function(s) which is then used to replace all the existing occasions where we do `rewind`, `fflush` and `fscanf` in sequence.  
As you can see by the number of commits, I went to a few iterations before I finally opted for a template approach, since this should result in basically the same code as before, but in a more generalized way. I also opted to use `std::optional`, to make error propagation easier and more transparent.

I would love to also move the check, if the `FILE*` been valid, into the function. But since this check is also used as a gate-keeper in some cases (see `get_cpu_power_k10temp`, `get_cpu_power_zenpower`, I decided against it for now.

Note that I also sorted the include alphabetically and removed unused from the header.