### PR TITLE
next: fix per-client resource leaks in the server

### DIFF
--- a/mangohud-next/ipc/client.cpp
+++ b/mangohud-next/ipc/client.cpp
@@ -609,6 +609,12 @@ void Client::stop_and_join() {
     if (run_t.joinable()) {
         run_t.join();
     }
+
+    std::queue<std::packaged_task<void()>> drain;
+    {
+        std::lock_guard<std::mutex> lock(work_mtx);
+        work_q.swap(drain);
+    }
 }
 
 int Client::spdlog_msg(sd_bus_message* m, void* userdata, sd_bus_error*) {

--- a/mangohud-next/render/egl_ctx.cpp
+++ b/mangohud-next/render/egl_ctx.cpp
@@ -399,21 +399,7 @@ void EglCtx::destroy_dmabuf_res(dmabuf_t& dmabuf) {
         dmabuf.egl_res.image = EGL_NO_IMAGE;
     }
 
-    if (dmabuf.gbm.bo) {
-        gbm_bo_destroy(dmabuf.gbm.bo);
-        dmabuf.gbm.bo = nullptr;
-    }
-
-    if (dmabuf.gbm.dev) {
-        gbm_device_destroy(dmabuf.gbm.dev);
-        dmabuf.gbm.dev = nullptr;
-    }
-
-    dmabuf.gbm.fd.reset();
-    dmabuf.gbm.modifier = 0;
-    dmabuf.gbm.stride = 0;
-    dmabuf.gbm.offset = 0;
-    dmabuf.gbm.plane_size = 0;
+    dmabuf.gbm = {};
 }
 
 bool EglCtx::init_dmabuf(clientRes* r, dmabuf_t& dmabuf) {

--- a/mangohud-next/render/shared.h
+++ b/mangohud-next/render/shared.h
@@ -93,7 +93,36 @@ struct gbmBuffer {
     uint32_t fourcc = 0;
     uint64_t plane_size = 0;
 
-    gbmBuffer() {
+    gbmBuffer() = default;
+
+    gbmBuffer(const gbmBuffer&) = delete;
+    gbmBuffer& operator=(const gbmBuffer&) = delete;
+
+    gbmBuffer(gbmBuffer&& o) noexcept { *this = std::move(o); }
+
+    gbmBuffer& operator=(gbmBuffer&& o) noexcept {
+        if (this != &o) {
+            if (bo)
+                gbm_bo_destroy(bo);
+            if (dev)
+                gbm_device_destroy(dev);
+
+            dev = o.dev;
+            bo = o.bo;
+            fd = std::move(o.fd);
+            modifier = o.modifier;
+            stride = o.stride;
+            offset = o.offset;
+            fourcc = o.fourcc;
+            plane_size = o.plane_size;
+
+            o.dev = nullptr;
+            o.bo = nullptr;
+        }
+        return *this;
+    }
+
+    ~gbmBuffer() {
         if (bo)
             gbm_bo_destroy(bo);
 


### PR DESCRIPTION
The mangohud-next server builds per-client resources on connect and tears them down on disconnect. Over a session of game launches, its open fd count climbs until the server stops serving new clients, and two ownership bugs in that path leak file descriptors. A third problem is masked by the client leak: once the client is freed correctly, nothing keeps the per-renderer Vulkan context alive between connects, so it is rebuilt each time, leaking descriptors the driver never frees on teardown.

Fix 1:
The gbm device and buffer object backing each client's dmabuf were never freed. Their cleanup (`gbm_bo_destroy` and `gbm_device_destroy`) sat in a method named after the struct, `gbmBuffer()`, so it was the default constructor rather than the destructor and ran while the pointers were still null. Each client leaked its gbm render node descriptors. Own the device and buffer object through RAII, in a `gbmAlloc` that holds them in smart pointers with the right deleters, so they are released when the buffer is destroyed.

Fix 2:
The per-client work queue held tasks that owned the client. `send_dmabuf`, `send_config` and `frame_ready` each posted a lambda capturing a `shared_ptr` to the `Client`, and the queue is itself a member of that `Client`, so a queued task was a strong reference from the client back to itself. When a client disconnected with a frame still in flight, the leftover task kept the `Client` alive and nothing it owned was released: its two eventfds, its event loop sources, in-flight fences, and the Vulkan render context it referenced. Change the queue to hold `void(Client*)` tasks and pass in the `Client` pointer the handler already holds.

Fix 3:
The per-renderer Vulkan context was cached in a `weak_ptr`, held strongly only by the connected client, so it was destroyed once the last client referencing it went away and a fresh Vulkan instance and device were built on the next connect. Hold it in a `shared_ptr` so it is built once and shared. While here, drop `VkCtx::gbm_dev`: it was never read, `create_gbm` builds its own device from `phys_fd()`, and with the context now persistent `init_client` would recreate it per connect while the destructor runs once, leaking one each time.