### PR TITLE
next: engage the fps cap on VK_SUBOPTIMAL_KHR acquires

### DIFF
--- a/mangohud-next/client/layer.cpp
+++ b/mangohud-next/client/layer.cpp
@@ -379,7 +379,7 @@ public:
             fps_limiter = std::make_unique<fpsLimiter>(false);
 
         VkResult r = pDispatch->AcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex);
-        if (r == VK_SUCCESS)
+        if (r == VK_SUCCESS || r == VK_SUBOPTIMAL_KHR)
             fps_limiter->limit(false);
 
         return r;
@@ -392,7 +392,7 @@ public:
             fps_limiter = std::make_unique<fpsLimiter>(false);
 
         VkResult r = pDispatch->AcquireNextImage2KHR(device, pAcquireInfo, pImageIndex);
-        if (r == VK_SUCCESS)
+        if (r == VK_SUCCESS || r == VK_SUBOPTIMAL_KHR)
             fps_limiter->limit(false);
 
         return r;


### PR DESCRIPTION
The fps limiter only runs after image acquire returns VK_SUCCESS. When the swapchain goes suboptimal (common under XWayland, or while a resize is pending) acquire returns VK_SUBOPTIMAL_KHR instead, and the cap silently stops working.

The acquired image is still usable in that case, so pace on it as well. QueuePresentKHR already treats VK_SUBOPTIMAL_KHR the same as VK_SUCCESS.

Tested with vkcube under XWayland (returns VK_SUBOPTIMAL_KHR on every acquire): the cap doesn't engage before this change and holds the limit after.