### PR TITLE
Fix 0W AMD GPU power

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -350,7 +350,7 @@ void AMDGPU::get_sysfs_metrics() {
 	// this value is instantaneous and should be averaged over time
 	// probably just average everything in this function to be safe
 #ifndef TEST_ONLY
-	if (get_params()->enabled[OVERLAY_PARAM_ENABLED_gpu_power]) {
+	if (!get_params()->enabled[OVERLAY_PARAM_ENABLED_gpu_power]) {
 		// NOTE: Do not read power1_average if it is not enabled, as some
 		// older GPUs may hang when reading the sysfs node.
 		metrics.powerUsage = 0;


### PR DESCRIPTION
During refactoring, the condition for GPU power was inverted in [commit b058618](https://github.com/flightlessmango/MangoHud/commit/b0586184e88221a12dcf7972218c9a467974eb9f), resulting in 0W power usage reported.

Probably fixes https://github.com/flightlessmango/MangoHud/issues/1919 and https://github.com/flightlessmango/MangoHud/issues/1953