### PR TITLE
vulkan: wait for pending draw to complete before destroying its handles

### DIFF
--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -1502,6 +1502,11 @@ static void shutdown_swapchain_data(struct swapchain_data *data)
 
    for (auto draw : data->draws) {
       if (!draw) continue;
+
+      // Ensure pending draw has completed before releasing its handles.
+      VK_CHECK(device_data->vtable.WaitForFences(device_data->device, 1,
+                                                 &draw->fence, VK_TRUE, ~0ull));
+
       device_data->vtable.FreeCommandBuffers(device_data->device, data->command_pool, 1, &draw->command_buffer);
       device_data->vtable.DestroySemaphore(device_data->device, draw->cross_engine_semaphore, NULL);
       device_data->vtable.DestroySemaphore(device_data->device, draw->semaphore, NULL);


### PR DESCRIPTION
Fixes a synchronisation issue in shutdown_swapchain_data where vulkan objects were potentially released while in use by the GPU.

I had a strange issue earlier this month when opening the HUD would cause a crash. I created an issue for it in #2011.  It was really hard to reproduce and I thought it was caused by validation warnings that were fixed in later versions - unfortunately ran into the issue again just now.

I had a look into it and found a synchronisation issue. There may be more lurking around - I suspect there are many in vkBasalt as well (which is unmaintained!).