### PR TITLE
Add gpu_hotspot_delta metric (junction - edge temperature)

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -344,6 +344,36 @@ void HudElements::gpu_stats(){
                 ImGui::PopFont();
             }
 
+            if (gpu->metrics.junction_temp > -1 &&
+                gpu->metrics.temp > -1 &&
+                HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_hotspot_delta]) {
+
+                ImguiNextColumnOrNewRow();
+
+                if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit]) {
+                    int delta_f = HUDElements.convert_to_fahrenheit(gpu->metrics.junction_temp)
+                                - HUDElements.convert_to_fahrenheit(gpu->metrics.temp);
+
+                    right_aligned_text(text_color, HUDElements.ralign_width, "%i", delta_f);
+
+                    ImGui::SameLine(0, 1.0f);
+                    HUDElements.TextColored(HUDElements.colors.text, "°F");
+                } else {
+                    int delta = gpu->metrics.junction_temp - gpu->metrics.temp;
+
+                    right_aligned_text(text_color, HUDElements.ralign_width, "%i", delta);
+
+                    ImGui::SameLine(0, 1.0f);
+                    HUDElements.TextColored(HUDElements.colors.text, "°C");
+                }
+
+                ImGui::SameLine(0, 3.0f);
+
+                ImGui::PushFont(HUDElements.sw_stats->font_small);
+                HUDElements.TextColored(HUDElements.colors.text, "dT");
+                ImGui::PopFont();
+            }
+
             if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_fan] && !gpu->is_apu()){
                 ImguiNextColumnOrNewRow();
                 right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.fan_speed);

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -817,6 +817,7 @@ static void set_param_defaults(struct overlay_params *params){
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_power] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_junction_temp] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_gpu_hotspot_delta] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_mem_temp] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] = true;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] = true;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -45,6 +45,7 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(cpu_power)                     \
    OVERLAY_PARAM_BOOL(gpu_temp)                      \
    OVERLAY_PARAM_BOOL(gpu_junction_temp)             \
+   OVERLAY_PARAM_BOOL(gpu_hotspot_delta)             \
    OVERLAY_PARAM_BOOL(gpu_mem_temp)                  \
    OVERLAY_PARAM_BOOL(cpu_stats)                     \
    OVERLAY_PARAM_BOOL(gpu_stats)                     \


### PR DESCRIPTION
This PR adds a new optional metric `gpu_hotspot_delta`, which displays the difference between GPU junction (hotspot) temperature and edge temperature.

This is particularly useful for AMD GPUs (RDNA2/RDNA3), where hotspot delta is commonly used to assess cooling performance, mounting pressure, and thermal paste condition.

Key characteristics:
- Uses existing metrics (no additional sensor polling)
- Lightweight and low overhead
- Disabled by default
- Supports both Celsius and Fahrenheit modes
- Integrated consistently with existing GPU metrics

Example:
GPU Temp: 72°C
GPU Junction: 94°C
dT: 22°C

This provides users with immediate visibility into hotspot spread without requiring manual calculation.