### PR TITLE
Add MagicPods headset battery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,8 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `custom_text`                      | Display a custom text e.g `custom_text=Fsync enabled`                                 |
 | `debug`                            | Shows the graph of gamescope app frametimes and latency (only on gamescope obviously) |
 | `device_battery_icon`              | Display wirless device battery icon.                                                  |
-| `device_battery`                   | Display wireless device battery percent. Currently supported arguments `gamepad` and `mouse` e.g `device_battery=gamepad,mouse` |
+| `device_battery`                   | Display wireless device battery percent. Currently supported arguments `gamepad`, `mouse`, and `headset` e.g `device_battery=gamepad,mouse,headset` |
+| `magicpods_url`                    | MagicPodsCore WebSocket endpoint for `device_battery=headset`, default `127.0.0.1:2020` |
 | `display_server`                   | Display the current display session (e.g. X11 or wayland)                             |
 | `dynamic_frame_timing`             | This changes frame_timing y-axis to correspond with the current maximum and minimum frametime instead of being a static 0-50 |
 | `engine_short_names`               | Display a short version of the used engine (e.g. `OGL` instead of `OpenGL`)           |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -145,8 +145,9 @@ cpu_stats
 ### Display battery information
 # battery
 # battery_icon
-# device_battery=gamepad,mouse
+# device_battery=gamepad,mouse,headset
 # device_battery_icon
+# magicpods_url=127.0.0.1:2020
 # battery_watt
 # battery_time
 

--- a/meson.build
+++ b/meson.build
@@ -308,6 +308,12 @@ if get_option('mangoapp')
   glfw3_dep = dependency('glfw3')
 endif
 
+if is_unixy and not get_option('with_magicpods').disabled()
+  nlohmann_json_dep = dependency('nlohmann_json', fallback: ['nlohmann_json', 'nlohmann_json_dep'], required: get_option('with_magicpods'))
+else
+  nlohmann_json_dep = null_dep
+endif
+
 subdir('src')
 
 if get_option('include_doc')
@@ -338,6 +344,33 @@ if get_option('tests').enabled()
   #   include_directories: inc_common)
 
   # test('test amdgpu', e, workdir : meson.project_source_root() + '/tests')
