### PR TITLE
Fixes regarding `hide_fps_superscript` in `horizontal` mode and `fps_metrics` component.

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1652,9 +1652,11 @@ void HudElements::fps_metrics(){
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.0f", metric.value);
         ImGui::SameLine(0, 1.0f);
-        ImGui::PushFont(HUDElements.sw_stats->font_small);
-        HUDElements.TextColored(HUDElements.colors.text, "FPS");
-        ImGui::PopFont();
+        if(!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hide_fps_superscript]){
+            ImGui::PushFont(HUDElements.sw_stats->font_small);
+            HUDElements.TextColored(HUDElements.colors.text, "FPS");
+            ImGui::PopFont();
+        }
         ImguiNextColumnOrNewRow();
     }
 }

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -117,11 +117,6 @@ inline const char* engine_name(const swapchain_stats& sw_stats) {
       return "FPS";
    }
 
-   if (en[OVERLAY_PARAM_ENABLED_horizontal] && !en[OVERLAY_PARAM_ENABLED_engine_short_names]) {
-      en[OVERLAY_PARAM_ENABLED_hide_fps_superscript] = true;
-      return "FPS";
-   }
-
    if (en[OVERLAY_PARAM_ENABLED_dx_api]) {
       if (engine == EngineTypes::VKD3D)
          return "DX12";


### PR DESCRIPTION
Fixing new inconsistent behavior implemented during a rewrite e96a0bf 
Which is, with `horizontal` mode enabled and long names selected (lacking `engine_short_names` in the config), fps superscript remains hidden (even without the use of `hide_fps_superscript`) and engine name is replaced with an "FPS" text. 
This shouldn't happen when user prefers a long engine name to be present.

Additionally addressed issues provided by @ChrisLane discussed in pr #1821 related to a feature implemented in pr #1751.  

>> 1. FPS superscript still appears for FPS stats in the `fps_metrics` component.
>> 2. `hide_engine_names` does not override `engine_short_names` so if the latter appears in config, the former will not take effect.

> 1. I figured out how to get the hide_fps_superscript to influence the superscript in the fps_metrics component. […]
> 2. […] it seems like this point is already taken care of. hide_engine_names with or without engine_short_names does show just the big FPS text, and hides superscript in the main FPS meter in the process, but also disables the superscript in the fps_metrics component.
Let me know how this should be handled.