### PR TITLE
Simplify the code for the battery's time remaining

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1267,24 +1267,15 @@ void HudElements::battery(){
                     char time_buffer[32];
                     snprintf(time_buffer, sizeof(time_buffer), "%02d:%02d", static_cast<int>(hours), static_cast<int>(minutes));
 
-                    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact]){
-                        ImGui::TableNextRow();
-                        ImGui::NextColumn();
-                        ImGui::PushFont(HUDElements.sw_stats->font_small);
-                        ImGuiTableSetColumnIndex(0);
-                        HUDElements.TextColored(HUDElements.colors.text, "%s", "Remaining Time");
-                        ImGui::PopFont();
-                        ImGuiTableSetColumnIndex(2);
-                    } else {
-                        if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal])
-                            ImguiNextColumnOrNewRow();
-
-                        ImguiNextColumnOrNewRow();
-                    }
-                    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact])
-                        ImGuiTableSetColumnIndex(0);
-
-                    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", time_buffer);
+                    ImguiNextColumnOrNewRow();
+                    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal])
+                        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", time_buffer);
+                    else
+                        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width * 1.25f, "%s", time_buffer);
+                    ImGui::SameLine(0, 1.0f);
+                    ImGui::PushFont(HUDElements.sw_stats->font_small);
+                    HUDElements.TextColored(HUDElements.colors.text, "REM");
+                    ImGui::PopFont();
                 }
             } else {
                 ImguiNextColumnOrNewRow();

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -249,14 +249,6 @@ static void ImguiNextColumnOrNewRow(int column = -1)
 static bool ImGuiTextOverflow(const char* text) {
     return ImGui::CalcTextSize(text).x > ImGui::CalcItemWidth() + HUDElements.ralign_width / 2;
 }
-// This function is only used in battery and battery is not used in windows builds
-// Battery should probably be reworked to not use this func since nothing else needs it
-#ifdef __linux__
-static void ImGuiTableSetColumnIndex(int column)
-{
-    ImGui::TableSetColumnIndex(std::max(0, std::min(column, ImGui::TableGetColumnCount() - 1)));
-}
-#endif
 
 void HudElements::time(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_time]){


### PR DESCRIPTION
Hi, I rewrote the code responsible for displaying the battery's time remaining in a way that is more consistent with the rest of the code.
It removes the 'Time Remaining' label and instead uses the 'REM' suffix, which I find clear enough.

I did this to fix a bug that overlaps text when using compact mode.
It also fixes #1162.

I'm open to suggestions.

<img width="424" height="77" alt="batt1" src="https://github.com/user-attachments/assets/2bafdfb8-166b-4a64-a85d-78c522c1d1f7" />
<img width="385" height="52" alt="batt2" src="https://github.com/user-attachments/assets/1a13161b-740e-48e8-a5b7-576ea677b52e" />