+
+  if nlohmann_json_dep.found()
+    src_inc = include_directories('src')
+
+    e = executable('ws_client', 'tests/test_ws_client.cpp',
+      files(
+        'src/ws_client.cpp'
+      ),
+      include_directories: [inc_common, src_inc])
+
+    test('test ws client', e, workdir : meson.project_source_root() + '/tests')
+
+    e = executable('magicpods_parse', 'tests/test_magicpods_parse.cpp',
+      files(
+        'src/magicpods.cpp',
+        'src/ws_client.cpp'
+      ),
+      cpp_args: ['-DHAVE_MAGICPODS'],
+      dependencies: [
+        nlohmann_json_dep,
+        spdlog_dep,
+        dep_pthread
+      ],
+      include_directories: [inc_common, src_inc])
+
+    test('test magicpods parse', e, workdir : meson.project_source_root() + '/tests')
+  endif
 
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,6 +7,7 @@ option('with_xnvctrl', type : 'feature', value : 'enabled', description: 'Enable
 option('with_x11', type : 'feature', value : 'enabled')
 option('with_wayland', type : 'feature', value : 'enabled')
 option('with_dbus', type : 'feature', value : 'enabled')
+option('with_magicpods', type : 'feature', value : 'enabled', description: 'Headset battery via MagicPodsCore WebSocket API')
 option('loglevel', type: 'combo', choices : ['trace', 'debug', 'info', 'warn', 'err', 'critical', 'off'], value : 'info', description: 'Max log level in non-debug build')
 option('mangoapp', type: 'boolean', value : false)
 option('mangohudctl', type: 'boolean', value : false)

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -29,6 +29,9 @@
 #include "ftrace.h"
 #include "winesync.h"
 #include "fps_limiter.h"
+#ifdef HAVE_MAGICPODS
+#include "magicpods.h"
+#endif
 
 #define CHAR_CELSIUS    "\xe2\x84\x83"
 #define CHAR_FAHRENHEIT "\xe2\x84\x89"
@@ -1394,9 +1397,10 @@ void HudElements::gamescope_frame_timing(){
 void HudElements::device_battery()
 {
 #ifdef __linux__
-    std::unique_lock<std::mutex> l(device_lock);
     if (!HUDElements.params->device_battery.empty()) {
-        if (device_found) {
+        {
+            std::unique_lock<std::mutex> l(device_lock);
+            if (device_found) {
             for (int i = 0; i < device_count; i++) {
                 std::string battery = device_data[i].battery;
                 std::string name = device_data[i].name;
@@ -1443,7 +1447,70 @@ void HudElements::device_battery()
                     ImGui::TableNextRow();
                 ImGui::PopFont();
             }
+            }
         }
+#ifdef HAVE_MAGICPODS
+        if (std::find(HUDElements.params->device_battery.begin(), HUDElements.params->device_battery.end(), "headset") != HUDElements.params->device_battery.end()) {
+            auto headset = MagicPods::snapshot();
+            if (headset.valid) {
+                auto slot_visible = [](const headset_slot& slot) {
+                    return (slot.status == 2 || slot.status == 3) && slot.battery >= 0;
+                };
+                auto add_slot = [&](std::string& text, const char* label, const headset_slot& slot) {
+                    if (!slot_visible(slot))
+                        return;
+                    if (!text.empty())
+                        text += " ";
+                    if (label && *label) {
+                        text += label;
+                        text += ":";
+                    }
+                    text += std::to_string(slot.battery);
+                    text += "%";
+                    if (slot.charging)
+                        text += ICON_FK_BOLT;
+                };
+
+                std::string status_text;
+                if (slot_visible(headset.single)) {
+                    add_slot(status_text, "", headset.single);
+                } else {
+                    add_slot(status_text, "L", headset.left);
+                    add_slot(status_text, "R", headset.right);
+                    add_slot(status_text, "C", headset.charging_case);
+                }
+
+                bool any_charging =
+                    (slot_visible(headset.single) && headset.single.charging) ||
+                    (slot_visible(headset.left) && headset.left.charging) ||
+                    (slot_visible(headset.right) && headset.right.charging) ||
+                    (slot_visible(headset.charging_case) && headset.charging_case.charging);
+                int min_level = 101;
+                for (const auto& slot : {headset.single, headset.left, headset.right, headset.charging_case}) {
+                    if (slot_visible(slot))
+                        min_level = std::min(min_level, static_cast<int>(slot.battery));
+                }
+
+                ImguiNextColumnFirstItem();
+                HUDElements.TextColored(HUDElements.colors.engine, "%s", headset.name.c_str());
+                ImguiNextColumnOrNewRow();
+                if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_device_battery_icon]) {
+                    if (any_charging)
+                        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", ICON_FK_USB);
+                    else if (min_level >= 75)
+                        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", ICON_FK_BATTERY_FULL);
+                    else if (min_level >= 50)
+                        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", ICON_FK_BATTERY_THREE_QUARTERS);
+                    else if (min_level >= 26)
+                        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", ICON_FK_BATTERY_HALF);
+                    else
+                        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", ICON_FK_BATTERY_QUARTER);
+                } else {
+                    right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%s", status_text.c_str());
+                }
+            }
+        }
+#endif
     }
 #endif
 }

--- a/src/magicpods.cpp
+++ b/src/magicpods.cpp
@@ -1,0 +1,311 @@
+#include "magicpods.h"
+
+#include "overlay_params.h"
+#include "ws_client.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cctype>
+#include <condition_variable>
+#include <mutex>
+#include <sstream>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#ifdef __linux__
+#include <pthread.h>
+#endif
+
+namespace {
+using json = nlohmann::json;
+using namespace std::chrono_literals;
+
+class MagicPodsService {
+public:
+   ~MagicPodsService()
+   {
+      stop();
+   }
+
+   void ensure(const overlay_params& params)
+   {
+      bool wanted = std::find(params.device_battery.begin(), params.device_battery.end(), "headset") != params.device_battery.end();
+      if (!wanted) {
+         stop();
+         return;
+      }
+
+      const std::string url = params.magicpods_url.empty() ? "127.0.0.1:2020" : params.magicpods_url;
+      {
+         std::lock_guard<std::mutex> lock(m_thread_mutex);
+         if (m_running && m_url == url)
+            return;
+      }
+
+      stop();
+
+      std::lock_guard<std::mutex> lock(m_thread_mutex);
+      m_url = url;
+      m_stop.store(false);
+      m_running = true;
+      m_thread = std::thread(&MagicPodsService::run, this);
+#ifdef __linux__
+      pthread_setname_np(m_thread.native_handle(), "mangohud-magicp");
+#endif
+   }
+
+   void stop()
+   {
+      {
+         std::lock_guard<std::mutex> lock(m_thread_mutex);
+         if (!m_running)
+            return;
+         m_stop.store(true);
+         m_cv.notify_all();
+      }
+
+      if (m_thread.joinable())
+         m_thread.join();
+
+      {
+         std::lock_guard<std::mutex> lock(m_thread_mutex);
+         m_running = false;
+      }
+      set_snapshot({});
+   }
+
+   headset_battery snapshot()
+   {
+      std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+      return m_snapshot;
+   }
+
+private:
+   struct endpoint {
+      std::string host = "127.0.0.1";
+      std::string port = "2020";
+      std::string path = "/";
+   };
+
+   static endpoint parse_url(std::string url)
+   {
+      endpoint ep;
+      const std::string scheme = "ws://";
+      if (url.rfind(scheme, 0) == 0)
+         url.erase(0, scheme.size());
+
+      auto slash = url.find('/');
+      std::string hostport = slash == std::string::npos ? url : url.substr(0, slash);
+      ep.path = slash == std::string::npos ? "/" : url.substr(slash);
+      if (ep.path.empty())
+         ep.path = "/";
+
+      if (!hostport.empty() && hostport.front() == '[') {
+         auto close = hostport.find(']');
+         if (close != std::string::npos) {
+            ep.host = hostport.substr(1, close - 1);
+            if (close + 2 <= hostport.size() && hostport[close + 1] == ':')
+               ep.port = hostport.substr(close + 2);
+            return ep;
+         }
+      }
+
+      auto colon = hostport.rfind(':');
+      if (colon != std::string::npos) {
+         ep.host = hostport.substr(0, colon);
+         ep.port = hostport.substr(colon + 1);
+      } else if (!hostport.empty()) {
+         ep.host = hostport;
+      }
+      if (ep.host.empty()) ep.host = "127.0.0.1";
+      if (ep.port.empty()) ep.port = "2020";
+      return ep;
+   }
+
+   void set_snapshot(const headset_battery& value)
+   {
+      std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+      m_snapshot = value;
+   }
+
+   bool wait_backoff(std::chrono::seconds delay)
+   {
+      std::unique_lock<std::mutex> lock(m_wait_mutex);
+      return m_cv.wait_for(lock, delay, [&] { return m_stop.load(); });
+   }
+
+   void run()
+   {
+      std::chrono::seconds backoff = 1s;
+      bool logged_down = false;
+
+      while (!m_stop.load()) {
+         auto ep = parse_url(m_url);
+         WebSocketClient ws;
+         if (!ws.connect(ep.host, ep.port, ep.path, 1000ms)) {
+            if (!logged_down) {
+               SPDLOG_INFO("MagicPodsCore WebSocket unavailable at {}:{}", ep.host, ep.port);
+               logged_down = true;
+            }
+            if (wait_backoff(backoff))
+               break;
+            backoff = std::min(backoff * 2, 30s);
+            continue;
+         }
+
+         SPDLOG_INFO("Connected to MagicPodsCore WebSocket at {}:{}", ep.host, ep.port);
+         logged_down = false;
+         backoff = 1s;
+         set_snapshot({});
+         ws.send_text("{\"method\":\"GetAll\"}");
+
+         while (!m_stop.load()) {
+            std::string msg;
+            auto status = ws.recv_message(msg, 1000ms);
+            if (status == WebSocketClient::RecvStatus::Timeout)
+               continue;
+            if (status != WebSocketClient::RecvStatus::Message) {
+               SPDLOG_DEBUG("MagicPodsCore WebSocket disconnected");
+               set_snapshot({});
+               break;
+            }
+
+            headset_battery next = snapshot();
+            if (MagicPods::parse_message(msg, next))
+               set_snapshot(next);
+         }
+      }
+   }
+
+   std::mutex m_thread_mutex;
+   std::thread m_thread;
+   bool m_running = false;
+   std::atomic<bool> m_stop {false};
+   std::condition_variable m_cv;
+   std::mutex m_wait_mutex;
+   std::string m_url = "127.0.0.1:2020";
+
+   std::mutex m_snapshot_mutex;
+   headset_battery m_snapshot;
+};
+
+MagicPodsService& service()
+{
+   static MagicPodsService instance;
+   return instance;
+}
+
+std::string sanitize_name(const json& value)
+{
+   std::string name = value.is_string() ? value.get<std::string>() : "HEADSET";
+   std::string out;
+   out.reserve(std::min<size_t>(name.size(), 24));
+   for (unsigned char c : name) {
+      if (out.size() >= 24)
+         break;
+      if (!std::isprint(c))
+         continue;
+      out.push_back(static_cast<char>(std::toupper(c)));
+   }
+   return out.empty() ? "HEADSET" : out;
+}
+
+headset_slot parse_slot(const json& root, const char* key)
+{
+   headset_slot slot;
+   if (!root.contains(key) || !root[key].is_object())
+      return slot;
+   const auto& obj = root[key];
+   int battery = obj.value("battery", -1);
+   int status = obj.value("status", 0);
+   slot.battery = static_cast<int8_t>(std::clamp(battery, 0, 100));
+   slot.status = static_cast<uint8_t>((status >= 0 && status <= 3) ? status : 0);
+   slot.charging = obj.value("charging", false);
+   return slot;
+}
+
+bool visible(const headset_slot& slot)
+{
+   return (slot.status == 2 || slot.status == 3) && slot.battery >= 0;
+}
+
+bool any_visible(const headset_battery& battery)
+{
+   return visible(battery.single) || visible(battery.left) ||
+          visible(battery.right) || visible(battery.charging_case);
+}
+
+void parse_info(const json& info, headset_battery& battery)
+{
+   if (!info.is_object() || info.empty() || !info.value("connected", false)) {
+      battery = {};
+      return;
+   }
+
+   if (!info.contains("capabilities") ||
+       !info["capabilities"].contains("battery") ||
+       !info["capabilities"]["battery"].is_object()) {
+      battery = {};
+      return;
+   }
+
+   headset_battery parsed;
+   parsed.name = sanitize_name(info.value("name", json("HEADSET")));
+   const auto& slots = info["capabilities"]["battery"];
+   parsed.single = parse_slot(slots, "single");
+   parsed.left = parse_slot(slots, "left");
+   parsed.right = parse_slot(slots, "right");
+   parsed.charging_case = parse_slot(slots, "case");
+   parsed.valid = any_visible(parsed);
+   battery = parsed;
+}
+}
+
+void MagicPods::ensure(const overlay_params& params)
+{
+   service().ensure(params);
+}
+
+headset_battery MagicPods::snapshot()
+{
+   return service().snapshot();
+}
+
+void MagicPods::stop()
+{
+   service().stop();
+}
+
+bool MagicPods::parse_message(const std::string& message, headset_battery& battery)
+{
+   if (message.size() > 64 * 1024)
+      return false;
+
+   json root = json::parse(message, nullptr, false);
+   if (root.is_discarded() || !root.is_object())
+      return false;
+
+   if (root.contains("init") && root["init"].is_object()) {
+      int api = root["init"].value("api", 0);
+      std::string version = root["init"].value("version", "");
+      SPDLOG_DEBUG("MagicPodsCore API {} version {}", api, version);
+      if (api != 0)
+         SPDLOG_WARN("MagicPodsCore API version {} differs from supported API 0", api);
+   }
+
+   if (root.contains("defaultbluetooth") && root["defaultbluetooth"].is_object() &&
+       root["defaultbluetooth"].value("enabled", true) == false) {
+      battery = {};
+      return true;
+   }
+
+   if (root.contains("info")) {
+      parse_info(root["info"], battery);
+      return true;
+   }
+
+   return false;
+}

--- a/src/magicpods.h
+++ b/src/magicpods.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+struct overlay_params;
+
+struct headset_slot {
+   int8_t battery = -1;
+   bool charging = false;
+   uint8_t status = 0;
+};
+
+struct headset_battery {
+   bool valid = false;
+   std::string name;
+   headset_slot single;
+   headset_slot left;
+   headset_slot right;
+   headset_slot charging_case;
+};
+
+class MagicPods {
+public:
+   static void ensure(const overlay_params& params);
+   static headset_battery snapshot();
+   static void stop();
+
+   static bool parse_message(const std::string& message, headset_battery& battery);
+};

--- a/src/meson.build
+++ b/src/meson.build
@@ -96,6 +96,14 @@ if is_unixy
     )
   endif
 
