### PR TITLE
Param: dx_api fix DX11 display as DX?

### DIFF
--- a/src/overlay.h
+++ b/src/overlay.h
@@ -129,7 +129,7 @@ inline const char* engine_name(const swapchain_stats& sw_stats) {
          if (sw_stats.applicationVersion == 1)
             return "DX9";
 
-         if (sw_stats.applicationVersion == 2)
+         if (sw_stats.applicationVersion == 0)
             return "DX11";
 
          return "DX?";


### PR DESCRIPTION
After checking dxvk's code.

I think applicationVersion for DX11 should be 0.

https://github.com/doitsujin/dxvk/blob/add6fe452a28f4dd69d467623e21f3e5817f4dfe/src/dxvk/dxvk_instance.h#L55C1-L58C1

the enum contain only D3D9 flag and the should be empty when the app is using D3D11.

This is DX11 game  
```
Vulkan application info:
	Application name: FUMES.exe
	Application version: 0
	Engine name: DXVK
	Engine version: 8417281
	Target API version: 4206592 (1.3.0)
	Used resolutions: 3840x2160 
```

And this is DX9 game  
```
Vulkan application info:
	Application name: game.exe
	Application version: 1
	Engine name: DXVK
	Engine version: 8417281
	Target API version: 4206592 (1.3.0)
	Used resolutions: 1920x1080 
```
