### PR TITLE
params: Fix DX10 and DX11 show as DX? and include DX3-8

### DIFF
--- a/src/overlay.h
+++ b/src/overlay.h
@@ -122,11 +122,11 @@ inline const char* engine_name(const swapchain_stats& sw_stats) {
          return "DX12";
 
       if (engine == EngineTypes::DXVK) {
-         if (sw_stats.applicationVersion == 1)
-            return "DX9";
+         if (sw_stats.applicationVersion == 0)
+            return "DX10,11";
 
-         if (sw_stats.applicationVersion == 2)
-            return "DX11";
+         if (sw_stats.applicationVersion == 1)
+            return "DX3-9";
 
          return "DX?";
       }


### PR DESCRIPTION
Fixed: #1906