### PR TITLE
FEX: Fixes dynamic pid updating

### DIFF
--- a/src/fex.cpp
+++ b/src/fex.cpp
@@ -238,6 +238,7 @@ static void init_shm(int pid) {
 
     fd = shm_open(f.c_str(), O_RDONLY, 0);
     if (fd == -1) {
+        fex_status = "Not Found!";
         goto err;
     }
 
@@ -302,6 +303,9 @@ err:
     if (shm_base != MAP_FAILED) {
         munmap(shm_base, shm_size);
     }
+
+    // Ensure no pid is being tracked
+    g_stats.pid = -1;
 }
 
 static void check_shm_update_necessary() {


### PR DESCRIPTION
When FEX is used in combination with gamescope+mangoapp, there are multiple tracked PIDs in flight. When window focus changes from a FEX tracked pid to something else, then the FEX tracking would have a stale pid.

This would effectively "freeze" the FEX stats in the overlay even when the process went away. So make sure when the pid has changed, and we don't find a FEX process that we update the tracked pid so the stats go away.