### PR TITLE
Fix read_cfg setting causes items to show up in HUD twice for presets using legacy_layout=false

### DIFF
--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -813,7 +813,7 @@ parse_overlay_env(struct overlay_params *params,
       }
    }
 
-   presets(current_preset, params);
+   presets(current_preset, params, use_existing_preset);
    env = env_start;
 
    while ((num = parse_string(env, key, value)) != 0) {


### PR DESCRIPTION
This change fixes this issue: https://github.com/flightlessmango/MangoHud/issues/1566

This is my first contribution and I have done some basic testing if mangohud still works as expected after this change, but I might have missed something.