### PR TITLE
amdgpu: fix AMDGPU stats showing 0 due to invalid gpu_metrics data

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -267,10 +267,17 @@ void AMDGPU::get_instant_metrics(struct amdgpu_common_metrics *metrics) {
 	metrics->is_current_throttled = is_current;
 	metrics->is_temp_throttled    = is_temp;
 	metrics->is_other_throttled   = is_other;
+
+	// flipping this flag to true tells us that
+	// gpu_metrics gave us valid snapshot
+	gpu_metrics_sampled = true;
 }
 
 void AMDGPU::get_samples_and_copy(struct amdgpu_common_metrics metrics_buffer[METRICS_SAMPLE_COUNT], bool &gpu_load_needs_dividing) {
 	while (!stop_thread) {
+	    // resetting the flag
+	    gpu_metrics_sampled = false;
+
 		// Get all the samples
 		for (size_t cur_sample_id=0; cur_sample_id < METRICS_SAMPLE_COUNT; cur_sample_id++) {
 			if (gpu_metrics_is_valid)
@@ -301,7 +308,10 @@ void AMDGPU::get_samples_and_copy(struct amdgpu_common_metrics metrics_buffer[ME
 		metrics.proc_vram_used = fdinfo_helper->amdgpu_helper_get_proc_vram();
 #endif
 
-		if (gpu_metrics_is_valid) {
+        // gpu_metrics file must exist & is readable and
+        // amdgpu_common_metrics should've been populated with valid
+        // gpu_metrics values to overwrite valid sysfs values
+		if (gpu_metrics_is_valid && gpu_metrics_sampled) {
 			UPDATE_METRIC_AVERAGE(gpu_load_percent);
 			UPDATE_METRIC_AVERAGE_FLOAT(average_gfx_power_w);
 			UPDATE_METRIC_AVERAGE_FLOAT(average_cpu_power_w);

--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -515,6 +515,7 @@ class AMDGPU {
 		std::thread thread;
 		struct amdgpu_files sysfs_nodes = {};
 		bool gpu_metrics_is_valid = false;
+		bool gpu_metrics_sampled = false;
 		std::condition_variable cond_var;
 		std::atomic<bool> stop_thread{false};
         std::atomic<bool> paused{false};


### PR DESCRIPTION
**Issue:** AMDGPU stats displaying 0
Fixes #2028
Fixes #2038 

**Problem**
-

I understand that the current implementation uses a hybrid model where sysfs values act as the baseline and are overridden by `gpu_metrics` when available.

However, the override logic assumes that the presence of the `gpu_metrics` file implies valid and supported data. In practice, this is not always true, the file may exist and be readable even when the kernel/firmware reports unsupported or invalid metrics.

As a result, valid sysfs values are unconditionally overwritten by invalid `gpu_metrics` data, leading to GPU statistics incorrectly showing as 0.

**Fix** 
-

Introduce a validity tracking flag for `gpu_metrics` sampling.

The flag is set only when at least one `gpu_metrics` sample successfully produces valid and usable metric data. This indicates `gpu_metrics` is functional on the system and only then is `gpu_metrics` allowed to override sysfs values.

**Consideration** 
-

This fix preserves the existing hybrid model by allowing `gpu_metrics` to override sysfs values once at least one valid sample has been observed.

However, it may be worth reconsidering whether a single successful sample is sufficient, or if multiple consecutive valid samples should be required before enabling overrides.

**Screenshots**
-

**Before patch**
<img width="350" height="205" alt="before-patch" src="https://github.com/user-attachments/assets/818dddbd-c0eb-4020-a574-24ca663d0fe7" />


**After patch**
<img width="350" height="205" alt="after-patch" src="https://github.com/user-attachments/assets/d6e670da-d995-4e8f-b395-508c94d089f2" />
