### PR TITLE
vulkan: recognize SDL GPU API

### DIFF
--- a/src/overlay.h
+++ b/src/overlay.h
@@ -36,7 +36,8 @@ enum EngineTypes
    FERAL3D,
    TOGL,
 
-   GAMESCOPE
+   GAMESCOPE,
+   SDL
 };
 
 struct swapchain_stats {
@@ -94,11 +95,11 @@ struct LOAD_DATA {
 inline const char* engine_name(const swapchain_stats& sw_stats) {
    const char* engines[] = {
       "Unknown", "OpenGL", "VULKAN", "DXVK", "VKD3D", "DAMAVAND",
-      "ZINK", "WINED3D", "Feral3D", "ToGL", "GAMESCOPE"
+      "ZINK", "WINED3D", "Feral3D", "ToGL", "GAMESCOPE", "SDL"
    };
    const char* engines_short[] = {
       "Unknown", "OGL", "VK", "DXVK", "VKD3D", "DV",
-       "ZINK", "WD3D", "Feral3D", "ToGL", "GS"
+       "ZINK", "WD3D", "Feral3D", "ToGL", "GS", "SDL"
    };
 
    auto engine = sw_stats.engine;

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1962,6 +1962,9 @@ static VkResult overlay_CreateInstance(
       else if (engineName == "Feral3D")
          engine = FERAL3D;
 
+      else if (engineName == "SDLGPU")
+         engine = SDL;
+
       else
          engine = VULKAN;
    }


### PR DESCRIPTION
From [SDL Wiki](https://wiki.libsdl.org/SDL3/CategoryGPU):

> The GPU API offers a cross-platform way for apps to talk to modern graphics hardware. It offers both 3D graphics and compute support, in the style of Metal, Vulkan, and Direct3D 12.

<img width="1280" height="839" alt="изображение" src="https://github.com/user-attachments/assets/0093f9bc-e2fe-4ebc-af90-1625a76ef51b" />
