### PR TITLE
feat: add a set-fps-limit control command

### DIFF
--- a/control/src/control/__init__.py
+++ b/control/src/control/__init__.py
@@ -202,6 +202,9 @@ def control(args):
         conn.send(bytearray(':hud;', 'utf-8'))
     elif args.cmd == 'toggle-fcat':
         conn.send(bytearray(':fcat;', 'utf-8'))
+    elif args.cmd == 'set-fps-limit':
+        msg = ':set_fps_limit={};'.format(args.fps)
+        conn.send(bytearray(msg, 'utf-8'))
 
 def main():
     parser = argparse.ArgumentParser(description='MangoHud control client')
@@ -214,6 +217,8 @@ def main():
     commands.add_parser('start-logging')
     commands.add_parser('stop-logging')
     commands.add_parser('toggle-fcat')
+    set_fps_limit_parser = commands.add_parser('set-fps-limit')
+    set_fps_limit_parser.add_argument('fps', type=float, help='FPS limit value (0 for unlimited)')
 
     args = parser.parse_args()
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -386,7 +386,7 @@ int main(int, char**)
     // Main loop
     while (!glfwWindowShouldClose(window)){
         real_params = get_params();
-        check_keybinds(*real_params);
+        check_keybinds(*real_params, &control_client);
         if (!real_params->no_display && new_frame){
             if (mangoapp_paused){
                 glfwShowWindow(window);

--- a/src/control.cpp
+++ b/src/control.cpp
@@ -7,6 +7,7 @@
 #include "overlay.h"
 #include "version.h"
 #include "app/mangoapp.h"
+#include "fps_limiter.h"
 
 int global_control_client;
 
@@ -35,6 +36,13 @@ static void parse_command(overlay_params &params,
       }
    } else if (!strncmp(cmd, "fcat", cmdlen)) {
       params.enabled[OVERLAY_PARAM_ENABLED_fcat] = !params.enabled[OVERLAY_PARAM_ENABLED_fcat];
+   } else if (!strncmp(cmd, "set_fps_limit", cmdlen)) {
+      if (param && param[0] && fps_limiter) {
+         char *endptr;
+         float fps = strtof(param, &endptr);
+         if (endptr != param && fps >= 0)
+            fps_limiter->set_target(fps);
+      }
    }
 }
 

--- a/src/fps_limiter.h
+++ b/src/fps_limiter.h
@@ -73,14 +73,16 @@ class fpsLimiter {
                 return;
 
             fps_limits_idx = (fps_limits_idx + 1) % v.size();
-            auto next_target = v[fps_limits_idx];
-            target = next_target <= 0.0f ? 0 : int64_t(1'000'000'000.0f / next_target);
-            SPDLOG_DEBUG("Changed fps limit to {}", next_target);
+            set_target(v[fps_limits_idx]);
+            SPDLOG_DEBUG("Changed fps limit to {}", v[fps_limits_idx]);
+        }
+
+        void set_target(float fps) {
+            target = fps <= 0.0f ? 0 : int64_t(1'000'000'000.0f / fps);
         }
 
         int current_limit() {
-            auto& v = get_params()->fps_limit;
-            return v[fps_limits_idx];
+            return target > 0 ? int(1'000'000'000.0f / target) : 0;
         }
 };
 

--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -213,7 +213,7 @@ void imgui_render(gl_context *ctx, unsigned int width, unsigned int height)
         process_control_socket(control_client, params);
     }
 
-    check_keybinds(params);
+    check_keybinds(params, &control_client);
     update_hud_info(sw_stats, params, vendorID);
 
     auto saved_imgui_contexts = get_current_imgui_contexts();

--- a/src/keybinds.cpp
+++ b/src/keybinds.cpp
@@ -10,10 +10,11 @@
 #include "keybinds.h"
 #include "fps_metrics.h"
 #include "fps_limiter.h"
+#include "mesa/util/os_socket.h"
 
 Clock::time_point last_f2_press, toggle_fps_limit_press, toggle_preset_press, last_f12_press, reload_cfg_press, last_upload_press;
 
-void check_keybinds(struct overlay_params& params){
+void check_keybinds(struct overlay_params& params, int* control_client){
    auto real_params = get_params();
    using namespace std::chrono_literals;
    auto now = Clock::now(); /* us */
@@ -55,7 +56,7 @@ void check_keybinds(struct overlay_params& params){
      for (size_t i = 0; i < size; i++){
        if(real_params->preset[i] == current_preset) {
          current_preset = real_params->preset[++i%size];
-         parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), true);
+         parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), true, control_client);
          break;
        }
      }
@@ -69,7 +70,7 @@ void check_keybinds(struct overlay_params& params){
 
    if (elapsedReloadCfg >= keyPressDelay &&
        keys_are_pressed(real_params->reload_cfg)) {
-      parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false);
+      parse_overlay_config(&params, getenv("MANGOHUD_CONFIG"), false, control_client);
       reload_cfg_press = now;
    }
 

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -160,7 +160,7 @@ void update_hud_info(struct swapchain_stats& sw_stats, const struct overlay_para
 void update_hud_info_with_frametime(struct swapchain_stats& sw_stats, const struct overlay_params& params, uint32_t vendorID, uint64_t frametime_ns);
 void update_hw_info(const struct overlay_params& params, uint32_t vendorID);
 void init_cpu_stats(overlay_params& params);
-void check_keybinds(overlay_params& params);
+void check_keybinds(overlay_params& params, int* control_client = nullptr);
 void init_system_info(void);
 void check_for_vkbasalt_and_gamemode();
 void create_fonts(ImFontAtlas* font_atlas, const overlay_params& params, ImFont*& small_font, ImFont*& text_font, ImFont*& secondary_font);

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -287,6 +287,7 @@ struct overlay_params {
    bool enabled[OVERLAY_PARAM_ENABLED_MAX];
    enum overlay_param_position position;
    int control;
+   std::string control_path;
    uint32_t fps_sampling_period; /* ns */
    std::vector<float> fps_limit;
    enum fps_limit_method fps_limit_method;
@@ -393,7 +394,7 @@ struct overlay_params {
 const extern char *overlay_param_names[];
 
 void parse_overlay_config(struct overlay_params *params,
-                       const char *env, bool ignore_preset);
+                       const char *env, bool ignore_preset, int* control_client = nullptr);
 void presets(int preset, struct overlay_params *params, bool inherit=false);
 bool parse_preset_config(int preset, struct overlay_params *params);
 void add_to_options(struct overlay_params *params, std::string option, std::string value);

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -471,7 +471,7 @@ static void snapshot_swapchain_frame(struct swapchain_data *data)
    struct device_data *device_data = data->device;
    struct instance_data *instance_data = device_data->instance;
    update_hud_info(data->sw_stats, instance_data->params, device_data->properties.vendorID);
-   check_keybinds(instance_data->params);
+   check_keybinds(instance_data->params, &instance_data->control_client);
 #ifdef __linux__
    if (instance_data->params.control >= 0) {
       control_client_check(instance_data->params.control, instance_data->control_client, gpu.c_str());


### PR DESCRIPTION
Preserve control socket if the reloaded config does not change its path. This lets clients keep the connection across preset changes or config reloads.

Update the fps_limiter to directly store the current target, supporting runtime values.

I want to upstream this for use in [mangochill](https://github.com/farnoy/mangochill)