### PR TITLE
cpu: fix cpu_power=0W on Zen 5 when cpu_temp is also enabled

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -359,21 +359,24 @@ static bool get_cpu_power_k10temp(CPUPowerData* cpuPowerData, float& power) {
 static bool get_cpu_power_zenpower(CPUPowerData* cpuPowerData, float& power) {
     CPUPowerData_zenpower* powerData_zenpower = (CPUPowerData_zenpower*)cpuPowerData;
 
-    if (!powerData_zenpower->corePowerFile || !powerData_zenpower->socPowerFile)
+    if (!powerData_zenpower->corePowerFile)
         return false;
 
     rewind(powerData_zenpower->corePowerFile);
-    rewind(powerData_zenpower->socPowerFile);
-
     fflush(powerData_zenpower->corePowerFile);
-    fflush(powerData_zenpower->socPowerFile);
 
-    int corePower, socPower;
+    int corePower = 0, socPower = 0;
 
     if (fscanf(powerData_zenpower->corePowerFile, "%d", &corePower) != 1)
         return false;
-    if (fscanf(powerData_zenpower->socPowerFile, "%d", &socPower) != 1)
-        return false;
+
+    // socPowerFile is null for zenpower5/Zen5 which reports a single RAPL_P_Package value
+    if (powerData_zenpower->socPowerFile) {
+        rewind(powerData_zenpower->socPowerFile);
+        fflush(powerData_zenpower->socPowerFile);
+        if (fscanf(powerData_zenpower->socPowerFile, "%d", &socPower) != 1)
+            return false;
+    }
 
     power = (corePower + socPower) / 1000000;
 
@@ -677,16 +680,25 @@ static CPUPowerData_zenpower* init_cpu_power_data_zenpower(const std::string pat
 
     std::string corePowerInput, socPowerInput;
 
-    if(!find_input(path, "power", corePowerInput, "SVI2_P_Core")) return nullptr;
-    if(!find_input(path, "power", socPowerInput, "SVI2_P_SoC")) return nullptr;
+    // Zen 4 and older: SVI2 separate core and SoC power rails
+    if(find_input(path, "power", corePowerInput, "SVI2_P_Core") &&
+       find_input(path, "power", socPowerInput, "SVI2_P_SoC")) {
+        SPDLOG_DEBUG("hwmon: using input: {}", corePowerInput);
+        SPDLOG_DEBUG("hwmon: using input: {}", socPowerInput);
+        powerData->corePowerFile = fopen(corePowerInput.c_str(), "r");
+        powerData->socPowerFile = fopen(socPowerInput.c_str(), "r");
+        return powerData.release();
+    }
 
-    SPDLOG_DEBUG("hwmon: using input: {}", corePowerInput);
-    SPDLOG_DEBUG("hwmon: using input: {}", socPowerInput);
+    // Zen 5 (zenpower5): single RAPL package power reading
+    if(find_input(path, "power", corePowerInput, "RAPL_P_Package")) {
+        SPDLOG_DEBUG("hwmon: using input (RAPL_P_Package): {}", corePowerInput);
+        powerData->corePowerFile = fopen(corePowerInput.c_str(), "r");
+        // socPowerFile intentionally left null; get_cpu_power_zenpower handles this
+        return powerData.release();
+    }
 
-    powerData->corePowerFile = fopen(corePowerInput.c_str(), "r");
-    powerData->socPowerFile = fopen(socPowerInput.c_str(), "r");
-
-    return powerData.release();
+    return nullptr;
 }
 
 static CPUPowerData_zenergy* init_cpu_power_data_zenergy(const std::string path) {
@@ -755,7 +767,7 @@ bool CPUStats::InitCpuPowerData() {
             cpuPowerData = (CPUPowerData*)init_cpu_power_data_k10temp(path);
         } else if (name == "zenpower") {
             cpuPowerData = (CPUPowerData*)init_cpu_power_data_zenpower(path);
-            break;
+            if (cpuPowerData) break;
         } else if (name == "zenergy") {
             cpuPowerData = (CPUPowerData*)init_cpu_power_data_zenergy(path);
             break;


### PR DESCRIPTION
Fixes #1794.

## Problem

On Zen 5 hardware with zenpower5-dkms-git loaded, `cpu_power` always shows 0W whenever `cpu_temp` is also present in the config. Removing `cpu_temp` makes power report correctly. The power data is available in sysfs — the issue is entirely in MangoHud's sensor scan logic.

Tested on Ryzen 7 9800X3D, kernel 6.17+, CachyOS.

## Root Cause

Three bugs interact to produce the symptom:

### 1. zenpower5 power label not recognised

`init_cpu_power_data_zenpower()` searches exclusively for SVI2 power labels:

```cpp
if(!find_input(path, "power", corePowerInput, "SVI2_P_Core")) return nullptr;
if(!find_input(path, "power", socPowerInput, "SVI2_P_SoC"))  return nullptr;
```

These labels are correct for Zen 2/3/4 (SVI2 voltage/current interface). zenpower5-dkms-git, which adds Zen 5 support, exposes power differently — a single RAPL package reading:

```
/sys/class/hwmon/hwmonN/power1_label  → "RAPL_P_Package"
/sys/class/hwmon/hwmonN/power1_input  → 41000000  (µW, ~41W at idle)
```

Neither SVI2 label is present, so `find_input` fails and the function returns `nullptr`.

### 2. Unconditional `break` prevents zenergy fallback

In `InitCpuPowerData()`:

```cpp
} else if (name == "zenpower") {
    cpuPowerData = (CPUPowerData*)init_cpu_power_data_zenpower(path);
    break;  // exits even if init returned nullptr
```

When zenpower is enumerated before zenergy, the loop breaks regardless of whether init succeeded. zenergy (hwmon at ISA bus, exporting `Esocket0` cumulative energy) would work as a fallback, but is never reached.

### 3. Why enabling `cpu_temp` triggers the failure

`GetCpuFile()` — called during `cpu_temp` initialisation — opens and stats files on the zenpower hwmon node. This warms the sysfs dcache entries for that device, which alters the `readdir()` hash bucket order on the subsequent `InitCpuPowerData()` call. The result is that zenpower appears before zenergy in the enumeration. Without `cpu_temp`, the ordering happens to put zenergy first (which succeeds immediately). With `cpu_temp`, zenpower comes first, fails silently, and the unconditional break exits the loop.

There is also a tertiary issue: a `static int retries` guard in `InitCpuPowerData()` gives up after 5 failed attempts and permanently sets a flag, leaving `m_cpuPowerData == nullptr` for the process lifetime. This cements the 0W display even if conditions later change.

## Fix

Three targeted changes to `src/cpu.cpp`:

**`init_cpu_power_data_zenpower`** — try SVI2 labels first (Zen 4 and older, existing path unchanged). If not found, try `RAPL_P_Package` (Zen 5 / zenpower5). Return `nullptr` only when neither is present.

**`get_cpu_power_zenpower`** — remove the early-return that required both `corePowerFile` and `socPowerFile` to be non-null. When `socPowerFile` is null (Zen 5 single-RAPL case), `socPower` stays 0 and only `corePower` is used.

**`InitCpuPowerData` loop** — change `break` to `if (cpuPowerData) break;` so that a failed zenpower init allows the loop to continue to zenergy.

Backward compatibility: Zen 4 and older zenpower (SVI2 labels present) takes the existing code path unchanged — the new `RAPL_P_Package` branch is only reached when SVI2 labels are absent.

## Test Results

```
# Hardware
CPU:    Ryzen 7 9800X3D (Zen 5)
Kernel: 7.0.3-1-cachyos
Driver: zenpower5-dkms-git
        power1_label = RAPL_P_Package
        power1_input ≈ 41 000 000 µW at idle
k10temp: blacklisted

# Before patch
MANGOHUD_CONFIG="cpu_temp,cpu_power" mangohud glxgears
→ cpu_power = 0W

# After patch
MANGOHUD_CONFIG="cpu_temp,cpu_power" mangohud glxgears
→ cpu_power ≈ 41W (correct, tracks load as expected)
```

Also verified that `MANGOHUD_CONFIG="cpu_power"` (without cpu_temp) still works correctly before and after the patch, and that the patch compiles cleanly with no warnings.