### PR TITLE
gpu_fdinfo: add missing implicit sstream header include

### DIFF
--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <set>
 #include <regex>
+#include <sstream>
 
 #ifdef TEST_ONLY
 #include <../src/mesa/util/os_time.h>


### PR DESCRIPTION
It's not implicit in gcc-16 anymore.

../src/gpu_fdinfo.cpp: In member function ‘void GPU_fdinfo::get_current_hwmon_readings()’: ../src/gpu_fdinfo.cpp:287:27: error: aggregate ‘std::stringstream ss’ has incomplete type and cannot be defined
  287 |         std::stringstream ss;
      |
      
      
GCC-16 is still work in progress but these implicit header removals happen every release.

I didn't see any order for the headers so its just last with the rest of the C++ system headers.