+  if nlohmann_json_dep.found()
+    pre_args += '-DHAVE_MAGICPODS'
+    vklayer_files += files(
+      'magicpods.cpp',
+      'ws_client.cpp',
+    )
+  endif
+
   opengl_files = files(
     'gl/glad.c',
     'gl/gl_renderer.cpp',
@@ -200,6 +208,7 @@ mangohud_static_lib = static_library(
     dep_dl,
     dep_rt,
     dep_pthread,
+    nlohmann_json_dep,
     vulkan_headers_dep,
     dep_vulkan_utility_libraries,
     windows_deps,

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -28,6 +28,9 @@
 #include "net.h"
 #include "fex.h"
 #include "ftrace.h"
+#ifdef HAVE_MAGICPODS
+#include "magicpods.h"
+#endif
 
 #ifdef __linux__
 #include <libgen.h>
@@ -130,6 +133,9 @@ void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
             device_info();
       }
    }
+#ifdef HAVE_MAGICPODS
+   MagicPods::ensure(params);
+#endif
    if (real_params->enabled[OVERLAY_PARAM_ENABLED_ram] || real_params->enabled[OVERLAY_PARAM_ENABLED_swap] || logger->is_active())
       update_meminfo();
    if (real_params->enabled[OVERLAY_PARAM_ENABLED_ram_temp])
