### PR TITLE
MangoHud-Next: compilation under elogind

### DIFF
--- a/mangohud-next/ipc/meson.build
+++ b/mangohud-next/ipc/meson.build
@@ -1,4 +1,4 @@
-systemd_dep = dependency('libsystemd')
+systemd_dep = dependency('libsystemd', 'libelogind')
 
 ipc_inc = include_directories('.')
 
@@ -45,4 +45,5 @@ ipc_lib = static_library(
 ipc_dep = declare_dependency(
   link_with: ipc_lib,
   include_directories: [ipc_inc],
+  dependencies: [systemd_dep]
 )

--- a/mangohud-next/meson.build
+++ b/mangohud-next/meson.build
@@ -8,11 +8,11 @@ inc_common += [
 subdir('utils')
 vkbootstrap_dep = subproject('vk-bootstrap').get_variable('vkbootstrap_dep')
 libdrm_dep = dependency('libdrm')
+subdir('ipc')
 # subdir('render')
 if get_option('with_server')
   subdir('render')
 endif
-subdir('ipc')
 if get_option('with_server')
   subdir('server')
 endif

--- a/mangohud-next/render/imgui/meson.build
+++ b/mangohud-next/render/imgui/meson.build
@@ -3,6 +3,6 @@ subdir('font')
 mangohud_imgui = static_library(
     'mangohud_imgui',
     files('imgui_ctx.cpp'),
-    dependencies: [dearimgui_dep, spdlog_dep, vkbootstrap_dep, implot_dep],
+    dependencies: [dearimgui_dep, spdlog_dep, vkbootstrap_dep, implot_dep, ipc_dep],
     include_directories: inc_common
 )

--- a/mangohud-next/render/meson.build
+++ b/mangohud-next/render/meson.build
@@ -15,7 +15,8 @@ render_lib = static_library(
                    dependency('libdrm'),
                    dependency('gl'),
                    dependency('egl'),
-                   dep_vulkan_utility_libraries],
+                   dep_vulkan_utility_libraries,
+                   ipc_dep],
     link_with: mangohud_imgui,
     include_directories: inc_common
 

--- a/mangohud-next/server/metrics/meson.build
+++ b/mangohud-next/server/metrics/meson.build
@@ -12,7 +12,8 @@ metrics_lib = static_library(
                   vkbootstrap_dep,
                   dearimgui_dep,
                   implot_dep,
-                  vulkan_dep],
+                  vulkan_dep,
+                  ipc_dep],
     link_with: [cpu_lib,
                 gpu_lib],
     include_directories: utils_inc


### PR DESCRIPTION
Allows for mangohud-next to be compiled on systems with elogind as a logind provider instead of systemd when the system does not have systemd (i.e. openrc.)

Reasoning for adding IPC module to server, metrics, render and imgui, they all consume ipc headers and under elogind the headers are not under the system include dir but instead `elogind/systemd...`.