### PR TITLE
next: send the client config once the bus is authenticated

### DIFF
--- a/mangohud-next/ipc/client.cpp
+++ b/mangohud-next/ipc/client.cpp
@@ -196,7 +196,6 @@ int Client::on_bus_disconnected(sd_bus_message *m, void *userdata, sd_bus_error 
 
 void Client::dbus_thread() {
     pthread_setname_np(pthread_self(), ("c_dbus " + std::to_string(pid)).substr(0, 15).c_str());
-    send_config();
 
     int r = sd_event_loop(event);
     if (r < 0 && !stop.load())
@@ -260,6 +259,8 @@ int Client::on_connect(sd_bus_message* m, void* userdata, sd_bus_error* ret_erro
     }
     self->pEngineName = engine;
     self->resources->api = static_cast<Backend>(raw_api);
+
+    self->send_config();
 
     return 0;
 }
@@ -419,6 +420,7 @@ void Client::send_config() {
             SPDLOG_DEBUG("failed to send message {}", r);
             return r;
         }
+        sd_bus_flush(self->bus);
         return 0;
     });
 }


### PR DESCRIPTION
The server sends each client its FPS cap over the per-client dbus connection. That config was queued from the client's dbus thread as soon as the thread started, before the peer-to-peer bus had finished authenticating. sd-bus holds outgoing messages until auth completes, and once it did nothing flushed the queued config, so it sat in the write buffer until the connection next woke for an unrelated reason about a second later.

Send the config from on_connect instead. That handler runs only after the client handshake arrives, which is the first point the bus is authenticated and a signal can actually be written, and flush it so it goes out immediately instead of waiting for the next loop wakeup.

With the change the config reaches the client within 1ms after connect instead of ~1 second, so the cap applies from the first presented frame.