### PR TITLE
Fix gpu stats for msm driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ Example output:
 		<th colspan="2">Intel Discrete</th>
 		<th>Intel Integrated</th>
 		<th>Panfrost/Panthor driver</th>
+		<th colspan="2">Qualcomm</th>
 	</tr>
 	<tr>
 		<th></th>
@@ -570,9 +571,13 @@ Example output:
 		<th>xe</th>
 		<th>i915/xe</th>
 		<th></th>
+		<th>msm_drm (kgsl)</th>
+		<th>msm_dpu</th>
 	</tr>
 	<tr>
 		<td>Usage%</td>
+		<td>🟢</td>
+		<td>🟢</td>
 		<td>🟢</td>
 		<td>🟢</td>
 		<td>🟢</td>
@@ -588,11 +593,15 @@ Example output:
 		<td>🟢</td>
 		<td>🔴</td>
 		<td>🟢</td>
+		<td>🟢</td>
+		<td>🟢</td>
 	</tr>
 	<tr>
 		<td>Junction Temperature</td>
 		<td>🔴</td>
 		<td>🟢</td>
+		<td>🔴</td>
+		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
@@ -606,6 +615,8 @@ Example output:
 		<td>🟢</td>
 		<td>🔴</td>
 		<td>🔴</td>
+		<td>🔴</td>
+		<td>🔴</td>
 	</tr>
 	<tr>
 		<td>Process VRAM</td>
@@ -615,11 +626,15 @@ Example output:
 		<td>🟢</td>
 		<td>🟢</td>
 		<td>🟢</td>
+		<td>🔴</td>
+		<td>🟢</td>
 	</tr>
 	<tr>
 		<td>System VRAM</td>
 		<td>🟢</td>
 		<td>🟢</td>
+		<td>🔴</td>
+		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
@@ -633,11 +648,15 @@ Example output:
 		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
+		<td>🔴</td>
+		<td>🔴</td>
 	</tr>
 	<tr>
 		<td>Memory Clock</td>
 		<td>🟢</td>
 		<td>🟢</td>
+		<td>🔴</td>
+		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
@@ -651,6 +670,8 @@ Example output:
 		<td>🟢</td>
 		<td>🟢</td>
 		<td>🟢</td>
+		<td>🟢</td>
+		<td>🔴</td>
 	</tr>
 	<tr>
 		<td>Power Usage</td>
@@ -658,6 +679,8 @@ Example output:
 		<td>🟢</td>
 		<td>🟢</td>
 		<td>🟢</td>
+		<td>🔴</td>
+		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
 	</tr>
@@ -669,6 +692,8 @@ Example output:
 		<td>🟢</td>
 		<td>🟢</td>
 		<td>🔴</td>
+		<td>🔴</td>
+		<td>🔴</td>
 	</tr>
 	<tr>
 		<td>Fan Speed</td>
@@ -678,6 +703,8 @@ Example output:
 		<td>🟢</td>
 		<td>🔴</td>
 		<td>🔴</td>
+		<td>🔴</td>
+		<td>🔴</td>
 	</tr>
 	<tr>
 		<td>Voltage</td>
@@ -685,6 +712,8 @@ Example output:
 		<td>🟢</td>
 		<td>🟢</td>
 		<td>🟢</td>
+		<td>🔴</td>
+		<td>🔴</td>
 		<td>🔴</td>
 		<td>🔴</td>
 	</tr>
@@ -703,3 +732,6 @@ Example output:
 #### Panfrost and Panthor notes
 - GPU usage requires `echo N | sudo tee /sys/class/drm/renderD*/device/profiling`
   - Where N is a number, 1 for panfrost and 3 for panthor.
+
+#### Qualcomm notes
+- GPU usage on `msm_dpu` shows usage of the current process, not total system usage

--- a/mangohud-next/server/metrics/gpu/msm/dpu.cpp
+++ b/mangohud-next/server/metrics/gpu/msm/dpu.cpp
@@ -38,3 +38,7 @@ int MSM_DPU::get_process_load(pid_t pid) {
 
     return static_cast<int>(::lroundf(result));
 }
+
+float MSM_DPU::get_process_vram_used(pid_t pid) {
+    return fdinfo.get_memory_used(pid, "drm-resident-memory");
+}

--- a/mangohud-next/server/metrics/gpu/msm/dpu.hpp
+++ b/mangohud-next/server/metrics/gpu/msm/dpu.hpp
@@ -28,4 +28,5 @@ public:
 
     // Process-related functions
     int     get_process_load(pid_t pid)         override;
+    float   get_process_vram_used(pid_t pid)    override;
 };

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -175,7 +175,7 @@ void GPU_fdinfo::find_hwmon_sensors()
 {
     std::string hwmon;
 
-    if (module == "msm")
+    if (module == "msm_dpu")
         hwmon = find_hwmon_sensor_dir("gpu");
     else if (module == "panfrost" || module == "panthor")
         hwmon = find_hwmon_sensor_dir("gpu_thermal");

--- a/src/gpu_fdinfo.cpp
+++ b/src/gpu_fdinfo.cpp
@@ -55,6 +55,11 @@ void GPU_fdinfo::find_fd()
                 client_id = val;
         }
 
+        // fixup mismatch between display engine and render engine drivers
+        if (module == "msm_dpu" && driver == "msm") {
+            driver = "msm_dpu";
+        }
+
         if (!driver.empty() && driver == module) {
             total++;
             SPDLOG_TRACE(

--- a/src/gpu_fdinfo.h
+++ b/src/gpu_fdinfo.h
@@ -144,8 +144,8 @@ public:
             drm_engine_type = "drm-engine-gfx";
             drm_memory_type = "drm-memory-vram";
         } else if (module == "msm_dpu") {
-            // msm driver does not report vram usage
             drm_engine_type = "drm-engine-gpu";
+            drm_memory_type = "drm-resident-memory";
         } else if (module == "msm_drm") {
             init_kgsl();
         } else if (module == "panfrost") {


### PR DESCRIPTION
Adreno-GPUs have split render and display nodes. As a result we sometimes deal with the `msm_dpu` module (for the display engine) or the `msm` module (for the render engine).

https://github.com/flightlessmango/MangoHud/pull/1704 and other PRs refactored the gpu detection logic in a way, where we don't set the module to `msm` anymore. This broke the logic in gpu_fdinfo in several place for this specific driver. This PR is trying to fix everything I was able to easily identify.

- 0b2badb fixes the hwmon sensor detection logic to test for `msm_dpu` instead of `msm` now. (It seems like this logic might have previously applied to the `msm_drm` driver as well, but I don't have a device to test that.) This fixes the displayed gpu temperature.
- eba872f adds a missing memory-type for msm, which is present in newer kernels and allows PVRAM to be used with this driver.
- 0be0cac fixes the mismatch between the render-driver read out from `fdinfo` and the stored `module` which referrs to the display-engine driver in our case. I am not sure, if there is a better/cleaner way to do this, but like this we are at least not re-introducing a separate `msm_driver` instance member. This fixes the gpu load and pvram being actually displayed.