### PR TITLE
Add experimental workarounds to for loading libEGL and dlsym RTLD_DEFAULT

### DIFF
--- a/src/gl/inject_egl.cpp
+++ b/src/gl/inject_egl.cpp
@@ -39,6 +39,18 @@ static void* get_egl_proc_address(const char* name) {
 
     void *func = nullptr;
     static void *(*pfn_eglGetProcAddress)(const char*) = nullptr;
+
+    const char* egl_simple_load_env = getenv("MANGOHUD_EGL_SIMPLE_LOAD");
+    const bool enable_egl_simple_load = egl_simple_load_env ? egl_simple_load_env[0] == '1' : false;
+
+    if (!pfn_eglGetProcAddress && enable_egl_simple_load)
+    {
+        static void *handle = real_dlopen("libEGL.so.1", RTLD_LAZY);
+
+        if (handle)
+            pfn_eglGetProcAddress = reinterpret_cast<decltype(pfn_eglGetProcAddress)>(real_dlsym(handle, "eglGetProcAddress"));
+    }
+
     const char *libs[] = {
         "*libEGL.so.*",
         "*libEGL_mesa.so.*",

--- a/src/gl/shim.c
+++ b/src/gl/shim.c
@@ -263,8 +263,10 @@ void* dlsym(void *handle, const char *name)
 {
     save_and_consume_real_dlerror();
     // const char* dlsym_enabled = getenv("MANGOHUD_DLSYM");
-    // const char* dlsym_RTLD_NEXT_env = getenv("MANGOHUD_DLSYM_RTLD_NEXT");
-    // const bool bypass_RTLD_NEXT = dlsym_RTLD_NEXT_env ? dlsym_RTLD_NEXT_env[0] == '0' : false;
+    const char* dlsym_RTLD_DEFAULT_env = getenv("MANGOHUD_DLSYM_RTLD_DEFAULT_FIX");
+    const bool enable_RTLD_DEFAULT_experimental_fix = dlsym_RTLD_DEFAULT_env ? dlsym_RTLD_DEFAULT_env[0] == '1' : false;
+    const char* dlsym_RTLD_NEXT_env = getenv("MANGOHUD_DLSYM_RTLD_NEXT_BAD_FIX");
+    const bool enable_RTLD_NEXT_experimental_fix = dlsym_RTLD_NEXT_env ? dlsym_RTLD_NEXT_env[0] == '1' : false;
     void* is_angle = real_dlsym(handle, "eglStreamPostD3DTextureANGLE");
     // Consume error message if there was an error
     if (!is_angle)
@@ -280,27 +282,28 @@ void* dlsym(void *handle, const char *name)
     // Note, RTLD_DEFAULT might still be broken for edge cases.
 
     // this causes issues with nvidia and will crash. Needs to be reworked
-    // if (!fn_ptr && (handle == RTLD_DEFAULT || (handle == RTLD_NEXT && !bypass_RTLD_NEXT)))
-    // {
-    //     void* ret_addr = __builtin_extract_return_addr(__builtin_return_address(0));
-    //     Dl_info dl_info = {};
+    if (enable_RTLD_DEFAULT_experimental_fix || enable_RTLD_NEXT_experimental_fix)
+    if (!fn_ptr && (handle == RTLD_DEFAULT || (handle == RTLD_NEXT && enable_RTLD_NEXT_experimental_fix)))
+    {
+        void* ret_addr = __builtin_extract_return_addr(__builtin_return_address(0));
+        Dl_info dl_info = {};
 
-    //     if (dladdr(ret_addr, &dl_info) && dl_info.dli_fname && dl_info.dli_fname[0])
-    //     {
-    //         void* caller_handle = dlopen(dl_info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
-    //         if (caller_handle)
-    //         {
-    //             // last real_dlsym call failed so we consume the last error
-    //             (void) real_dlerror();
-    //             fn_ptr = real_dlsym(caller_handle, name);
-    //             if (handle == RTLD_NEXT)
-    //             {
-    //                 fprintf(stderr, "MANGOHUD: WARNING dlsym called with RTLD_NEXT, if you are facing issues try to disable mangohud.\n");
-    //                 fprintf(stderr, "MANGOHUD: or you can try MANGOHUD_DLSYM_RTLD_NEXT=0\n");
-    //             }
-    //         }
-    //     }
-    // }
+        if (dladdr(ret_addr, &dl_info) && dl_info.dli_fname && dl_info.dli_fname[0])
+        {
+            void* caller_handle = dlopen(dl_info.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
+            if (caller_handle)
+            {
+                // last real_dlsym call failed so we consume the last error
+                (void) real_dlerror();
+                fn_ptr = real_dlsym(caller_handle, name);
+                if (handle == RTLD_NEXT)
+                {
+                    fprintf(stderr, "MANGOHUD: WARNING dlsym called with RTLD_NEXT, if you are facing issues try to disable mangohud.\n");
+                    fprintf(stderr, "MANGOHUD: or you can try MANGOHUD_DLSYM_RTLD_NEXT_BAD_FIX=0 or unset it if already set.\n");
+                }
+            }
+        }
+    }
 
     // Activate override if there wasn't any new error
     // from real_dlsym


### PR DESCRIPTION
Due to issues with the dlsym fix it was commented out, and in earlier attempt to fix this issue the methodology used to load libEGL was changed into a hacky way.

the dlsym fix was force enabled in 0.8.2 (which was a breaking change for some) and is now commented out.
this allows it to be enabled for users who need it, while also keeping it disabled by default for 0.8.3 (similar to pre-0.8.2)

the hacky method to load libEGL is causing issues for some nvidia users, this gives users a simpler method to load libEGL.

All changes introduced here are disabled by default and can be enabled with the following environment variables:

- ``MANGOHUD_EGL_SIMPLE_LOAD=1`` Used to enable the simpler libEGL loading.
- ``MANGOHUD_DLSYM_RTLD_DEFAULT_FIX=1`` Used to enable the DLSYM workarounds for ``RTLD_DEFAULT`` handle.
- ``MANGOHUD_DLSYM_RTLD_NEXT_BAD_FIX=1`` Used to enable the DLSYM workarounds for ``RTLD_DEFAULT`` **and** ``RTLD_NEXT`` handles (this is mostly the wrong behavior for RTLD_NEXT, but allowed for experimentation as needed).

for NVIDIA users it may be recommended to use both  ``MANGOHUD_EGL_SIMPLE_LOAD=1`` and ``MANGOHUD_DLSYM_RTLD_DEFAULT_FIX=1``; but end user must determine what works best.