### PR TITLE
cpu: use hwmon reading if amdgpu reported CPU temp is 0

### DIFF
--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -295,7 +295,7 @@ bool CPUStats::ReadcpuTempFile(int& temp) {
 bool CPUStats::UpdateCpuTemp() {
     if (gpus) {
         for (auto gpu : gpus->available_gpus) {
-            if (gpu->is_apu()) {
+            if (gpu->is_apu() && gpu->metrics.apu_cpu_temp > 0) {
                 m_cpuDataTotal.temp = gpu->metrics.apu_cpu_temp;
                 return true;
             }


### PR DESCRIPTION
Right now, on my Strix Halo APU, my CPU temperature always reads as 0C even though k10temp is working and reporting Tctl and the amdgpu sensors output clearly shows no CPU temp value (just edge).

I took a quick look at the amdgpu format 3 handling and it's iterating through all the sensors which are "VALID" but all reporting zero, so it preferes that value over the one reported by k10temp.

My initial thought would be that we should prioritize the hwmon value for the CPU temp anyway, but this is the minimal change to continue prioritizing the amdgpu reported value and only fallback to hwmon if the reading is 0.