### PR TITLE
overlay: remove shell spawns in `init_system_info()` to avoid pressure-vessel seccomp failures

### DIFF
--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -1,6 +1,7 @@
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
+#include <string>
 #include <thread>
 #include <condition_variable>
 #include <spdlog/spdlog.h>
@@ -32,6 +33,8 @@
 #ifdef __linux__
 #include <libgen.h>
 #include <unistd.h>
+#include <sys/sysinfo.h>
+#include <sys/utsname.h>
 #endif
 
 namespace fs = ghc::filesystem;
@@ -762,22 +765,66 @@ struct pci_bus {
    int func;
 };
 
+static std::string parse_value_from_file(std::ifstream& file, const std::string& key, const std::string& separator) {
+   std::string line;
+
+   while (std::getline(file, line)) {
+      const auto position = line.find(separator);
+      if (std::string::npos == position) continue;
+
+      auto current_key = line.substr(0, position); trim(current_key);
+      auto current_value = line.substr(position + separator.size()); trim(current_value);
+
+      if (current_key == key && !current_value.empty())
+         return current_value;
+   }
+   return std::string();
+}
+
+static void strip_parenthesized_blocks(std::string& s) {
+   std::size_t pos = 0;
+   while (std::string::npos != (pos = s.find('(', pos))) {
+      const auto end = s.find(')', pos + 1);
+      if (end == std::string::npos) break;
+      s.erase(pos, end - pos + 1);
+   }
+
+   while (std::string::npos != s.find("  "))
+      s.replace(s.find("  "), 2, " ");
+
+   trim(s);
+}
+
 void init_system_info(){
    #ifdef __linux__
+      struct sysinfo info_buf;
+      if (0 == sysinfo(&info_buf)) {
+         auto ram_bytes = static_cast<unsigned long long>(info_buf.totalram) * info_buf.mem_unit;
+         ram = std::to_string(ram_bytes >> 10);
+      } else {
+         ram.clear();
+      }
+
+      struct utsname uts_buf;
+      if (0 == uname(&uts_buf)) {
+         kernel = uts_buf.release;
+      } else {
+         kernel.clear();
+      }
+
+      std::ifstream cpuinfo("/proc/cpuinfo");
+      cpu = parse_value_from_file(cpuinfo, "model name", ":");
+      strip_parenthesized_blocks(cpu);
+
+      std::ifstream osrel("/etc/os-release");
+      os = parse_value_from_file(osrel, "PRETTY_NAME", "=");
+      os.erase(std::remove(os.begin(), os.end(), '\"' ), os.end());
+
+      cpusched = read_line("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
+
       const char* ld_preload = getenv("LD_PRELOAD");
       if (ld_preload)
          unsetenv("LD_PRELOAD");
-
-      ram =  exec("sed -n 's/^MemTotal: *\\([0-9]*\\).*/\\1/p' /proc/meminfo");
-      trim(ram);
-      cpu =  exec("sed -n 's/^model name.*: \\(.*\\)/\\1/p' /proc/cpuinfo | sed 's/([^)]*)//g' | tail -n1");
-      trim(cpu);
-      kernel = exec("uname -r");
-      trim(kernel);
-      os = exec("sed -n 's/PRETTY_NAME=\\(.*\\)/\\1/p' /etc/os-release");
-      os.erase(remove(os.begin(), os.end(), '\"' ), os.end());
-      trim(os);
-      cpusched = read_line("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
 
 // Get WINE version
 

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -779,16 +779,6 @@ void init_system_info(){
       trim(os);
       cpusched = read_line("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
 
-      const char* mangohud_recursion = getenv("MANGOHUD_RECURSION");
-      if (!mangohud_recursion) {
-         setenv("MANGOHUD_RECURSION", "1", 1);
-         // driver = exec("glxinfo -B | sed -n 's/^OpenGL version.*: \\(.*\\)/\\1/p' | sed 's/([^)]*)//g;s/  / /g'");
-         // trim(driver);
-         unsetenv("MANGOHUD_RECURSION");
-      } else {
-         driver = "MangoHud glxinfo recursion detected";
-      }
-
 // Get WINE version
 
       wineProcess = get_exe_path();

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -822,10 +822,6 @@ void init_system_info(){
 
       cpusched = read_line("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
 
-      const char* ld_preload = getenv("LD_PRELOAD");
-      if (ld_preload)
-         unsetenv("LD_PRELOAD");
-
 // Get WINE version
 
       wineProcess = get_exe_path();
@@ -864,14 +860,20 @@ void init_system_info(){
                findVersion << "\"" << dir << "/wine\" --version";
             else
                findVersion << "\"" << dir << "/wine64\" --version";
+            const char* ld_preload = getenv("LD_PRELOAD");
+            if (ld_preload)
+               unsetenv("LD_PRELOAD");
             const char *wine_env = getenv("WINELOADERNOEXEC");
             if (wine_env)
                unsetenv("WINELOADERNOEXEC");
+
             wineVersion = exec(findVersion.str());
             trim(wineVersion);
             SPDLOG_DEBUG("WINE version: {}", wineVersion);
             if (wine_env)
                setenv("WINELOADERNOEXEC", wine_env, 1);
+            if (ld_preload)
+               setenv("LD_PRELOAD", ld_preload, 1);
          }
       }
       else {
@@ -879,9 +881,6 @@ void init_system_info(){
       }
 
       check_for_vkbasalt_and_gamemode();
-
-      if (ld_preload)
-         setenv("LD_PRELOAD", ld_preload, 1);
 
       SPDLOG_DEBUG("Ram:{}", ram);
       SPDLOG_DEBUG("Cpu:{}", cpu);


### PR DESCRIPTION
This PR removes shell-based system info collection from `init_system_info()` and replaces it with native code paths.

## Motivation

In Steam Runtime / pressure-vessel setups (notably via Wine + Vulkan layer), spawning `/bin/sh` pipelines from MangoHud can fail under runtime/seccomp constraints and produce noisy logs and host coredumps (e.g. `dash`).

By removing those shell callouts, MangoHud avoids this failure mode during initialization.

Ref: https://github.com/ValveSoftware/steam-runtime/issues/804

---

## Exact scope of this PR

### `init_system_info()` no longer shells out for basic system info

Replaced shell pipelines with native logic:

- `ram`:
  - before: `sed` on `/proc/meminfo`
  - now: `sysinfo(2)` (`totalram * mem_unit`, converted to KiB)

- `kernel`:
  - before: `uname -r` shell call
  - now: `uname(2)` via `utsname.release`

- `cpu`:
  - before: `sed ... /proc/cpuinfo | sed 's/([^)]*)//g;s/  / /g' | tail -n1`
  - now: direct `/proc/cpuinfo` parsing in C++, plus equivalent cleanup of parenthesized blocks/spacing

- `os`:
  - before: `sed` on `/etc/os-release` for `PRETTY_NAME`
  - now: direct `/etc/os-release` parsing in C++, then quote removal

### Environment mutation scope reduced

Because the above shell spawns are gone, `LD_PRELOAD` handling was narrowed down to only where subprocess spawning is still needed (Wine version probing path).

The disabled OpenGL/glxinfo callout block is guarded so re-enabling it cannot silently miss the required `LD_PRELOAD` workaround.

### No broader refactors

This PR intentionally does **not** migrate every remaining external callout in the file. Only the `init_system_info()` shell pipelines are targeted to fix the runtime failure mode above.

---

## Behavioral notes

- Intended output stays consistent with prior behavior, including CPU-name cleanup semantics.
- Main expected impact: no `/usr/bin/dash` coredumps in affected pressure-vessel scenarios.
- Nice side effect: lower init overhead from avoiding shell/process startup (potentially visible as faster game start, and possibly less overhead if/when initialization paths are re-entered).


## Future considerations

This change reduces `getenv()`/`setenv()` usage in one hot path, but the broader pattern still exists in other parts of the codebase.

Given MangoHud runs as a Vulkan layer inside the game process, process-global environment mutation is risky:

- `getenv()`/`setenv()` are process-global and generally not a good fit for highly concurrent in-process code.
- Behavior is timing-sensitive and can become hard to reason about across threads/components.
- It may work most of the time, but failures are non-local and difficult to debug.

Follow-up work could:

1. Audit all environment mutation/read patterns in layer/runtime paths.
2. Minimize or eliminate process-global env writes in runtime code.
3. Prefer explicit per-call process setup (where external tools are unavoidable), or native APIs that avoid subprocesses.
4. Isolate remaining external callouts behind strict wrappers with clear threading/lifetime constraints.
