### PR TITLE
Improve AMD k10temp and Vega20 gpu_metrics compatibility

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -50,38 +50,112 @@ void AMDGPU::get_instant_metrics(struct amdgpu_common_metrics *metrics) {
 	}
 
 	bool is_power=false, is_current=false, is_temp=false, is_other=false;
-	if (header.format_revision == 1) {
-		// Desktop GPUs
-		if (buf.size() < sizeof(gpu_metrics_v1_3)) {
-			SPDLOG_DEBUG(
-				"amdgpu metrics file '{}' too small for gpu_metrics_v1_3 "
-				"(have {}, need {})",
-				gpu_metrics_path, buf.size(), sizeof(gpu_metrics_v1_3));
-			return;
+
+        if (header.format_revision == 1) {
+
+    switch(header.content_revision) {
+
+    case 0:
+        if (buf.size() < 80) {
+ 	    SPDLOG_DEBUG(
+       	        "gpu_metrics_v1_0 too small (have {}, need 80)",
+                buf.size());
+ 	    return;
+        }
+
+        {
+            const auto *m =
+                reinterpret_cast<const gpu_metrics_v1_0 *>(buf.data());
+
+            SPDLOG_DEBUG(
+                "v1_0 metrics: load={}, power_raw={}, gfxclk={}, uclk={}, temp={}",
+                 m->average_gfx_activity,
+                 m->average_socket_power,
+                 m->current_gfxclk,
+                 m->current_uclk,
+                 m->temperature_edge
+	     );
+
+            metrics->gpu_load_percent =
+                m->average_gfx_activity;
+
+            metrics->average_gfx_power_w =
+                m->average_socket_power;
+
+            metrics->current_gfxclk_mhz =
+                m->current_gfxclk;
+
+            metrics->current_uclk_mhz =
+                m->current_uclk;
+
+            if (m->temperature_edge != 0xffff)
+		{
+		 metrics->gpu_temp_c = m->temperature_edge;
 		}
+		else if (sysfs_nodes.temp)
+		{
+		  char buf[32];
 
-		const auto *amdgpu_metrics = reinterpret_cast<const gpu_metrics_v1_3 *>(buf.data());
-		metrics->gpu_load_percent = amdgpu_metrics->average_gfx_activity;
+		  rewind(sysfs_nodes.temp);
 
-		metrics->average_gfx_power_w = amdgpu_metrics->average_socket_power;
+	     if (fgets(buf, sizeof(buf), sysfs_nodes.temp))
+          	  metrics->gpu_temp_c = atoi(buf) / 1000;
+		}
+        }
 
-		metrics->current_gfxclk_mhz = amdgpu_metrics->current_gfxclk;
-		metrics->current_uclk_mhz = amdgpu_metrics->current_uclk;
+        return;
 
-		metrics->gpu_temp_c = amdgpu_metrics->temperature_edge;
-		metrics->fan_speed = amdgpu_metrics->current_fan_speed;
 
-		uint64_t indep = amdgpu_metrics->indep_throttle_status;
-		// RDNA 3 almost always shows the TEMP_HOTSPOT throtting flag,
-		// so clear that bit
-		indep &= ~(1ull << TEMP_HOTSPOT_BIT);  // your existing quirk
+    case 3:
+        if (buf.size() < sizeof(gpu_metrics_v1_3)) {
+            SPDLOG_DEBUG(
+                "gpu_metrics_v1_3 too small (have {}, need {})",
+                buf.size(),
+                sizeof(gpu_metrics_v1_3));
+            return;
+        }
 
-		is_power   = ((indep >> 0)  & 0xFF) != 0;
-		is_current = ((indep >> 16) & 0xFF) != 0;
-		is_temp    = ((indep >> 32) & 0xFFFF) != 0;
-		is_other   = ((indep >> 56) & 0xFF) != 0;
-		if (throttling)
-			throttling->indep_throttle_status = indep;
+        {
+                const auto *amdgpu_metrics =
+		    reinterpret_cast<const gpu_metrics_v1_3 *>(buf.data());
+
+                metrics->gpu_load_percent = amdgpu_metrics->average_gfx_activity;
+
+                if (amdgpu_metrics->average_socket_power != 0xffff)
+		    metrics->average_gfx_power_w =
+	        	amdgpu_metrics->average_socket_power;
+
+                metrics->current_gfxclk_mhz = amdgpu_metrics->current_gfxclk;
+                metrics->current_uclk_mhz = amdgpu_metrics->current_uclk;
+
+                metrics->gpu_temp_c = amdgpu_metrics->temperature_edge;
+                metrics->fan_speed = amdgpu_metrics->current_fan_speed;
+
+                uint64_t indep = amdgpu_metrics->indep_throttle_status;
+                // RDNA 3 almost always shows the TEMP_HOTSPOT throtting flag,
+                // so clear that bit
+                indep &= ~(1ull << TEMP_HOTSPOT_BIT);  // your existing quirk
+
+                is_power   = ((indep >> 0)  & 0xFF) != 0;
+                is_current = ((indep >> 16) & 0xFF) != 0;
+                is_temp    = ((indep >> 32) & 0xFFFF) != 0;
+                is_other   = ((indep >> 56) & 0xFF) != 0;
+                if (throttling)
+                        throttling->indep_throttle_status = indep;
+
+
+         }
+
+        return;
+
+
+    default:
+        SPDLOG_DEBUG(
+            "Unsupported amdgpu metrics content revision {}",
+            header.content_revision);
+        return;
+    }
+
 	} else if (header.format_revision == 2) {
 		// APUS
 		size_t needed = 0;

--- a/src/amdgpu.h
+++ b/src/amdgpu.h
@@ -30,6 +30,57 @@ struct metrics_table_header {
 	uint8_t				format_revision;
 	uint8_t				content_revision;
 };
+struct gpu_metrics_v1_0 {
+        struct metrics_table_header common_header;
+
+        uint16_t temperature_edge;
+        uint16_t temperature_hotspot;
+        uint16_t temperature_mem;
+        uint16_t temperature_vrgfx;
+        uint16_t temperature_vrsoc;
+        uint16_t temperature_vrmem;
+
+        uint16_t average_gfx_activity;
+        uint16_t average_umc_activity;
+
+        uint16_t average_socket_power;
+
+        uint64_t energy_accumulator;
+
+        uint64_t system_clock_counter;
+
+        uint16_t current_gfxclk;
+        uint16_t current_socclk;
+        uint16_t current_uclk;
+
+        uint16_t padding[18];
+};
+
+struct gpu_metrics_v1_0_ext {
+        struct metrics_table_header common_header;
+
+        uint16_t temperature_edge;
+        uint16_t temperature_hotspot;
+        uint16_t temperature_mem;
+        uint16_t temperature_vrgfx;
+        uint16_t temperature_vrsoc;
+        uint16_t temperature_vrmem;
+
+        uint16_t average_gfx_activity;
+        uint16_t average_umc_activity;
+
+        uint16_t average_socket_power;
+
+        uint64_t energy_accumulator;
+
+        uint64_t system_clock_counter;
+
+        uint16_t current_gfxclk;
+        uint16_t current_socclk;
+        uint16_t current_uclk;
+
+        uint16_t padding[22];
+};
 
 struct gpu_metrics_v1_3 {
 	struct metrics_table_header	common_header;

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -584,9 +584,12 @@ bool CPUStats::GetCpuFile() {
             find_input(path, "temp", input, "Package id 0");
             break;
         } else if ((name == "zenpower" || name == "k10temp")) {
-            if (!find_input(path, "temp", input, "Tdie"))
-                find_input(path, "temp", input, "Tctl");
-            break;
+   	    if (!find_input(path, "temp", input, "Tdie")) {
+     	        if (!find_input(path, "temp", input, "Tctl")) {
+                    find_fallback_input(path, "temp1", input);
+                }
+            }
+ 	    break;
         } else if (name == "atk0110") {
             find_input(path, "temp", input, "CPU Temperature");
             break;


### PR DESCRIPTION
This patch improves AMD hardware compatibility on older platforms.

Changes:

- Add k10temp fallback CPU temperature detection when Tdie/Tctl are unavailable.
- Add support for gpu_metrics v1.0 content_revision=0 used by older AMD GPUs such as Radeon VII (Vega20).
- Use hwmon temperature fallback when gpu_metrics exposes invalid temperature values (0xffff).

Tested on:

- AMD FX-8350 CPU (k10temp)
- AMD Radeon VII GPU (Vega20)
- Linux kernel amdgpu driver
- RADV Vulkan driver
- KDE Plasma on X11

The changes are backward compatible and keep existing newer gpu_metrics handling unchanged.

The patched build was installed using the standard Meson install process and verified to load correctly through the Vulkan implicit layer system.

On this older AMD platform MangoHud correctly reports:

- CPU temperature
- GPU temperature
- GPU power
- GPU core and memory clocks (GFXCLK/UCLK)