### PR TITLE
Add RAM temperature for DDR5 with SPD5118

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `procmem`<br>`procmem_shared`, `procmem_virt`| Displays process' memory usage: resident, shared and/or virtual. `procmem` (resident) also toggles others off if disabled |
 | `proc_vram`                        | Display process' VRAM usage                                                           |
 | `ram`<br>`vram`                    | Display system RAM/VRAM usage                                                         |
+| `ram_temp`                         | Display RAM temperature (only supports DDR5 with `spd5118` driver)                    |
 | `read_cfg`                         | Add to MANGOHUD_CONFIG as first parameter to also load config file. Otherwise only `MANGOHUD_CONFIG` parameters are used |
 | `reload_cfg=`                      | Change keybind for reloading the config. Default = `Shift_L+F4`                       |
 | `resolution`                       | Display the current resolution                                                        |

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -749,9 +749,13 @@ void HudElements::proc_vram() {
 
 void HudElements::ram(){
 #ifdef __linux__
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram]){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram] ||
+        HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram_temp]) {
         ImguiNextColumnFirstItem();
         HUDElements.TextColored(HUDElements.colors.ram, "RAM");
+    }
+
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram]) {
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.1f", memused);
         if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
@@ -769,6 +773,21 @@ void HudElements::ram(){
         ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "GiB");
         ImGui::PopFont();
+    }
+
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_ram_temp]) {
+        ImguiNextColumnOrNewRow();
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit])
+            right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", HUDElements.convert_to_fahrenheit(mem_temp));
+        else
+            right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", mem_temp);
+        ImGui::SameLine(0, 1.0f);
+        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact])
+            HUDElements.TextColored(HUDElements.colors.text, "°");
+        else if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit])
+            HUDElements.TextColored(HUDElements.colors.text, "°F");
+        else
+            HUDElements.TextColored(HUDElements.colors.text, "°C");
     }
 #endif
 }

--- a/src/memory.h
+++ b/src/memory.h
@@ -5,9 +5,11 @@
 #include <cstdint>
 
 extern float memused, memmax, swapused;
+extern int mem_temp;
 extern uint64_t proc_mem_resident, proc_mem_shared, proc_mem_virt;
 
 void update_meminfo();
+void update_mem_temp();
 void update_procmem();
 
 #endif //MANGOHUD_MEMORY_H

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -132,6 +132,8 @@ void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
    }
    if (real_params->enabled[OVERLAY_PARAM_ENABLED_ram] || real_params->enabled[OVERLAY_PARAM_ENABLED_swap] || logger->is_active())
       update_meminfo();
+   if (real_params->enabled[OVERLAY_PARAM_ENABLED_ram_temp])
+      update_mem_temp();
    if (real_params->enabled[OVERLAY_PARAM_ENABLED_procmem])
       update_procmem();
    if (real_params->enabled[OVERLAY_PARAM_ENABLED_io_read] || real_params->enabled[OVERLAY_PARAM_ENABLED_io_write])

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -803,6 +803,7 @@ static void set_param_defaults(struct overlay_params *params){
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_ram] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_ram_temp] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_swap] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_vram] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_read_cfg] = false;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -47,6 +47,7 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(cpu_stats)                     \
    OVERLAY_PARAM_BOOL(gpu_stats)                     \
    OVERLAY_PARAM_BOOL(ram)                           \
+   OVERLAY_PARAM_BOOL(ram_temp)                      \
    OVERLAY_PARAM_BOOL(swap)                          \
    OVERLAY_PARAM_BOOL(vram)                          \
    OVERLAY_PARAM_BOOL(proc_vram)                     \


### PR DESCRIPTION
Currently one need to enable `ram` to see `ram_temp`. Maybe renaming `ram` -> `ram_usage` and making `ram` like `*pu_stats` would be better?