@@ -224,6 +230,9 @@ static std::unique_ptr<hw_info_updater> hw_update_thread;
 
 void stop_hw_updater()
 {
+#ifdef HAVE_MAGICPODS
+   MagicPods::stop();
+#endif
    if (hw_update_thread)
       hw_update_thread.reset();
 }

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -643,6 +643,7 @@ parse_ftrace(const char *str) {
 #define parse_text_outline_color(s) parse_color(s)
 #define parse_text_outline_thickness(s) parse_float(s)
 #define parse_device_battery(s) parse_str_tokenize(s)
+#define parse_magicpods_url(s) parse_str(s)
 #define parse_network(s) parse_str_tokenize(s)
 #define parse_gpu_text(s) parse_str_tokenize(s)
 
@@ -925,6 +926,7 @@ static void set_param_defaults(struct overlay_params *params){
    params->fps_value = { 30, 60 };
    params->round_corners = 0;
    params->battery_color =0xff9078;
+   params->magicpods_url = "127.0.0.1:2020";
    params->fsr_steam_sharpness = -1;
    params->picmip = -17;
    params->af = -1;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -220,6 +220,7 @@ struct Tracepoint;
    OVERLAY_PARAM_CUSTOM(text_outline_thickness)      \
    OVERLAY_PARAM_CUSTOM(fps_text)                    \
    OVERLAY_PARAM_CUSTOM(device_battery)              \
+   OVERLAY_PARAM_CUSTOM(magicpods_url)               \
    OVERLAY_PARAM_CUSTOM(fps_metrics)                 \
    OVERLAY_PARAM_CUSTOM(network)                     \
    OVERLAY_PARAM_CUSTOM(gpu_list)                    \
@@ -363,6 +364,7 @@ struct overlay_params {
    unsigned text_outline_color;
    float text_outline_thickness;
    std::vector<std::string> device_battery;
+   std::string magicpods_url;
    std::vector<std::string> fps_metrics;
    std::vector<std::string> network;
    std::vector<unsigned> gpu_list;

--- a/src/ws_client.cpp
+++ b/src/ws_client.cpp
@@ -1,0 +1,426 @@
+#include "ws_client.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cctype>
+#include <cstring>
+#include <fcntl.h>
+#include <poll.h>
+#include <random>
+#include <sstream>
+#include <unistd.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+namespace {
+constexpr size_t MAX_WS_MESSAGE = 64 * 1024;
+constexpr auto HEADER_TIMEOUT = std::chrono::milliseconds(5000);
+constexpr const char* WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+uint32_t rol(uint32_t value, unsigned bits)
+{
+   return (value << bits) | (value >> (32 - bits));
+}
+
+std::array<uint8_t, 20> sha1(const std::string& input)
+{
+   uint64_t bit_len = static_cast<uint64_t>(input.size()) * 8;
+   std::string msg = input;
+   msg.push_back(static_cast<char>(0x80));
+   while ((msg.size() % 64) != 56)
+      msg.push_back(0);
+   for (int i = 7; i >= 0; --i)
+      msg.push_back(static_cast<char>((bit_len >> (i * 8)) & 0xff));
+
+   uint32_t h0 = 0x67452301;
+   uint32_t h1 = 0xefcdab89;
+   uint32_t h2 = 0x98badcfe;
+   uint32_t h3 = 0x10325476;
+   uint32_t h4 = 0xc3d2e1f0;
+
+   for (size_t offset = 0; offset < msg.size(); offset += 64) {
+      uint32_t w[80] {};
+      for (int i = 0; i < 16; ++i) {
+         size_t j = offset + i * 4;
+         w[i] = (static_cast<uint8_t>(msg[j]) << 24) |
+                (static_cast<uint8_t>(msg[j + 1]) << 16) |
+                (static_cast<uint8_t>(msg[j + 2]) << 8) |
+                static_cast<uint8_t>(msg[j + 3]);
+      }
+      for (int i = 16; i < 80; ++i)
+         w[i] = rol(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1);
+
+      uint32_t a = h0, b = h1, c = h2, d = h3, e = h4;
+      for (int i = 0; i < 80; ++i) {
+         uint32_t f, k;
+         if (i < 20) {
+            f = (b & c) | ((~b) & d);
+            k = 0x5a827999;
+         } else if (i < 40) {
+            f = b ^ c ^ d;
+            k = 0x6ed9eba1;
+         } else if (i < 60) {
+            f = (b & c) | (b & d) | (c & d);
+            k = 0x8f1bbcdc;
+         } else {
+            f = b ^ c ^ d;
+            k = 0xca62c1d6;
+         }
+         uint32_t temp = rol(a, 5) + f + e + k + w[i];
+         e = d;
+         d = c;
+         c = rol(b, 30);
+         b = a;
+         a = temp;
+      }
+
+      h0 += a; h1 += b; h2 += c; h3 += d; h4 += e;
+   }
+
+   std::array<uint8_t, 20> out {};
+   uint32_t h[5] {h0, h1, h2, h3, h4};
+   for (int i = 0; i < 5; ++i) {
+      out[i * 4] = (h[i] >> 24) & 0xff;
+      out[i * 4 + 1] = (h[i] >> 16) & 0xff;
+      out[i * 4 + 2] = (h[i] >> 8) & 0xff;
+      out[i * 4 + 3] = h[i] & 0xff;
+   }
+   return out;
+}
+
+std::string base64(const uint8_t* data, size_t size)
+{
+   static constexpr char alphabet[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+   std::string out;
+   out.reserve(((size + 2) / 3) * 4);
+   for (size_t i = 0; i < size; i += 3) {
+      uint32_t v = data[i] << 16;
+      if (i + 1 < size) v |= data[i + 1] << 8;
+      if (i + 2 < size) v |= data[i + 2];
+      out.push_back(alphabet[(v >> 18) & 0x3f]);
+      out.push_back(alphabet[(v >> 12) & 0x3f]);
+      out.push_back(i + 1 < size ? alphabet[(v >> 6) & 0x3f] : '=');
+      out.push_back(i + 2 < size ? alphabet[v & 0x3f] : '=');
+   }
+   return out;
+}
+
+bool random_bytes(uint8_t* data, size_t size)
+{
+   int fd = ::open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+   if (fd >= 0) {
+      size_t done = 0;
+      while (done < size) {
+         ssize_t ret = ::read(fd, data + done, size - done);
+         if (ret <= 0) break;
+         done += static_cast<size_t>(ret);
+      }
+      ::close(fd);
+      if (done == size) return true;
+   }
+
+   std::random_device rd;
+   for (size_t i = 0; i < size; ++i)
+      data[i] = static_cast<uint8_t>(rd());
+   return true;
+}
+
+std::string lower(std::string s)
+{
+   std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+      return static_cast<char>(std::tolower(c));
+   });
+   return s;
+}
+
+bool header_value(const std::string& headers, const std::string& key, std::string& value)
+{
+   std::istringstream in(headers);
+   std::string line;
+   std::string wanted = lower(key);
+   while (std::getline(in, line)) {
+      if (!line.empty() && line.back() == '\r')
+         line.pop_back();
+      auto colon = line.find(':');
+      if (colon == std::string::npos)
+         continue;
+      if (lower(line.substr(0, colon)) != wanted)
+         continue;
+      value = line.substr(colon + 1);
+      while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
+         value.erase(value.begin());
+      while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
+         value.pop_back();
+      return true;
+   }
+   return false;
+}
+
+bool send_all(int fd, const char* data, size_t size)
+{
+   size_t done = 0;
+   while (done < size) {
+      ssize_t ret = ::send(fd, data + done, size - done, MSG_NOSIGNAL);
+      if (ret < 0 && errno == EINTR)
+         continue;
+      if (ret <= 0)
+         return false;
+      done += static_cast<size_t>(ret);
+   }
+   return true;
+}
+}
+
+WebSocketClient::~WebSocketClient()
+{
+   close();
+}
+
+std::string WebSocketClient::websocket_accept(const std::string& key)
+{
+   auto digest = sha1(key + WS_GUID);
+   return base64(digest.data(), digest.size());
+}
+
+bool WebSocketClient::connect(const std::string& host, const std::string& port,
+                              const std::string& path, std::chrono::milliseconds timeout)
+{
+   close();
+
+   addrinfo hints {};
+   hints.ai_socktype = SOCK_STREAM;
+   hints.ai_family = AF_UNSPEC;
+
+   addrinfo* result = nullptr;
+   if (::getaddrinfo(host.c_str(), port.c_str(), &hints, &result) != 0)
+      return false;
+
+   auto deadline = std::chrono::steady_clock::now() + timeout;
+   for (addrinfo* ai = result; ai; ai = ai->ai_next) {
+      int fd = ::socket(ai->ai_family, ai->ai_socktype | SOCK_CLOEXEC, ai->ai_protocol);
+      if (fd < 0)
+         continue;
+
+      int flags = ::fcntl(fd, F_GETFL, 0);
+      ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+      int ret = ::connect(fd, ai->ai_addr, ai->ai_addrlen);
+      if (ret < 0 && errno != EINPROGRESS) {
+         ::close(fd);
+         continue;
+      }
+
+      auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+      if (remaining.count() < 0)
+         remaining = std::chrono::milliseconds(0);
+      pollfd pfd {fd, POLLOUT, 0};
+      ret = ::poll(&pfd, 1, static_cast<int>(remaining.count()));
+      if (ret > 0) {
+         int err = 0;
+         socklen_t len = sizeof(err);
+         if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0 && err == 0) {
+            ::fcntl(fd, F_SETFL, flags);
+            m_fd = fd;
+            break;
+         }
+      }
+      ::close(fd);
+   }
+   ::freeaddrinfo(result);
+
+   if (m_fd < 0)
+      return false;
+
+   std::array<uint8_t, 16> key_bytes {};
+   random_bytes(key_bytes.data(), key_bytes.size());
+   std::string key = base64(key_bytes.data(), key_bytes.size());
+   std::string request_path = path.empty() ? "/" : path;
+
+   std::ostringstream req;
+   req << "GET " << request_path << " HTTP/1.1\r\n"
+       << "Host: " << host << ":" << port << "\r\n"
+       << "Upgrade: websocket\r\n"
+       << "Connection: Upgrade\r\n"
+       << "Sec-WebSocket-Key: " << key << "\r\n"
+       << "Sec-WebSocket-Version: 13\r\n\r\n";
+   auto req_str = req.str();
+   if (!send_all(m_fd, req_str.data(), req_str.size())) {
+      close();
+      return false;
+   }
+
+   std::string response;
+   char c = 0;
+   auto header_deadline = std::chrono::steady_clock::now() + HEADER_TIMEOUT;
+   while (response.find("\r\n\r\n") == std::string::npos && response.size() < 8192) {
+      auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(header_deadline - std::chrono::steady_clock::now());
+      if (remaining.count() <= 0 || !read_exact(&c, 1, remaining)) {
+         close();
+         return false;
+      }
+      response.push_back(c);
+   }
+
+   if (response.rfind("HTTP/1.1 101", 0) != 0 && response.rfind("HTTP/1.0 101", 0) != 0) {
+      close();
+      return false;
+   }
+
+   std::string accept;
+   if (!header_value(response, "Sec-WebSocket-Accept", accept) || accept != websocket_accept(key)) {
+      close();
+      return false;
+   }
+
+   return true;
+}
+
+bool WebSocketClient::wait_readable(std::chrono::milliseconds timeout)
+{
+   pollfd pfd {m_fd, POLLIN, 0};
+   int ret = ::poll(&pfd, 1, static_cast<int>(timeout.count()));
+   return ret > 0 && (pfd.revents & POLLIN);
+}
+
+bool WebSocketClient::read_exact(void* data, size_t size, std::chrono::milliseconds timeout)
+{
+   uint8_t* out = static_cast<uint8_t*>(data);
+   size_t done = 0;
+   auto deadline = std::chrono::steady_clock::now() + timeout;
+   while (done < size) {
+      auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+      if (remaining.count() <= 0 || !wait_readable(remaining))
+         return false;
+      ssize_t ret = ::recv(m_fd, out + done, size - done, 0);
+      if (ret <= 0)
+         return false;
+      done += static_cast<size_t>(ret);
+   }
+   return true;
+}
+
+bool WebSocketClient::send_frame(uint8_t opcode, const std::string& payload)
+{
+   if (m_fd < 0 || payload.size() > MAX_WS_MESSAGE)
+      return false;
+
+   std::string frame;
+   frame.push_back(static_cast<char>(0x80 | opcode));
+   if (payload.size() < 126) {
+      frame.push_back(static_cast<char>(0x80 | payload.size()));
+   } else if (payload.size() <= 0xffff) {
+      frame.push_back(static_cast<char>(0x80 | 126));
+      frame.push_back(static_cast<char>((payload.size() >> 8) & 0xff));
+      frame.push_back(static_cast<char>(payload.size() & 0xff));
+   } else {
+      frame.push_back(static_cast<char>(0x80 | 127));
+      for (int i = 7; i >= 0; --i)
+         frame.push_back(static_cast<char>((payload.size() >> (i * 8)) & 0xff));
+   }
+
+   uint8_t mask[4] {};
+   random_bytes(mask, sizeof(mask));
+   frame.append(reinterpret_cast<char*>(mask), sizeof(mask));
+   for (size_t i = 0; i < payload.size(); ++i)
+      frame.push_back(static_cast<char>(payload[i] ^ mask[i % 4]));
+
+   return send_all(m_fd, frame.data(), frame.size());
+}
+
+bool WebSocketClient::send_text(const std::string& message)
+{
+   return send_frame(0x1, message);
+}
+
+WebSocketClient::RecvStatus WebSocketClient::recv_message(std::string& message, std::chrono::milliseconds timeout)
+{
+   message.clear();
+   if (m_fd < 0)
+      return RecvStatus::Closed;
+
+   auto deadline = std::chrono::steady_clock::now() + timeout;
+   while (true) {
+      uint8_t hdr[2] {};
+      auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+      if (remaining.count() <= 0)
+         return RecvStatus::Timeout;
+      if (!read_exact(hdr, sizeof(hdr), remaining))
+         return RecvStatus::Closed;
+
+      bool fin = hdr[0] & 0x80;
+      uint8_t opcode = hdr[0] & 0x0f;
+      bool masked = hdr[1] & 0x80;
+      uint64_t len = hdr[1] & 0x7f;
+      if (len == 126) {
+         uint8_t ext[2] {};
+         if (!read_exact(ext, sizeof(ext), remaining))
+            return RecvStatus::Closed;
+         len = (ext[0] << 8) | ext[1];
+      } else if (len == 127) {
+         uint8_t ext[8] {};
+         if (!read_exact(ext, sizeof(ext), remaining))
+            return RecvStatus::Closed;
+         len = 0;
+         for (uint8_t b : ext)
+            len = (len << 8) | b;
+      }
+      if (len > MAX_WS_MESSAGE)
+         return RecvStatus::Error;
+
+      uint8_t mask[4] {};
+      if (masked && !read_exact(mask, sizeof(mask), remaining))
+         return RecvStatus::Closed;
+
+      std::string payload;
+      payload.resize(static_cast<size_t>(len));
+      if (len && !read_exact(payload.data(), static_cast<size_t>(len), remaining))
+         return RecvStatus::Closed;
+      if (masked) {
+         for (size_t i = 0; i < payload.size(); ++i)
+            payload[i] ^= mask[i % 4];
+      }
+
+      if (opcode == 0x8)
+         return RecvStatus::Closed;
+      if (opcode == 0x9) {
+         send_frame(0xA, payload);
+         continue;
+      }
+      if (opcode == 0xA)
+         continue;
+      if (opcode != 0x0 && opcode != 0x1)
+         return RecvStatus::Error;
+
+      if (opcode == 0x1) {
+         m_fragment.clear();
+         m_fragment_opcode = opcode;
+      } else if (m_fragment_opcode == 0) {
+         return RecvStatus::Error;
+      }
+
+      if (m_fragment.size() + payload.size() > MAX_WS_MESSAGE)
+         return RecvStatus::Error;
+      m_fragment += payload;
+      if (fin) {
+         message = m_fragment;
+         m_fragment.clear();
+         m_fragment_opcode = 0;
+         return RecvStatus::Message;
+      }
+   }
+}
+
+void WebSocketClient::close()
+{
+   if (m_fd >= 0) {
+      send_frame(0x8, "");
+      ::shutdown(m_fd, SHUT_RDWR);
+      ::close(m_fd);
+      m_fd = -1;
+   }
+   m_fragment.clear();
+   m_fragment_opcode = 0;
+}

