### PR TITLE
bugfix: present mode value text alignment

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1570,7 +1570,7 @@ void HudElements::graphs(){
         auto gpu = gpus->active_gpu();
         if (!gpu)
             return;
-        
+
         HUDElements.max = gpu->metrics.memoryTotal;
         HUDElements.min = 0;
         HUDElements.TextColored(HUDElements.colors.engine, "%s", "VRAM");
@@ -1685,7 +1685,7 @@ void HudElements::present_mode() {
     if (ImGuiTextOverflow(title))
         ImguiNextColumnOrNewRow();
 
-    HUDElements.TextColored(HUDElements.colors.text, "%s\n", HUDElements.get_present_mode().c_str());
+    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s\n", HUDElements.get_present_mode().c_str());
     ImGui::PopFont();
 }
 


### PR DESCRIPTION
Fixed VSYNC/present mode value being incorrectly left aligned.

**Before**

<img width="744" height="613" alt="image" src="https://github.com/user-attachments/assets/697fc12e-1030-4bb2-9873-ae078e91a8de" />

**After**

<img width="727" height="604" alt="image" src="https://github.com/user-attachments/assets/b8c0923f-fc1c-4eb9-bf88-773284158dcd" />

Edited: better screenshot formats