### PR TITLE
fix two use after free race conditions upon exit in NVIDIA sampling.

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -18,7 +18,7 @@ bool sysInfoFetched = false;
 double fps;
 float frametime;
 logData currentLogData = {};
-std::unique_ptr<Logger> logger;
+std::shared_ptr<Logger> logger;
 ofstream output_file;
 std::thread log_thread;
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -76,7 +76,7 @@ private:
   bool m_values_valid;
 };
 
-extern std::unique_ptr<Logger> logger;
+extern std::shared_ptr<Logger> logger;
 
 extern std::string os, cpu, gpu, ram, kernel, driver, cpusched;
 extern bool sysInfoFetched;

--- a/src/nvidia.h
+++ b/src/nvidia.h
@@ -96,7 +96,7 @@ class NVIDIA {
 
         std::vector<nvmlProcessInfo_v1_t> process_info = {};
 
-        void get_instant_metrics_nvml(struct gpu_metrics *metrics);
+        void get_instant_metrics_nvml(struct gpu_metrics *metrics, struct overlay_params *params);
         std::shared_ptr<libnvml_loader> nvml = get_libnvml_loader();
 #endif
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -1252,7 +1252,6 @@ void add_to_options(struct overlay_params *params, std::string option, std::stri
    params->options[option] = value;
 }
 
-int i = 0;
 void presets(int preset, struct overlay_params *params, bool inherit) {
    if (!inherit && parse_preset_config(preset, params))
          return;


### PR DESCRIPTION
- fix race accessing overlay_params upon shutdown. Hold smart_ptr outside of sampling loop.
- fix race accessing logger in NVIDIA sampling. Made logger a smart_ptr, explicitly increment ref count while sampling.