### PR TITLE
fix ImGui assertion crash in overlay graphs

### DIFF
--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -602,9 +602,9 @@ static void render_benchmark(swapchain_stats& data, const struct overlay_params&
    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0, 0.0, 0.0, alpha / params.background_alpha));
    ImGui::Dummy(ImVec2(0.0f, 8.0f));
    if (params.enabled[OVERLAY_PARAM_ENABLED_histogram])
-      ImGui::PlotHistogram("", benchmark.fps_data.data(), benchmark.fps_data.size(), 0, "", 0.0f, max + 10, ImVec2(ImGui::GetContentRegionAvail().x, 50));
+      ImGui::PlotHistogram("##plot_histogram", benchmark.fps_data.data(), benchmark.fps_data.size(), 0, "", 0.0f, max + 10, ImVec2(ImGui::GetContentRegionAvail().x, 50));
    else
-      ImGui::PlotLines("", benchmark.fps_data.data(), benchmark.fps_data.size(), 0, "", 0.0f, max + 10, ImVec2(ImGui::GetContentRegionAvail().x, 50));
+      ImGui::PlotLines("##plot_lines", benchmark.fps_data.data(), benchmark.fps_data.size(), 0, "", 0.0f, max + 10, ImVec2(ImGui::GetContentRegionAvail().x, 50));
    ImGui::PopStyleColor(2);
    ImGui::End();
 }


### PR DESCRIPTION
Update ImGui graph calls to include unique IDs to prevent crashes with ImGui 1.91.6+.

In ImGui 1.91.6, passing an empty label ("") to PlotLines or PlotHistogram at the root of a window triggers an assertion failure: `id != window->ID`. 
This occurs because an empty string results in a hash collision with the window ID.

Added hidden IDs to ensure unique hashing without changing the UI.
Relevant ImGui documentation link: https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-about-the-id-stack-system

Fixes: #1916