### PR TITLE
params: add fps limit from MANGOHUD_FPS_LIMIT to front of limits list

### DIFF
--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -1088,20 +1088,14 @@ parse_overlay_config(struct overlay_params *params,
                                 );
 
    // check if user specified an env for fps limiter instead
-   if (params->fps_limit.size() == 0 ||
-      (params->fps_limit.size() == 1 && params->fps_limit[0] == 0))
+   const char *fps_limit_env = getenv("MANGOHUD_FPS_LIMIT");
+   if (fps_limit_env)
    {
-      const char *env = getenv("MANGOHUD_FPS_LIMIT");
-      if (env)
-      {
-         try {
-            int fps = std::stof(env);
-            if (params->fps_limit.size() == 0)
-               params->fps_limit.push_back(fps);
-            else
-               params->fps_limit[0] = fps;
-         } catch(...) {}
-      }
+      try {
+         int fps = std::stof(fps_limit_env);
+         auto front = params->fps_limit.begin();
+         params->fps_limit.insert(front, fps);
+      } catch(...) {}
    }
 
 #ifdef HAVE_DBUS


### PR DESCRIPTION
When MANGOHUD_FPS_LIMIT is defined it will add that limit to the front of the vector with the fps limits so that it's the default one.
This will allow to use MANGOHUD_FPS_LIMIT even if fps_limit is defined in Mangohud.conf and will also allow the use of the toggle fps limit to use the other limits instead of overwriting them

Fixes #1962