### PR TITLE
egl: Implement eglGetPlatformDisplayEXT injection

### DIFF
--- a/src/gl/gl.h
+++ b/src/gl/gl.h
@@ -33,6 +33,8 @@ unsigned int eglDestroyContext( void*, void* );
 void* eglGetProcAddress( const char* );
 int eglTerminate( void* );
 
+void* eglGetPlatformDisplayEXT(unsigned int platform, void* native_display, const intptr_t* attrib_list);
+
 #ifdef __cplusplus
 }
 #endif //__cplusplus

--- a/src/gl/inject_egl.cpp
+++ b/src/gl/inject_egl.cpp
@@ -195,6 +195,28 @@ EXPORT_C_(void*) eglGetPlatformDisplay( unsigned int platform, void* native_disp
     return ret;
 }
 
+EXPORT_C_(void*) eglGetPlatformDisplayEXT( unsigned int platform, void* native_display, const intptr_t* attrib_list);
+EXPORT_C_(void*) eglGetPlatformDisplayEXT( unsigned int platform, void* native_display, const intptr_t* attrib_list)
+{
+    void *ret;
+    static void* (*pfn_eglGetPlatformDisplayEXT)(unsigned int, void*, const intptr_t*) = nullptr;
+
+    if (!pfn_eglGetPlatformDisplayEXT)
+        pfn_eglGetPlatformDisplayEXT = reinterpret_cast<decltype(pfn_eglGetPlatformDisplayEXT)>(get_egl_proc_address("eglGetPlatformDisplayEXT"));
+
+    ret = pfn_eglGetPlatformDisplayEXT(platform, native_display, attrib_list);
+
+#ifdef HAVE_WAYLAND
+    if (platform == EGL_PLATFORM_WAYLAND_KHR && ret)
+    {
+        HUDElements.display_server = HUDElements.display_servers::WAYLAND;
+        init_wayland_data((struct wl_display*)native_display, ret);
+    }
+#endif
+
+    return ret;
+}
+
 EXPORT_C_(void*) eglGetDisplay( void* native_display );
 EXPORT_C_(void*) eglGetDisplay( void* native_display )
 {
@@ -254,11 +276,12 @@ struct func_ptr {
    void *ptr;
 };
 
-static std::array<const func_ptr, 6> name_to_funcptr_map = {{
+static std::array<const func_ptr, 7> name_to_funcptr_map = {{
 #define ADD_HOOK(fn) { #fn, (void *) fn }
     ADD_HOOK(eglDestroyContext),
     ADD_HOOK(eglGetDisplay),
     ADD_HOOK(eglGetPlatformDisplay),
+    ADD_HOOK(eglGetPlatformDisplayEXT),
     ADD_HOOK(eglGetProcAddress),
     ADD_HOOK(eglSwapBuffers),
     ADD_HOOK(eglTerminate)

--- a/src/gl/shim.c
+++ b/src/gl/shim.c
@@ -160,6 +160,11 @@ CREATE_FWD(void*, eglGetPlatformDisplay,
      void* native_display,
      const intptr_t* attrib_list),
      platform, native_display, attrib_list)
+CREATE_FWD(void*, eglGetPlatformDisplayEXT,
+    (unsigned int platform,
+     void* native_display,
+     const intptr_t* attrib_list),
+     platform, native_display, attrib_list)
 CREATE_FWD(unsigned int, eglSwapBuffers, (void* dpy, void* surf), dpy, surf)
 CREATE_FWD(void*, eglGetProcAddress, (const char* procName), procName)
 CREATE_FWD(int, eglTerminate, (void *display), display)
@@ -185,6 +190,7 @@ static struct func_ptr hooks[] = {
     ADD_HOOK(eglDestroyContext),
     ADD_HOOK(eglSwapBuffers),
     ADD_HOOK(eglGetPlatformDisplay),
+    ADD_HOOK(eglGetPlatformDisplayEXT),
     ADD_HOOK(eglGetDisplay),
     ADD_HOOK(eglGetProcAddress),
     ADD_HOOK(eglTerminate)


### PR DESCRIPTION
Some applications (or libraries) make use of eglGetPlatformDisplayEXT instead of eglGetPlatformDisplay or eglGetDisplay, which completely skips init_wayland_data resulting in key binds not working.

an example of this is GLFW https://github.com/glfw/glfw/blob/7b6aead9fb88b3623e3b3725ebb42670cbe4c579/src/egl_context.c#L493

fixes #1861