--- a/src/ws_client.h
+++ b/src/ws_client.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+class WebSocketClient {
+public:
+   enum class RecvStatus {
+      Message,
+      Timeout,
+      Closed,
+      Error,
+   };
+
+   WebSocketClient() = default;
+   ~WebSocketClient();
+
+   WebSocketClient(const WebSocketClient&) = delete;
+   WebSocketClient& operator=(const WebSocketClient&) = delete;
+
+   bool connect(const std::string& host, const std::string& port,
+                const std::string& path, std::chrono::milliseconds timeout);
+   bool send_text(const std::string& message);
+   RecvStatus recv_message(std::string& message, std::chrono::milliseconds timeout);
+   void close();
+
+   bool connected() const { return m_fd >= 0; }
+   int fd() const { return m_fd; }
+
+   static std::string websocket_accept(const std::string& key);
+
+private:
+   bool send_frame(uint8_t opcode, const std::string& payload);
+   bool read_exact(void* data, size_t size, std::chrono::milliseconds timeout);
+   bool wait_readable(std::chrono::milliseconds timeout);
+
+   int m_fd = -1;
+   std::string m_fragment;
+   uint8_t m_fragment_opcode = 0;
+};

--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = json
+source_url = https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+source_filename = json-3.11.3.tar.xz
+source_hash = d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
+patch_directory = nlohmann_json

