### PR TITLE
overlay: restore horizontal "FPS" label in gamescope

### DIFF
--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -854,7 +854,11 @@ void HudElements::fps(){
             right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%.0f", HUDElements.sw_stats->fps);
         }
         ImGui::SameLine(0, 1.0f);
-        if(!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hide_fps_superscript]){
+        // horizontal mode already shows "FPS" as the engine label
+        bool horizontal_fps_label = HUDElements.params->fps_text.empty() &&
+                                    HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal] &&
+                                    !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_engine_short_names];
+        if(!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hide_fps_superscript] && !horizontal_fps_label){
             ImGui::PushFont(HUDElements.sw_stats->font_small);
             HUDElements.TextColored(HUDElements.colors.text, "FPS");
             ImGui::PopFont();

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -117,6 +117,9 @@ inline const char* engine_name(const swapchain_stats& sw_stats) {
       return "FPS";
    }
 
+   if (en[OVERLAY_PARAM_ENABLED_horizontal] && !en[OVERLAY_PARAM_ENABLED_engine_short_names])
+      return "FPS";
+
    if (en[OVERLAY_PARAM_ENABLED_dx_api]) {
       if (engine == EngineTypes::VKD3D)
          return "DX12";


### PR DESCRIPTION
330c42a removed the horizontal block from engine_name() because its en[hide_fps_superscript] = true side effect leaked into the fps_metrics component. However, this regressed the horizontal overlay's FPS label back to showing GAMESCOPE instead.

Return the FPS label in horizontal mode directly instead of going through the shared flag, and suppress the now-redundant superscript locally in HudElements::fps().