### PR TITLE
cpu: reduce syscalls and avoid runtime fmt parsing

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <unistd.h>
 #include <sstream>
 #include <dirent.h>
 #include <string.h>
@@ -108,9 +109,9 @@ CPUStats::CPUStats()
 
 CPUStats::~CPUStats()
 {
-    if (m_cpuTempFile) {
-        fclose(m_cpuTempFile);
-        m_cpuTempFile = nullptr;
+    if (m_cpuTempFd != -1) {
+        close(m_cpuTempFd);
+        m_cpuTempFd = -1;
     }
 }
 
@@ -281,14 +282,23 @@ bool CPUStats::UpdateCoreMhz() {
 }
 
 bool CPUStats::ReadcpuTempFile(int& temp) {
-	if (!m_cpuTempFile)
+	if (m_cpuTempFd == -1)
 		return false;
-
-	rewind(m_cpuTempFile);
-	fflush(m_cpuTempFile);
-	bool ret = (fscanf(m_cpuTempFile, "%d", &temp) == 1);
-	temp = temp / 1000;
-
+    int ret = -1;
+    char buf[21];
+    /* lseek + read */
+    ssize_t read_sz = pread(m_cpuTempFd, buf, sizeof(buf), 0);
+    /* valid temp */
+    if (read_sz > 3) {
+        if (buf[read_sz] == '\n') /* sysfs guarantees newline? */
+            --read_sz;
+        /* extract degrees */
+        read_sz -= 3;
+        buf[read_sz] = '\0';
+        char *buf_e;
+        temp = strtol(buf, &buf_e, 10);
+        ret = buf_e - buf;
+    }
 	return ret;
 }
 
@@ -559,7 +569,7 @@ static void check_thermal_zones(std::string& path, std::string& input) {
 }
 
 bool CPUStats::GetCpuFile() {
-    if (m_cpuTempFile)
+    if (m_cpuTempFd != -1)
         return true;
 
     std::string name, path, input;
@@ -634,7 +644,7 @@ bool CPUStats::GetCpuFile() {
     }
 
     SPDLOG_INFO("hwmon: using input: {}", input);
-    m_cpuTempFile = fopen(input.c_str(), "r");
+    m_cpuTempFd = open(input.c_str(), O_RDONLY);
 
     return true;
 }
@@ -739,7 +749,6 @@ bool CPUStats::InitCpuPowerData() {
         return true;
 
     retries++;
-    
     std::string name, path;
     std::string hwmon = "/sys/class/hwmon/";
 
@@ -789,7 +798,6 @@ bool CPUStats::InitCpuPowerData() {
             }
         }
     }
-    
     if(cpuPowerData == nullptr) {
         SPDLOG_ERROR("Failed to initialize CPU power data");
         return false;

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -297,7 +297,7 @@ bool CPUStats::ReadcpuTempFile(int& temp) {
         buf[read_sz] = '\0';
         char *buf_e;
         const long n = strtol(buf, &buf_e, 10);
-        if (n != LONG_MIN && n != LONG_MAX) {
+        if (n >= INT_MIN && n <= INT_MAX) {
             temp = n;
             ret = buf_e - buf;
         }

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -296,8 +296,11 @@ bool CPUStats::ReadcpuTempFile(int& temp) {
         read_sz -= 3;
         buf[read_sz] = '\0';
         char *buf_e;
-        temp = strtol(buf, &buf_e, 10);
-        ret = buf_e - buf;
+        const long n = strtol(buf, &buf_e, 10);
+        if (n != LONG_MIN && n != LONG_MAX) {
+            temp = n;
+            ret = buf_e - buf;
+        }
     }
 	return ret;
 }

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -200,7 +200,7 @@ private:
    double m_cpuPeriod = 0;
    bool m_updatedCPUs = false; // TODO use caching or just update?
    bool m_inited = false;
-   FILE *m_cpuTempFile = nullptr;
+   int m_cpuTempFd = -1;
    std::unique_ptr<CPUPowerData> m_cpuPowerData;
 
    const std::map<std::string, std::string> intel_cores = {


### PR DESCRIPTION
Currently, ReadcpuTempFile() uses lseek() + read() internally and parses the temperature string with fscanf(). Now, pread(), directly reading from offset 0, avoids the double syscall from lseek() + read() and the internal locking in the stdio functions, and strtol() avoids the runtime format parsing and the variadic argument overhead from fscanf().