### PR TITLE
hudelements: Show display-server only if enabled

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1742,6 +1742,9 @@ void HudElements::network() {
 }
 
 void HudElements::_display_session() {
+    if (not HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_display_server])
+        return;
+
     ImGui::PushFont(HUDElements.sw_stats->font_secondary);
     ImguiNextColumnFirstItem();
 


### PR DESCRIPTION
**Why**
The method `_display_session` does not contain the same check as all the other `HudElements`. And so the `display-server` can only be disabled if `legacy_layout` is set.

Reported-by: ruthan
Fixes: #1918 (Cant make display_server text dissappear)