--- a/subprojects/packagefiles/nlohmann_json/meson.build
+++ b/subprojects/packagefiles/nlohmann_json/meson.build
@@ -1,0 +1,5 @@
+project('nlohmann_json', 'cpp', version : '3.11.3')
+
+nlohmann_json_dep = declare_dependency(
+  include_directories : include_directories('include')
+)

--- a/tests/test_magicpods_parse.cpp
+++ b/tests/test_magicpods_parse.cpp
@@ -1,0 +1,87 @@
+#include "magicpods.h"
+
+#include <cassert>
+#include <string>
+
+static headset_battery parse(const std::string& msg)
+{
+   headset_battery battery;
+   bool changed = MagicPods::parse_message(msg, battery);
+   assert(changed);
+   return battery;
+}
+
+int main()
+{
+   auto tws = parse(R"json({
+      "info": {
+         "name": "AirPods Pro\u0001 Extra Long Headphone Name",
+         "connected": true,
+         "capabilities": {
+            "battery": {
+               "single": {"battery": 0, "charging": false, "status": 0},
+               "left": {"battery": 80, "charging": true, "status": 2},
+               "right": {"battery": 70, "charging": false, "status": 2},
+               "case": {"battery": 250, "charging": false, "status": 3}
+            }
+         }
+      }
+   })json");
+   assert(tws.valid);
+   assert(tws.name == "AIRPODS PRO EXTRA LONG H");
+   assert(tws.left.battery == 80);
+   assert(tws.left.charging);
+   assert(tws.right.battery == 70);
+   assert(tws.charging_case.battery == 100);
+   assert(!tws.single.status);
+
+   auto single = parse(R"json({
+      "info": {
+         "name": "Beats Flex",
+         "connected": true,
+         "capabilities": {
+            "battery": {
+               "single": {"battery": 95, "charging": false, "status": 2},
+               "left": {"battery": 0, "charging": false, "status": 0},
+               "right": {"battery": 0, "charging": false, "status": 0},
+               "case": {"battery": 0, "charging": false, "status": 0}
+            }
+         }
+      }
+   })json");
+   assert(single.valid);
+   assert(single.name == "BEATS FLEX");
+   assert(single.single.battery == 95);
+
+   auto missing_caps = parse(R"json({"info":{"name":"buds","connected":true}})json");
+   assert(!missing_caps.valid);
+
+   auto disconnected = parse(R"json({"info":{}})json");
+   assert(!disconnected.valid);
+
+   headset_battery existing = single;
+   assert(MagicPods::parse_message(R"json({"defaultbluetooth":{"enabled":false}})json", existing));
+   assert(!existing.valid);
+
+   existing = single;
+   assert(!MagicPods::parse_message("", existing));
+   assert(existing.valid);
+
+   auto hidden = parse(R"json({
+      "info": {
+         "name": "Hidden",
+         "connected": true,
+         "capabilities": {
+            "battery": {
+               "single": {"battery": 50, "charging": false, "status": 9},
+               "left": {"battery": 50, "charging": false, "status": 1},
+               "right": {"battery": 50, "charging": false, "status": 0},
+               "case": {"battery": 50, "charging": false, "status": 0}
+            }
+         }
+      }
+   })json");
+   assert(!hidden.valid);
+
+   return 0;
+}

--- a/tests/test_ws_client.cpp
+++ b/tests/test_ws_client.cpp
@@ -1,0 +1,10 @@
+#include "ws_client.h"
+
+#include <cassert>
+
+int main()
+{
+   assert(WebSocketClient::websocket_accept("dGhlIHNhbXBsZSBub25jZQ==") ==
+          "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+   return 0;
+}


### PR DESCRIPTION
## Summary
- add a minimal localhost WebSocket client and MagicPods service for headset battery snapshots
- support `device_battery=headset` plus `magicpods_url` in the legacy HUD path
- render single-slot and TWS headset battery rows, with icon-mode support
- add focused parser and WebSocket accept-vector tests

## Testing
- `./build.sh install`
- `ninja -C build/nlohmann-fallback-check test`
- manual MagicPodsCore API check against `ws://127.0.0.1:2020/` returned Beats Flex battery data
