### PR TITLE
next: fdinfo: skip inaccessible process fd directories

### DIFF
--- a/mangohud-next/server/metrics/fdinfo.cpp
+++ b/mangohud-next/server/metrics/fdinfo.cpp
@@ -60,7 +60,9 @@ std::vector<std::string> FDInfoBase::find_fds() {
 
     std::vector<std::string> fds;
 
-    for (const auto& entry : fs::directory_iterator(path)) {
+    for (const auto& entry : fs::directory_iterator(
+        path, fs::directory_options::skip_permission_denied
+    )) {
         if (!entry.is_symlink())
             continue;
 


### PR DESCRIPTION
## What changed

Enumerate `/proc/<pid>/fd` with
`std::filesystem::directory_options::skip_permission_denied`.

This keeps the fdinfo poller from throwing when procfs exposes a process
directory but denies descriptor enumeration.

## Nested Desktop case

This was reproduced on a Steam Deck running:

- SteamOS 3.8.16, build 20260716.1
- MangoHud `0.8.3.rc1.r24.g33c2c7dd-3`
- Steam's Nested Desktop session (`SteamAppId=2871001439`), which runs
  `kwin_wayland` fullscreen under Gamescope

The KWin process belongs to the logged-in user, but procfs protects its file
descriptors. Both descriptor directories exist while enumeration fails with
`EACCES`:

```text
$ stat -c '%U:%G %a %A %n' /proc/$KWIN_PID/fd /proc/$KWIN_PID/fdinfo
root:root 500 dr-x------ /proc/$KWIN_PID/fd
deck:deck 555 dr-xr-xr-x /proc/$KWIN_PID/fdinfo

$ ls /proc/$KWIN_PID/fd
ls: cannot open directory '/proc/.../fd': Permission denied
```

The packaged MangoApp version enumerates `fdinfo` directly and aborts:

```text
terminate called after throwing an instance of
'ghc::filesystem::filesystem_error'
what(): Permission denied: '/proc/.../fdinfo'
gamescope-mangoapp.service: Failed with result 'core-dump'
```

Systemd restarts MangoApp repeatedly until its start limit is reached. The
built-in Gamescope performance overlay then disappears even though Steam still
reports it as enabled.

Current `master` discovers descriptors through `/proc/<pid>/fd` instead, but
that directory has the same access restriction in this case. Its unguarded
`std::filesystem::directory_iterator` can therefore fail in the same way.

## Result

For a protected process, the iterator now yields no descriptors instead of
terminating MangoApp. That process contributes no per-process fd metrics, while
the service and the rest of the performance overlay continue running. Normal
descriptor collection is unchanged.

## Validation

- `git diff --check`
- Full Ubuntu 24.04 GCC 13.3 Meson build with the upstream workflow options,
  tests enabled, `--werror`, and staged install
- Standalone C++17 regression probe against an unreadable directory:
  the default iterator throws `Permission denied`, while
  `skip_permission_denied` returns an empty iterator without an exception
