### PR TITLE
params: Restore the old transfer function on params reload.

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -149,7 +149,7 @@ void HudElements::convert_colors(const struct overlay_params& params)
         fc.w = params.alpha;
         if (HUDElements.colors.convert)
         {
-            switch(params.transfer_function)
+            switch (params.transfer_function)
             {
                 case PQ:
                     fc = SRGBToLinear(fc);

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -912,7 +912,9 @@ parse_overlay_config(struct overlay_params *params,
    SPDLOG_DEBUG("Version: {}", MANGOHUD_VERSION);
    std::vector<int> default_preset = {-1, 0, 1, 2, 3, 4};
    auto preset = std::move(params->preset);
+   int transfer_function = params->transfer_function;
    *params = {};
+   params->transfer_function = transfer_function;
    params->preset = use_existing_preset ? std::move(preset) : default_preset;
    set_param_defaults(params);
    if (!use_existing_preset) {


### PR DESCRIPTION
If you reload the HUD, the original transfer function cannot be recovered until the swapchain is recreated. This resolves the problem by restoring the original transfer function