### PR TITLE
Add Super I/O (motherboard) fan support via hwmon

### DIFF
--- a/FAN_SUPERIO.md
+++ b/FAN_SUPERIO.md
@@ -50,10 +50,13 @@ Config lives in `~/.config/MangoHud/MangoHud.conf`.
 
 Two independent elements — enable either or both:
 
-| Element | Source | Label |
-|---------|--------|-------|
-| `fan`   | Steam Deck APU fan (`steamdeck_hwmon` → `fan1_input`) | `FAN` |
-| `cfan`  | Custom / Super I/O chip fan(s) | `CFAN` (or your label) |
+| Element | Source | Label | Label color |
+|---------|--------|-------|-------------|
+| `fan`   | Steam Deck APU fan (`steamdeck_hwmon` → `fan1_input`) | `FAN` | `fan_color` |
+| `cfan`  | Custom / Super I/O chip fan(s) | `CFAN` (or your label) | `cfan_color` |
+
+Each element has its own label color, e.g. `cfan_color=00ff00` (defaults to the same
+`eb5b5b` as `fan_color`).
 
 ### 1. Steam Deck fan
 

--- a/FAN_SUPERIO.md
+++ b/FAN_SUPERIO.md
@@ -1,0 +1,132 @@
+# MangoHud — Super I/O fan support (fork changes)
+
+This is a fork of [MangoHud](https://github.com/flightlessmango/MangoHud) that adds
+the ability to read **chassis / CPU / system fan RPM from Super I/O chips** via the
+Linux `hwmon` interface, and to display them in the overlay.
+
+This file documents *only* what differs from upstream MangoHud. For everything else,
+see the main [`README.md`](README.md).
+
+---
+
+## Why
+
+Stock MangoHud can only show two kinds of fan:
+
+- `gpu_fan` — the GPU's own fan (AMD RPM, or NVIDIA percentage)
+- `fan` — the **Steam Deck** APU fan only
+
+It has no way to read the **motherboard fan headers** (CPU fan, case fans, etc.).
+On a desktop those are wired to a Super I/O chip (Nuvoton, ITE, Fintek, …) which the
+kernel exposes through `hwmon`. This fork teaches the existing `fan` element to read
+those chips, with optional manual sensor selection for multi-fan boards.
+
+---
+
+## What changed
+
+| Area | Upstream | This fork |
+|------|----------|-----------|
+| `fan` element | Steam Deck only | Steam Deck **and** auto-detected Super I/O chip |
+| Sensor selection | n/a | New `fan_custom_sensor` option to pick exact chip + input(s) |
+| Multiple fans | n/a | Multiple labelled fans via `fan_custom_sensor` |
+
+### Touched source files
+- `src/overlay.cpp` — `find_active_fan_input()` helper and the rewritten `update_fan()`
+  auto-detection (Steam Deck → Super I/O).
+- `src/overlay_params.cpp` / `.h` — `fan_custom_sensor` parameter and its parser
+  (`parse_fan_custom_sensor`).
+- `src/hud_elements.cpp` / `.h`, `src/overlay.h` — overlay plumbing for rendering the
+  resolved fan(s).
+
+---
+
+## Usage
+
+Config lives in `~/.config/MangoHud/MangoHud.conf`.
+
+### 1. Auto-detect (simple case)
+
+```ini
+fan
+```
+
+`update_fan()` resolves the sensor **once** on first frame, then refreshes its RPM
+every update. Auto-detect order:
+
+1. **Steam Deck** — an hwmon named `steamdeck_hwmon` (uses `fan1_input`).
+2. **Super I/O** — the first hwmon whose `name` starts with a known prefix:
+
+   | Vendor   | Prefixes matched                        |
+   |----------|-----------------------------------------|
+   | Nuvoton  | `nct61`, `nct67`, `nct77` (incl. nct6799) |
+   | ITE      | `it86`, `it87`                          |
+   | Fintek   | `f7188`, `f8000`                        |
+   | Winbond  | `w836`, `w8362`, `w8377`                |
+   | SMSC     | `smsc`, `sch311`                        |
+
+   Within that chip it picks the **first spinning fan** — the lowest-numbered
+   `fanN_input` reporting a nonzero RPM (`find_active_fan_input()`).
+
+> **Caveat:** auto-detect only finds one fan, and only one that is *already spinning*
+> when the overlay starts. If the fan you want is idle at launch, or you have several
+> fans, use `fan_custom_sensor` below.
+
+### 2. Manual selection (recommended for desktops / multi-fan)
+
+```ini
+# single fan
+fan_custom_sensor=nct6799,fan2_input
+
+# multiple fans, with labels
+fan_custom_sensor=nct6799,fan2_input,CPU;nct6799,fan7_input,GPU
+```
+
+Format — one or more entries separated by `;`:
+
+```
+chip,input[,label]
+```
+
+- **chip** — matched against the hwmon `name` file (e.g. `nct6799`).
+- **input** — the raw sysfs filename (e.g. `fan2_input`).
+- **label** — optional display label. Defaults to `FAN` for a single sensor, or
+  `FAN1`, `FAN2`, … when several are configured.
+
+When `fan_custom_sensor` is set, auto-detection is skipped and one overlay entry is
+created per configured sensor.
+
+---
+
+## Finding your chip name and inputs
+
+List the hwmon chips and their live fan readings:
+
+```sh
+for d in /sys/class/hwmon/hwmon*; do
+  n=$(cat "$d/name" 2>/dev/null)
+  echo "== $n  ($d)"
+  for f in "$d"/fan*_input; do
+    [ -e "$f" ] && echo "   $(basename "$f") -> $(cat "$f") rpm"
+  done
+done
+```
+
+Use the printed `name` as **chip** and the `fanN_input` filename as **input** in
+`fan_custom_sensor`.
+
+If no Super I/O chip shows up, load the right kernel module (e.g.
+`sudo modprobe nct6775` for Nuvoton) — and run `sudo sensors-detect` from
+`lm_sensors` once if you haven't.
+
+---
+
+## Troubleshooting
+
+- **Nothing shows:** run with `MANGOHUD_CONFIG=fan` and check the debug log —
+  `update_fan()` emits `fan: using ...` / `fan: no fan sensor found` via `SPDLOG_DEBUG`
+  (build/run with debug logging enabled).
+- **Wrong fan picked:** auto-detect grabbed the first spinning fan — switch to an
+  explicit `fan_custom_sensor`.
+- **RPM reads `-1`:** the sysfs path returned empty or non-numeric; double-check the
+  exact `fanN_input` filename for that chip.

--- a/FAN_SUPERIO.md
+++ b/FAN_SUPERIO.md
@@ -18,8 +18,9 @@ Stock MangoHud can only show two kinds of fan:
 
 It has no way to read the **motherboard fan headers** (CPU fan, case fans, etc.).
 On a desktop those are wired to a Super I/O chip (Nuvoton, ITE, Fintek, …) which the
-kernel exposes through `hwmon`. This fork teaches the existing `fan` element to read
-those chips, with optional manual sensor selection for multi-fan boards.
+kernel exposes through `hwmon`. This fork adds a dedicated **`cfan`** element that reads
+those chips, with optional manual sensor selection for multi-fan boards, while leaving
+the original **`fan`** element for the Steam Deck fan.
 
 ---
 
@@ -27,17 +28,19 @@ those chips, with optional manual sensor selection for multi-fan boards.
 
 | Area | Upstream | This fork |
 |------|----------|-----------|
-| `fan` element | Steam Deck only | Steam Deck **and** auto-detected Super I/O chip |
-| Sensor selection | n/a | New `fan_custom_sensor` option to pick exact chip + input(s) |
-| Multiple fans | n/a | Multiple labelled fans via `fan_custom_sensor` |
+| `fan` element | Steam Deck only | Steam Deck only (unchanged) |
+| `cfan` element | n/a | **New** — auto-detected Super I/O chip fan |
+| Sensor selection | n/a | New `fan_custom_sensor` option to pick exact chip + input(s) for `cfan` |
+| Multiple fans | n/a | Multiple labelled fans on `cfan` via `fan_custom_sensor` |
 
 ### Touched source files
-- `src/overlay.cpp` — `find_active_fan_input()` helper and the rewritten `update_fan()`
-  auto-detection (Steam Deck → Super I/O).
-- `src/overlay_params.cpp` / `.h` — `fan_custom_sensor` parameter and its parser
-  (`parse_fan_custom_sensor`).
-- `src/hud_elements.cpp` / `.h`, `src/overlay.h` — overlay plumbing for rendering the
-  resolved fan(s).
+- `src/overlay.cpp` — `find_active_fan_input()` helper and the rewritten `update_fan()`,
+  which now fills two lists: `fan_sensors` (Steam Deck) and `cfan_sensors`
+  (custom / Super I/O).
+- `src/overlay_params.cpp` / `.h` — the `cfan` boolean element plus the
+  `fan_custom_sensor` parameter and its parser (`parse_fan_custom_sensor`).
+- `src/hud_elements.cpp` / `.h`, `src/overlay.h` — `HudElements::cfan()` render function
+  and overlay plumbing for the resolved fan(s).
 
 ---
 
@@ -45,36 +48,50 @@ those chips, with optional manual sensor selection for multi-fan boards.
 
 Config lives in `~/.config/MangoHud/MangoHud.conf`.
 
-### 1. Auto-detect (simple case)
+Two independent elements — enable either or both:
+
+| Element | Source | Label |
+|---------|--------|-------|
+| `fan`   | Steam Deck APU fan (`steamdeck_hwmon` → `fan1_input`) | `FAN` |
+| `cfan`  | Custom / Super I/O chip fan(s) | `CFAN` (or your label) |
+
+### 1. Steam Deck fan
 
 ```ini
 fan
 ```
 
+Reads the Steam Deck's `steamdeck_hwmon` sensor. No effect on other hardware.
+
+### 2. Super I/O auto-detect (desktops)
+
+```ini
+cfan
+```
+
 `update_fan()` resolves the sensor **once** on first frame, then refreshes its RPM
-every update. Auto-detect order:
+every update. `cfan` auto-detect picks the first hwmon whose `name` starts with a known
+Super I/O prefix:
 
-1. **Steam Deck** — an hwmon named `steamdeck_hwmon` (uses `fan1_input`).
-2. **Super I/O** — the first hwmon whose `name` starts with a known prefix:
+| Vendor   | Prefixes matched                        |
+|----------|-----------------------------------------|
+| Nuvoton  | `nct61`, `nct67`, `nct77` (incl. nct6799) |
+| ITE      | `it86`, `it87`                          |
+| Fintek   | `f7188`, `f8000`                        |
+| Winbond  | `w836`, `w8362`, `w8377`                |
+| SMSC     | `smsc`, `sch311`                        |
 
-   | Vendor   | Prefixes matched                        |
-   |----------|-----------------------------------------|
-   | Nuvoton  | `nct61`, `nct67`, `nct77` (incl. nct6799) |
-   | ITE      | `it86`, `it87`                          |
-   | Fintek   | `f7188`, `f8000`                        |
-   | Winbond  | `w836`, `w8362`, `w8377`                |
-   | SMSC     | `smsc`, `sch311`                        |
-
-   Within that chip it picks the **first spinning fan** — the lowest-numbered
-   `fanN_input` reporting a nonzero RPM (`find_active_fan_input()`).
+Within that chip it picks the **first spinning fan** — the lowest-numbered
+`fanN_input` reporting a nonzero RPM (`find_active_fan_input()`).
 
 > **Caveat:** auto-detect only finds one fan, and only one that is *already spinning*
 > when the overlay starts. If the fan you want is idle at launch, or you have several
 > fans, use `fan_custom_sensor` below.
 
-### 2. Manual selection (recommended for desktops / multi-fan)
+### 3. Manual selection for `cfan` (recommended for desktops / multi-fan)
 
 ```ini
+cfan
 # single fan
 fan_custom_sensor=nct6799,fan2_input
 
@@ -123,9 +140,9 @@ If no Super I/O chip shows up, load the right kernel module (e.g.
 
 ## Troubleshooting
 
-- **Nothing shows:** run with `MANGOHUD_CONFIG=fan` and check the debug log —
-  `update_fan()` emits `fan: using ...` / `fan: no fan sensor found` via `SPDLOG_DEBUG`
-  (build/run with debug logging enabled).
+- **Nothing shows:** run with `MANGOHUD_CONFIG=cfan` (or `fan`) and check the debug log —
+  `update_fan()` emits `fan: using ...` / `cfan: using ...` / `fan: no fan sensor found`
+  via `SPDLOG_DEBUG` (build/run with debug logging enabled).
 - **Wrong fan picked:** auto-detect grabbed the first spinning fan — switch to an
   explicit `fan_custom_sensor`.
 - **RPM reads `-1`:** the sysfs path returned empty or non-numeric; double-check the

--- a/FAN_SUPERIO.md
+++ b/FAN_SUPERIO.md
@@ -30,15 +30,16 @@ the original **`fan`** element for the Steam Deck fan.
 |------|----------|-----------|
 | `fan` element | Steam Deck only | Steam Deck only (unchanged) |
 | `cfan` element | n/a | **New** — auto-detected Super I/O chip fan |
-| Sensor selection | n/a | New `fan_custom_sensor` option to pick exact chip + input(s) for `cfan` |
-| Multiple fans | n/a | Multiple labelled fans on `cfan` via `fan_custom_sensor` |
+| Sensor selection | n/a | New `cfan_custom_sensor` option to pick exact chip + input(s) for `cfan` |
+| Multiple fans | n/a | Multiple labelled fans on `cfan` via `cfan_custom_sensor` |
 
 ### Touched source files
 - `src/overlay.cpp` — `find_active_fan_input()` helper and the rewritten `update_fan()`,
   which now fills two lists: `fan_sensors` (Steam Deck) and `cfan_sensors`
   (custom / Super I/O).
 - `src/overlay_params.cpp` / `.h` — the `cfan` boolean element plus the
-  `fan_custom_sensor` parameter and its parser (`parse_fan_custom_sensor`).
+  `fan_custom_sensor` / `cfan_custom_sensor` parameters and their shared parser
+  (`parse_fan_custom_sensor`).
 - `src/hud_elements.cpp` / `.h`, `src/overlay.h` — `HudElements::cfan()` render function
   and overlay plumbing for the resolved fan(s).
 
@@ -58,13 +59,20 @@ Two independent elements — enable either or both:
 Each element has its own label color, e.g. `cfan_color=00ff00` (defaults to the same
 `eb5b5b` as `fan_color`).
 
-### 1. Steam Deck fan
+### 1. The `fan` element
 
 ```ini
 fan
 ```
 
-Reads the Steam Deck's `steamdeck_hwmon` sensor. No effect on other hardware.
+By default reads the Steam Deck's `steamdeck_hwmon` sensor. On other hardware you can
+point it at any hwmon sensor with `fan_custom_sensor` (same format as
+`cfan_custom_sensor`, described below):
+
+```ini
+fan
+fan_custom_sensor=nct6799,fan7_input,CPU
+```
 
 ### 2. Super I/O auto-detect (desktops)
 
@@ -89,17 +97,17 @@ Within that chip it picks the **first spinning fan** — the lowest-numbered
 
 > **Caveat:** auto-detect only finds one fan, and only one that is *already spinning*
 > when the overlay starts. If the fan you want is idle at launch, or you have several
-> fans, use `fan_custom_sensor` below.
+> fans, use `cfan_custom_sensor` below.
 
 ### 3. Manual selection for `cfan` (recommended for desktops / multi-fan)
 
 ```ini
 cfan
 # single fan
-fan_custom_sensor=nct6799,fan2_input
+cfan_custom_sensor=nct6799,fan2_input
 
 # multiple fans, with labels
-fan_custom_sensor=nct6799,fan2_input,CPU;nct6799,fan7_input,GPU
+cfan_custom_sensor=nct6799,fan2_input,CPU;nct6799,fan7_input,GPU
 ```
 
 Format — one or more entries separated by `;`:
@@ -113,7 +121,7 @@ chip,input[,label]
 - **label** — optional display label. Defaults to `FAN` for a single sensor, or
   `FAN1`, `FAN2`, … when several are configured.
 
-When `fan_custom_sensor` is set, auto-detection is skipped and one overlay entry is
+When `cfan_custom_sensor` is set, auto-detection is skipped and one overlay entry is
 created per configured sensor.
 
 ---
@@ -133,7 +141,7 @@ done
 ```
 
 Use the printed `name` as **chip** and the `fanN_input` filename as **input** in
-`fan_custom_sensor`.
+`cfan_custom_sensor`.
 
 If no Super I/O chip shows up, load the right kernel module (e.g.
 `sudo modprobe nct6775` for Nuvoton) — and run `sudo sensors-detect` from
@@ -147,6 +155,6 @@ If no Super I/O chip shows up, load the right kernel module (e.g.
   `update_fan()` emits `fan: using ...` / `cfan: using ...` / `fan: no fan sensor found`
   via `SPDLOG_DEBUG` (build/run with debug logging enabled).
 - **Wrong fan picked:** auto-detect grabbed the first spinning fan — switch to an
-  explicit `fan_custom_sensor`.
+  explicit `cfan_custom_sensor`.
 - **RPM reads `-1`:** the sysfs path returned empty or non-numeric; double-check the
   exact `fanN_input` filename for that chip.

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `refresh_rate`                     | Display the current refresh rate (only works in gamescope)                            |
 | `full`                             | Enable most of the toggleable parameters (currently excludes `histogram`)             |
 | `gamemode`                         | Show if GameMode is on                                                                |
-| `gpu_color`<br>`cpu_color`<br>`vram_color`<br>`ram_color`<br>`io_color`<br>`engine_color`<br>`fan_color`<br>`frametime_color`<br>`background_color`<br>`text_color`<br>`media_player_color`<br>`network_color`         | Change default colors: `gpu_color=RRGGBB` |
+| `gpu_color`<br>`cpu_color`<br>`vram_color`<br>`ram_color`<br>`io_color`<br>`engine_color`<br>`fan_color`<br>`cfan_color`<br>`frametime_color`<br>`background_color`<br>`text_color`<br>`media_player_color`<br>`network_color`         | Change default colors: `gpu_color=RRGGBB` |
 | `gpu_core_clock`<br>`gpu_mem_clock`| Display GPU core/memory frequency                                                     |
 | `gpu_fan`                          | GPU fan in RPM, except NVIDIA where it is a percentage |
 | `gpu_load_change`                  | Change the color of the GPU load depending on load                                    |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and m
 
 > **Fork note:** This fork adds **Super I/O fan support**. The `fan` element shows the
 > Steam Deck fan, and a new **`cfan`** element shows motherboard / Super I/O chip fans
-> (Nuvoton, ITE, Fintek, Winbond, SMSC) via `hwmon`, with `fan_custom_sensor` for manual
+> (Nuvoton, ITE, Fintek, Winbond, SMSC) via `hwmon`, with `cfan_custom_sensor` for manual
 > selection and `cfan_color` for its label color. See [`FAN_SUPERIO.md`](FAN_SUPERIO.md)
 > for full details.
 
@@ -383,9 +383,10 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `engine_version`                   | Display OpenGL or vulkan and vulkan-based render engine's version                     |
 | `exec`                             | Display output of bash command in next column, e.g. `custom_text=/home` , `exec=df -h /home \| tail -n 1`. Only works with `legacy_layout=0` |
 | `exec_name`                        | Display current exec name                                                             |
-| `fan`                              | Shows the Steam Deck fan rpm. |
-| `cfan`                             | Shows custom / Super I/O fan rpm. Auto-detects a Super I/O chip (e.g. nct6799) and picks the first spinning fan, or uses `fan_custom_sensor` if set. |
-| `fan_custom_sensor`                | Selects the hwmon sensor(s) used by `cfan`. One or more `chip,input[,label]` entries separated by `;`. e.g `fan_custom_sensor=nct6799,fan2_input` or `fan_custom_sensor=nct6799,fan2_input,CPU;nct6799,fan7_input,GPU`. |
+| `fan`                              | Shows fan rpm. Auto-detects the Steam Deck fan, or uses `fan_custom_sensor` if set. |
+| `fan_custom_sensor`                | Selects the hwmon sensor(s) used by `fan`. One or more `chip,input[,label]` entries separated by `;`. e.g `fan_custom_sensor=nct6799,fan2_input` or `fan_custom_sensor=nct6799,fan2_input,CPU;nct6799,fan7_input,GPU`. |
+| `cfan`                             | Shows custom / Super I/O fan rpm. Auto-detects a Super I/O chip (e.g. nct6799) and picks the first spinning fan, or uses `cfan_custom_sensor` if set. |
+| `cfan_custom_sensor`                | Selects the hwmon sensor(s) used by `cfan`. Same `chip,input[,label]` format as `fan_custom_sensor`, separated by `;`. e.g `cfan_custom_sensor=nct6799,fan2_input,RAD;nct6799,fan4_input,BTM`. |
 | `fcat`                             | Enables frame capture analysis                                                        |
 | `fcat_overlay_width=`              | Sets the width of fcat. Default is `24`                                               |
 | `fcat_screen_edge=`                | Decides the edge fcat is displayed on. A value between `1` and `4`                    |

--- a/README.md
+++ b/README.md
@@ -377,8 +377,9 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `engine_version`                   | Display OpenGL or vulkan and vulkan-based render engine's version                     |
 | `exec`                             | Display output of bash command in next column, e.g. `custom_text=/home` , `exec=df -h /home \| tail -n 1`. Only works with `legacy_layout=0` |
 | `exec_name`                        | Display current exec name                                                             |
-| `fan`                              | Shows fan rpm. Auto-detects the Steam Deck fan or a Super I/O chip (e.g. nct6799). Picks the first spinning fan by default. |
-| `fan_custom_sensor`                | Use custom hwmon sensor(s) for fan rpm. One or more `chip,input[,label]` entries separated by `;`. e.g `fan_custom_sensor=nct6799,fan2_input` or `fan_custom_sensor=nct6799,fan2_input,CPU;nct6799,fan7_input,GPU`. |
+| `fan`                              | Shows the Steam Deck fan rpm. |
+| `cfan`                             | Shows custom / Super I/O fan rpm. Auto-detects a Super I/O chip (e.g. nct6799) and picks the first spinning fan, or uses `fan_custom_sensor` if set. |
+| `fan_custom_sensor`                | Selects the hwmon sensor(s) used by `cfan`. One or more `chip,input[,label]` entries separated by `;`. e.g `fan_custom_sensor=nct6799,fan2_input` or `fan_custom_sensor=nct6799,fan2_input,CPU;nct6799,fan7_input,GPU`. |
 | `fcat`                             | Enables frame capture analysis                                                        |
 | `fcat_overlay_width=`              | Sets the width of fcat. Default is `24`                                               |
 | `fcat_screen_edge=`                | Decides the edge fcat is displayed on. A value between `1` and `4`                    |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A Vulkan and OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and m
 
 ![Example gif showing a standard performance readout with frametimes](assets/overlay_example.gif)
 
+> **Fork note:** This fork adds **Super I/O fan support**. The `fan` element shows the
+> Steam Deck fan, and a new **`cfan`** element shows motherboard / Super I/O chip fans
+> (Nuvoton, ITE, Fintek, Winbond, SMSC) via `hwmon`, with `fan_custom_sensor` for manual
+> selection and `cfan_color` for its label color. See [`FAN_SUPERIO.md`](FAN_SUPERIO.md)
+> for full details.
+
 ---
 
 - [MangoHud](#mangohud)

--- a/README.md
+++ b/README.md
@@ -377,7 +377,8 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `engine_version`                   | Display OpenGL or vulkan and vulkan-based render engine's version                     |
 | `exec`                             | Display output of bash command in next column, e.g. `custom_text=/home` , `exec=df -h /home \| tail -n 1`. Only works with `legacy_layout=0` |
 | `exec_name`                        | Display current exec name                                                             |
-| `fan`                              | Shows the Steam Deck fan rpm                                                          |
+| `fan`                              | Shows fan rpm. Auto-detects the Steam Deck fan or a Super I/O chip (e.g. nct6799). Picks the first spinning fan by default. |
+| `fan_custom_sensor`                | Use custom hwmon sensor(s) for fan rpm. One or more `chip,input[,label]` entries separated by `;`. e.g `fan_custom_sensor=nct6799,fan2_input` or `fan_custom_sensor=nct6799,fan2_input,CPU;nct6799,fan7_input,GPU`. |
 | `fcat`                             | Enables frame capture analysis                                                        |
 | `fcat_overlay_width=`              | Sets the width of fcat. Default is `24`                                               |
 | `fcat_screen_edge=`                | Decides the edge fcat is displayed on. A value between `1` and `4`                    |
@@ -407,7 +408,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `refresh_rate`                     | Display the current refresh rate (only works in gamescope)                            |
 | `full`                             | Enable most of the toggleable parameters (currently excludes `histogram`)             |
 | `gamemode`                         | Show if GameMode is on                                                                |
-| `gpu_color`<br>`cpu_color`<br>`vram_color`<br>`ram_color`<br>`io_color`<br>`engine_color`<br>`frametime_color`<br>`background_color`<br>`text_color`<br>`media_player_color`<br>`network_color`         | Change default colors: `gpu_color=RRGGBB` |
+| `gpu_color`<br>`cpu_color`<br>`vram_color`<br>`ram_color`<br>`io_color`<br>`engine_color`<br>`fan_color`<br>`frametime_color`<br>`background_color`<br>`text_color`<br>`media_player_color`<br>`network_color`         | Change default colors: `gpu_color=RRGGBB` |
 | `gpu_core_clock`<br>`gpu_mem_clock`| Display GPU core/memory frequency                                                     |
 | `gpu_fan`                          | GPU fan in RPM, except NVIDIA where it is a percentage |
 | `gpu_load_change`                  | Change the color of the GPU load depending on load                                    |

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -170,6 +170,7 @@ void HudElements::convert_colors(const struct overlay_params& params)
     HUDElements.colors.vram = convert(params.vram_color);
     HUDElements.colors.ram = convert(params.ram_color);
     HUDElements.colors.engine = convert(params.engine_color);
+    HUDElements.colors.fan = convert(params.fan_color);
     HUDElements.colors.io = convert(params.io_color);
     HUDElements.colors.frametime = convert(params.frametime_color);
     HUDElements.colors.background = convert(params.background_color);
@@ -1460,11 +1461,22 @@ void HudElements::frame_count(){
 }
 
 void HudElements::fan(){
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fan] && fan_speed != -1) {
+    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fan])
+        return;
+
+    bool first = true;
+    for (auto& s : fan_sensors) {
+        if (s.rpm < 0)
+            continue;
+        // The render loop gives this element one row; start a fresh row for
+        // each additional fan so labels don't spill into trailing columns.
+        if (!first && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal])
+            ImGui::TableNextRow();
+        first = false;
         ImguiNextColumnFirstItem();
-        HUDElements.TextColored(HUDElements.colors.engine, "%s", "FAN");
+        HUDElements.TextColored(HUDElements.colors.fan, "%s", s.label.c_str());
         ImguiNextColumnOrNewRow();
-        right_aligned_text(HUDElements.colors.text,HUDElements.ralign_width, "%i", fan_speed);
+        right_aligned_text(HUDElements.colors.text,HUDElements.ralign_width, "%i", s.rpm);
         ImGui::SameLine(0, 1.0f);
         ImGui::PushFont(HUDElements.sw_stats->font_small);
         HUDElements.TextColored(HUDElements.colors.text, "RPM");

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -171,6 +171,7 @@ void HudElements::convert_colors(const struct overlay_params& params)
     HUDElements.colors.ram = convert(params.ram_color);
     HUDElements.colors.engine = convert(params.engine_color);
     HUDElements.colors.fan = convert(params.fan_color);
+    HUDElements.colors.cfan = convert(params.cfan_color);
     HUDElements.colors.io = convert(params.io_color);
     HUDElements.colors.frametime = convert(params.frametime_color);
     HUDElements.colors.background = convert(params.background_color);
@@ -1498,7 +1499,7 @@ void HudElements::cfan(){
             ImGui::TableNextRow();
         first = false;
         ImguiNextColumnFirstItem();
-        HUDElements.TextColored(HUDElements.colors.fan, "%s", s.label.c_str());
+        HUDElements.TextColored(HUDElements.colors.cfan, "%s", s.label.c_str());
         ImguiNextColumnOrNewRow();
         right_aligned_text(HUDElements.colors.text,HUDElements.ralign_width, "%i", s.rpm);
         ImGui::SameLine(0, 1.0f);

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -1484,6 +1484,30 @@ void HudElements::fan(){
     }
 }
 
+void HudElements::cfan(){
+    if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cfan])
+        return;
+
+    bool first = true;
+    for (auto& s : cfan_sensors) {
+        if (s.rpm < 0)
+            continue;
+        // The render loop gives this element one row; start a fresh row for
+        // each additional fan so labels don't spill into trailing columns.
+        if (!first && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal])
+            ImGui::TableNextRow();
+        first = false;
+        ImguiNextColumnFirstItem();
+        HUDElements.TextColored(HUDElements.colors.fan, "%s", s.label.c_str());
+        ImguiNextColumnOrNewRow();
+        right_aligned_text(HUDElements.colors.text,HUDElements.ralign_width, "%i", s.rpm);
+        ImGui::SameLine(0, 1.0f);
+        ImGui::PushFont(HUDElements.sw_stats->font_small);
+        HUDElements.TextColored(HUDElements.colors.text, "RPM");
+        ImGui::PopFont();
+    }
+}
+
 void HudElements::throttling_status(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_throttling_status] && gpus){
         auto gpu = gpus->active_gpu();
@@ -2000,6 +2024,7 @@ void HudElements::sort_elements(const std::pair<std::string, std::string>& optio
         {"device_battery", {device_battery}},
         {"frame_count", {frame_count}},
         {"fan", {fan}},
+        {"cfan", {cfan}},
         {"throttling_status", {throttling_status}},
         {"exec_name", {exec_name}},
         {"duration", {duration}},
@@ -2080,6 +2105,8 @@ void HudElements::legacy_elements(const overlay_params* temp_params){
         ordered_functions.push_back({battery, "battery", value});
     if (temp_params->enabled[OVERLAY_PARAM_ENABLED_fan])
         ordered_functions.push_back({fan, "fan", value});
+    if (temp_params->enabled[OVERLAY_PARAM_ENABLED_cfan])
+        ordered_functions.push_back({cfan, "cfan", value});
     if (temp_params->enabled[OVERLAY_PARAM_ENABLED_fsr])
         ordered_functions.push_back({gamescope_fsr, "gamescope_fsr", value});
     if (temp_params->enabled[OVERLAY_PARAM_ENABLED_hdr])

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -131,6 +131,7 @@ class HudElements{
                 swap,
                 engine,
                 fan,
+                cfan,
                 io,
                 frametime,
                 background,

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -129,6 +129,7 @@ class HudElements{
                 ram,
                 swap,
                 engine,
+                fan,
                 io,
                 frametime,
                 background,

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -106,6 +106,7 @@ class HudElements{
         static void device_battery();
         static void frame_count();
         static void fan();
+        static void cfan();
         static void throttling_status();
         static void exec_name();
         static void duration();

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -50,6 +50,7 @@ bool gpu_metrics_exists = false;
 bool steam_focused = false;
 vector<float> frametime_data(200,0.f);
 std::vector<fan_sensor> fan_sensors;
+std::vector<fan_sensor> cfan_sensors;
 fcatoverlay fcatstatus;
 std::string drm_dev;
 int current_preset;
@@ -902,23 +903,37 @@ static string find_active_fan_input(const string& hwmon_dir){
 }
 
 void update_fan(){
-   // Resolves the fan sensor(s) once and caches their sysfs paths into
-   // fan_sensors, then refreshes the RPM of each every call.
+   // Resolves the fan sensor(s) once and caches their sysfs paths, then
+   // refreshes the RPM of each every call.
    //
-   // If fan_custom_sensor is set, one entry is created per configured sensor
-   // (allowing multiple fans to be shown). Otherwise a single fan is
-   // auto-detected: Steam Deck first, then any Super I/O chip
-   // (nct67xx/nct6799, it87xx, etc.) exposed through hwmon.
+   //   fan_sensors  -> "fan" element:  the Steam Deck APU fan.
+   //   cfan_sensors -> "cfan" element: custom / Super I/O chip fan(s). Uses
+   //                   fan_custom_sensor if set, otherwise auto-detects a
+   //                   Super I/O chip (nct67xx/nct6799, it87xx, etc.).
    static bool checked = false;
 
    if (!checked){
       checked = true;
       fan_sensors.clear();
+      cfan_sensors.clear();
       string path = "/sys/class/hwmon/";
       auto dirs = ls(path.c_str(), "hwmon", LS_DIRS);
 
-      auto custom = get_params()->fan_custom_sensor;
+      // "fan": the Steam Deck APU fan.
+      for (auto& dir : dirs) {
+         string dir_path = path + dir;
+         if (read_line(dir_path + "/name").find("steamdeck_hwmon") != string::npos){
+            fan_sensor fs;
+            fs.label = "FAN";
+            fs.path = dir_path + "/fan1_input";
+            fan_sensors.push_back(fs);
+            SPDLOG_DEBUG("fan: using Steam Deck sensor ({})", fs.path);
+            break;
+         }
+      }
 
+      // "cfan": custom / Super I/O chip fan(s).
+      auto custom = get_params()->fan_custom_sensor;
       if (!custom.empty()){
          // User explicitly picked one or more chip+input pairs.
          size_t idx = 1;
@@ -942,66 +957,59 @@ void update_fan(){
                   if (label_it != cs.end() && !label_it->second.empty())
                      fs.label = label_it->second;
                   else
-                     fs.label = custom.size() > 1 ? "FAN" + std::to_string(idx) : "FAN";
-                  fan_sensors.push_back(fs);
-                  SPDLOG_DEBUG("fan: using sensor '{}' ({})", fs.label, fs.path);
+                     fs.label = custom.size() > 1 ? "CFAN" + std::to_string(idx) : "CFAN";
+                  cfan_sensors.push_back(fs);
+                  SPDLOG_DEBUG("cfan: using sensor '{}' ({})", fs.label, fs.path);
                }
                break;
             }
             idx++;
          }
       } else {
-         // Auto-detect a single fan: Steam Deck, then Super I/O.
-         string hwmon_path;
+         // Auto-detect a single Super I/O fan.
+         static const std::vector<string> superio_prefixes = {
+            "nct61", "nct67", "nct77",                 // Nuvoton (incl. nct6799)
+            "it86", "it87",                            // ITE
+            "f7188", "f8000",                          // Fintek
+            "w836", "w8362", "w8377",                  // Winbond
+            "smsc", "sch311",                          // SMSC
+         };
          for (auto& dir : dirs) {
             string dir_path = path + dir;
-            if (read_line(dir_path + "/name").find("steamdeck_hwmon") != string::npos){
-               hwmon_path = dir_path + "/fan1_input";
+            string name = read_line(dir_path + "/name");
+
+            bool is_superio = false;
+            for (auto& p : superio_prefixes){
+               if (starts_with(name, p.c_str())){ is_superio = true; break; }
+            }
+            if (!is_superio)
+               continue;
+
+            string found = find_active_fan_input(dir_path);
+            if (!found.empty()){
+               fan_sensor fs;
+               fs.label = "CFAN";
+               fs.path = found;
+               cfan_sensors.push_back(fs);
+               SPDLOG_DEBUG("cfan: using Super I/O sensor '{}' ({})", name, fs.path);
                break;
             }
          }
-
-         if (hwmon_path.empty()){
-            static const std::vector<string> superio_prefixes = {
-               "nct61", "nct67", "nct77",                 // Nuvoton (incl. nct6799)
-               "it86", "it87",                            // ITE
-               "f7188", "f8000",                          // Fintek
-               "w836", "w8362", "w8377",                  // Winbond
-               "smsc", "sch311",                          // SMSC
-            };
-            for (auto& dir : dirs) {
-               string dir_path = path + dir;
-               string name = read_line(dir_path + "/name");
-
-               bool is_superio = false;
-               for (auto& p : superio_prefixes){
-                  if (starts_with(name, p.c_str())){ is_superio = true; break; }
-               }
-               if (!is_superio)
-                  continue;
-
-               string found = find_active_fan_input(dir_path);
-               if (!found.empty()){
-                  hwmon_path = found;
-                  SPDLOG_DEBUG("fan: using Super I/O sensor '{}' ({})", name, hwmon_path);
-                  break;
-               }
-            }
-         }
-
-         if (!hwmon_path.empty()){
-            fan_sensor fs;
-            fs.label = "FAN";
-            fs.path = hwmon_path;
-            fan_sensors.push_back(fs);
-         }
       }
 
-      if (fan_sensors.empty())
+      if (fan_sensors.empty() && cfan_sensors.empty())
          SPDLOG_DEBUG("fan: no fan sensor found");
    }
 
    for (auto& s : fan_sensors){
+      string val = read_line(s.path);
+      try {
+         s.rpm = val.empty() ? -1 : stoi(val);
+      } catch (...) {
+         s.rpm = -1;
+      }
+   }
+   for (auto& s : cfan_sensors){
       string val = read_line(s.path);
       try {
          s.rpm = val.empty() ? -1 : stoi(val);

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -49,7 +49,7 @@ double min_frametime, max_frametime;
 bool gpu_metrics_exists = false;
 bool steam_focused = false;
 vector<float> frametime_data(200,0.f);
-int fan_speed;
+std::vector<fan_sensor> fan_sensors;
 fcatoverlay fcatstatus;
 std::string drm_dev;
 int current_preset;
@@ -882,27 +882,133 @@ void check_for_vkbasalt_and_gamemode() {
 #endif
 }
 
-void update_fan(){
-   // This just handles steam deck fan for now
-   static bool init;
-   string hwmon_path;
+// Returns the path of the first fanN_input node under hwmon_dir that reports a
+// non-zero RPM, or an empty string if none is found.
+static string find_active_fan_input(const string& hwmon_dir){
+   auto inputs = ls(hwmon_dir.c_str(), "fan", LS_FILES);
+   // Sort so fan1_input is preferred over fan2_input, etc.
+   std::sort(inputs.begin(), inputs.end());
+   for (auto& f : inputs){
+      if (f.find("_input") == string::npos)
+         continue;
+      string full = hwmon_dir + "/" + f;
+      string val = read_line(full);
+      try {
+         if (!val.empty() && stoi(val) > 0)
+            return full;
+      } catch (...) {}
+   }
+   return "";
+}
 
-   if (!init){
+void update_fan(){
+   // Resolves the fan sensor(s) once and caches their sysfs paths into
+   // fan_sensors, then refreshes the RPM of each every call.
+   //
+   // If fan_custom_sensor is set, one entry is created per configured sensor
+   // (allowing multiple fans to be shown). Otherwise a single fan is
+   // auto-detected: Steam Deck first, then any Super I/O chip
+   // (nct67xx/nct6799, it87xx, etc.) exposed through hwmon.
+   static bool checked = false;
+
+   if (!checked){
+      checked = true;
+      fan_sensors.clear();
       string path = "/sys/class/hwmon/";
       auto dirs = ls(path.c_str(), "hwmon", LS_DIRS);
-      for (auto& dir : dirs) {
-         string full_path = (path + dir + "/name").c_str();
-         if (read_line(full_path).find("steamdeck_hwmon") != string::npos){
-            hwmon_path = path + dir + "/fan1_input";
-            break;
+
+      auto custom = get_params()->fan_custom_sensor;
+
+      if (!custom.empty()){
+         // User explicitly picked one or more chip+input pairs.
+         size_t idx = 1;
+         for (auto& cs : custom){
+            auto name_it = cs.find("hwmon_name");
+            auto input_it = cs.find("hwmon_input");
+            if (name_it == cs.end() || input_it == cs.end())
+               continue;
+            const string& name = name_it->second;
+            const string& input = input_it->second;
+
+            for (auto& dir : dirs) {
+               string dir_path = path + dir;
+               if (read_line(dir_path + "/name") != name)
+                  continue;
+               string candidate = dir_path + "/" + input;
+               if (file_exists(candidate)){
+                  fan_sensor fs;
+                  fs.path = candidate;
+                  auto label_it = cs.find("label");
+                  if (label_it != cs.end() && !label_it->second.empty())
+                     fs.label = label_it->second;
+                  else
+                     fs.label = custom.size() > 1 ? "FAN" + std::to_string(idx) : "FAN";
+                  fan_sensors.push_back(fs);
+                  SPDLOG_DEBUG("fan: using sensor '{}' ({})", fs.label, fs.path);
+               }
+               break;
+            }
+            idx++;
+         }
+      } else {
+         // Auto-detect a single fan: Steam Deck, then Super I/O.
+         string hwmon_path;
+         for (auto& dir : dirs) {
+            string dir_path = path + dir;
+            if (read_line(dir_path + "/name").find("steamdeck_hwmon") != string::npos){
+               hwmon_path = dir_path + "/fan1_input";
+               break;
+            }
+         }
+
+         if (hwmon_path.empty()){
+            static const std::vector<string> superio_prefixes = {
+               "nct61", "nct67", "nct77",                 // Nuvoton (incl. nct6799)
+               "it86", "it87",                            // ITE
+               "f7188", "f8000",                          // Fintek
+               "w836", "w8362", "w8377",                  // Winbond
+               "smsc", "sch311",                          // SMSC
+            };
+            for (auto& dir : dirs) {
+               string dir_path = path + dir;
+               string name = read_line(dir_path + "/name");
+
+               bool is_superio = false;
+               for (auto& p : superio_prefixes){
+                  if (starts_with(name, p.c_str())){ is_superio = true; break; }
+               }
+               if (!is_superio)
+                  continue;
+
+               string found = find_active_fan_input(dir_path);
+               if (!found.empty()){
+                  hwmon_path = found;
+                  SPDLOG_DEBUG("fan: using Super I/O sensor '{}' ({})", name, hwmon_path);
+                  break;
+               }
+            }
+         }
+
+         if (!hwmon_path.empty()){
+            fan_sensor fs;
+            fs.label = "FAN";
+            fs.path = hwmon_path;
+            fan_sensors.push_back(fs);
          }
       }
+
+      if (fan_sensors.empty())
+         SPDLOG_DEBUG("fan: no fan sensor found");
    }
 
-   if (!hwmon_path.empty())
-      fan_speed = stoi(read_line(hwmon_path));
-   else
-      fan_speed = -1;
+   for (auto& s : fan_sensors){
+      string val = read_line(s.path);
+      try {
+         s.rpm = val.empty() ? -1 : stoi(val);
+      } catch (...) {
+         s.rpm = -1;
+      }
+   }
 }
 
 void next_hud_position(){

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -103,7 +103,7 @@ void init_spdlog()
 void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
 {
    auto real_params = get_params();
-   if (real_params->enabled[OVERLAY_PARAM_ENABLED_fan])
+   if (real_params->enabled[OVERLAY_PARAM_ENABLED_fan] || real_params->enabled[OVERLAY_PARAM_ENABLED_cfan])
       update_fan();
    if (real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] || logger->is_active()) {
       cpuStats.UpdateCPUData();
@@ -902,14 +902,51 @@ static string find_active_fan_input(const string& hwmon_dir){
    return "";
 }
 
+// Resolves user-configured "chip,input[,label]" entries into fan_sensor nodes
+// appended to out. Shared by the "fan" and "cfan" elements.
+static void resolve_custom_fan_sensors(
+      const std::vector<std::map<std::string, std::string>>& custom,
+      const std::vector<string>& dirs, const string& path,
+      std::vector<fan_sensor>& out, const char* default_prefix){
+   size_t idx = 1;
+   for (auto& cs : custom){
+      auto name_it = cs.find("hwmon_name");
+      auto input_it = cs.find("hwmon_input");
+      if (name_it == cs.end() || input_it == cs.end())
+         continue;
+      const string& name = name_it->second;
+      const string& input = input_it->second;
+
+      for (auto& dir : dirs) {
+         string dir_path = path + dir;
+         if (read_line(dir_path + "/name") != name)
+            continue;
+         string candidate = dir_path + "/" + input;
+         if (file_exists(candidate)){
+            fan_sensor fs;
+            fs.path = candidate;
+            auto label_it = cs.find("label");
+            if (label_it != cs.end() && !label_it->second.empty())
+               fs.label = label_it->second;
+            else
+               fs.label = custom.size() > 1 ? default_prefix + std::to_string(idx) : default_prefix;
+            out.push_back(fs);
+            SPDLOG_DEBUG("fan: using custom sensor '{}' ({})", fs.label, fs.path);
+         }
+         break;
+      }
+      idx++;
+   }
+}
+
 void update_fan(){
    // Resolves the fan sensor(s) once and caches their sysfs paths, then
    // refreshes the RPM of each every call.
    //
-   //   fan_sensors  -> "fan" element:  the Steam Deck APU fan.
-   //   cfan_sensors -> "cfan" element: custom / Super I/O chip fan(s). Uses
-   //                   fan_custom_sensor if set, otherwise auto-detects a
-   //                   Super I/O chip (nct67xx/nct6799, it87xx, etc.).
+   //   fan_sensors  -> "fan" element:  fan_custom_sensor if set, otherwise the
+   //                   Steam Deck APU fan.
+   //   cfan_sensors -> "cfan" element: cfan_custom_sensor if set, otherwise a
+   //                   auto-detected Super I/O chip (nct67xx/nct6799, it87xx, etc.).
    static bool checked = false;
 
    if (!checked){
@@ -919,52 +956,28 @@ void update_fan(){
       string path = "/sys/class/hwmon/";
       auto dirs = ls(path.c_str(), "hwmon", LS_DIRS);
 
-      // "fan": the Steam Deck APU fan.
-      for (auto& dir : dirs) {
-         string dir_path = path + dir;
-         if (read_line(dir_path + "/name").find("steamdeck_hwmon") != string::npos){
-            fan_sensor fs;
-            fs.label = "FAN";
-            fs.path = dir_path + "/fan1_input";
-            fan_sensors.push_back(fs);
-            SPDLOG_DEBUG("fan: using Steam Deck sensor ({})", fs.path);
-            break;
+      // "fan": fan_custom_sensor if set, otherwise the Steam Deck APU fan.
+      auto fan_custom = get_params()->fan_custom_sensor;
+      if (!fan_custom.empty()){
+         resolve_custom_fan_sensors(fan_custom, dirs, path, fan_sensors, "FAN");
+      } else {
+         for (auto& dir : dirs) {
+            string dir_path = path + dir;
+            if (read_line(dir_path + "/name").find("steamdeck_hwmon") != string::npos){
+               fan_sensor fs;
+               fs.label = "FAN";
+               fs.path = dir_path + "/fan1_input";
+               fan_sensors.push_back(fs);
+               SPDLOG_DEBUG("fan: using Steam Deck sensor ({})", fs.path);
+               break;
+            }
          }
       }
 
-      // "cfan": custom / Super I/O chip fan(s).
-      auto custom = get_params()->fan_custom_sensor;
-      if (!custom.empty()){
-         // User explicitly picked one or more chip+input pairs.
-         size_t idx = 1;
-         for (auto& cs : custom){
-            auto name_it = cs.find("hwmon_name");
-            auto input_it = cs.find("hwmon_input");
-            if (name_it == cs.end() || input_it == cs.end())
-               continue;
-            const string& name = name_it->second;
-            const string& input = input_it->second;
-
-            for (auto& dir : dirs) {
-               string dir_path = path + dir;
-               if (read_line(dir_path + "/name") != name)
-                  continue;
-               string candidate = dir_path + "/" + input;
-               if (file_exists(candidate)){
-                  fan_sensor fs;
-                  fs.path = candidate;
-                  auto label_it = cs.find("label");
-                  if (label_it != cs.end() && !label_it->second.empty())
-                     fs.label = label_it->second;
-                  else
-                     fs.label = custom.size() > 1 ? "CFAN" + std::to_string(idx) : "CFAN";
-                  cfan_sensors.push_back(fs);
-                  SPDLOG_DEBUG("cfan: using sensor '{}' ({})", fs.label, fs.path);
-               }
-               break;
-            }
-            idx++;
-         }
+      // "cfan": cfan_custom_sensor if set, otherwise a Super I/O chip.
+      auto cfan_custom = get_params()->cfan_custom_sensor;
+      if (!cfan_custom.empty()){
+         resolve_custom_fan_sensors(cfan_custom, dirs, path, cfan_sensors, "CFAN");
       } else {
          // Auto-detect a single Super I/O fan.
          static const std::vector<string> superio_prefixes = {

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -151,7 +151,8 @@ struct fan_sensor {
    std::string path;  // resolved hwmon sysfs path (e.g. .../fanN_input)
    int rpm = -1;      // last read value; -1 means unavailable
 };
-extern std::vector<fan_sensor> fan_sensors;
+extern std::vector<fan_sensor> fan_sensors;   // "fan": Steam Deck APU fan
+extern std::vector<fan_sensor> cfan_sensors;  // "cfan": custom / Super I/O fan(s)
 extern int current_preset;
 extern std::vector<float> frametime_data;
 

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -146,7 +146,12 @@ extern std::string wineVersion;
 extern std::deque<logData> graph_data;
 extern double min_frametime, max_frametime;
 extern bool steam_focused;
-extern int fan_speed;
+struct fan_sensor {
+   std::string label; // display label, e.g. "FAN", "FAN1", or a user-provided name
+   std::string path;  // resolved hwmon sysfs path (e.g. .../fanN_input)
+   int rpm = -1;      // last read value; -1 means unavailable
+};
+extern std::vector<fan_sensor> fan_sensors;
 extern int current_preset;
 extern std::vector<float> frametime_data;
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -1102,12 +1102,14 @@ parse_overlay_config(struct overlay_params *params,
       params->font_scale_media_player = 0.55f;
 
    // Convert from 0xRRGGBB to ImGui's format
-   std::array<unsigned *, 24> colors = {
+   std::array<unsigned *, 26> colors = {
       &params->cpu_color,
       &params->gpu_color,
       &params->vram_color,
       &params->ram_color,
       &params->engine_color,
+      &params->fan_color,
+      &params->cfan_color,
       &params->io_color,
       &params->background_color,
       &params->frametime_color,

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -664,6 +664,7 @@ parse_ftrace(const char *str) {
 #define parse_engine_color(s) parse_color(s)
 #define parse_fan_color(s) parse_color(s)
 #define parse_cfan_color(s) parse_color(s)
+#define parse_cfan_custom_sensor(s) parse_fan_custom_sensor(s)
 #define parse_io_color(s) parse_color(s)
 #define parse_frametime_color(s) parse_color(s)
 #define parse_background_color(s) parse_color(s)

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -250,6 +250,48 @@ static std::map<std::string, std::string> parse_cpu_custom_temp_sensor(const std
    return map;
 }
 
+static std::vector<std::map<std::string, std::string>> parse_fan_custom_sensor(const std::string str) {
+   // Accepts one or more sensors separated by ';'. Each sensor is
+   // "hwmon_name,hwmon_input[,label]", e.g.
+   //   "nct6799,fan2_input"
+   //   "nct6799,fan2_input,CPU;nct6799,fan7_input,GPU"
+   std::vector<std::map<std::string, std::string>> sensors;
+
+   std::stringstream ss(str);
+   std::string segment;
+   while (std::getline(ss, segment, ';')) {
+      trim(segment);
+      if (segment.empty())
+         continue;
+
+      size_t c1 = segment.find(',');
+      if (c1 == std::string::npos || c1 == segment.length() - 1)
+         continue; // need at least name,input
+
+      std::map<std::string, std::string> map;
+      map["hwmon_name"] = segment.substr(0, c1);
+
+      size_t c2 = segment.find(',', c1 + 1);
+      if (c2 == std::string::npos) {
+         map["hwmon_input"] = segment.substr(c1 + 1);
+      } else {
+         map["hwmon_input"] = segment.substr(c1 + 1, c2 - (c1 + 1));
+         map["label"] = segment.substr(c2 + 1);
+      }
+
+      if (map["hwmon_name"].empty() || map["hwmon_input"].empty())
+         continue;
+
+      SPDLOG_DEBUG(
+         "fan_custom_sensor: name=\"{}\" input=\"{}\" label=\"{}\"",
+         map["hwmon_name"], map["hwmon_input"], map["label"]
+      );
+      sensors.push_back(map);
+   }
+
+   return sensors;
+}
+
 static uint32_t
 parse_fps_sampling_period(const char *str)
 {
@@ -620,6 +662,7 @@ parse_ftrace(const char *str) {
 #define parse_vram_color(s) parse_color(s)
 #define parse_ram_color(s) parse_color(s)
 #define parse_engine_color(s) parse_color(s)
+#define parse_fan_color(s) parse_color(s)
 #define parse_io_color(s) parse_color(s)
 #define parse_frametime_color(s) parse_color(s)
 #define parse_background_color(s) parse_color(s)
@@ -901,6 +944,7 @@ static void set_param_defaults(struct overlay_params *params){
    params->vram_color = 0xad64c1;
    params->ram_color = 0xc26693;
    params->engine_color = 0xeb5b5b;
+   params->fan_color = 0xeb5b5b;
    params->io_color = 0xa491d3;
    params->frametime_color = 0x00ff00;
    params->background_color = 0x020202;

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -663,6 +663,7 @@ parse_ftrace(const char *str) {
 #define parse_ram_color(s) parse_color(s)
 #define parse_engine_color(s) parse_color(s)
 #define parse_fan_color(s) parse_color(s)
+#define parse_cfan_color(s) parse_color(s)
 #define parse_io_color(s) parse_color(s)
 #define parse_frametime_color(s) parse_color(s)
 #define parse_background_color(s) parse_color(s)
@@ -945,6 +946,7 @@ static void set_param_defaults(struct overlay_params *params){
    params->ram_color = 0xc26693;
    params->engine_color = 0xeb5b5b;
    params->fan_color = 0xeb5b5b;
+   params->cfan_color = 0xeb5b5b;
    params->io_color = 0xa491d3;
    params->frametime_color = 0x00ff00;
    params->background_color = 0x020202;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -99,6 +99,7 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(device_battery_icon)           \
    OVERLAY_PARAM_BOOL(hide_fsr_sharpness)            \
    OVERLAY_PARAM_BOOL(fan)                           \
+   OVERLAY_PARAM_CUSTOM(fan_custom_sensor)           \
    OVERLAY_PARAM_BOOL(throttling_status)             \
    OVERLAY_PARAM_BOOL(throttling_status_graph)       \
    OVERLAY_PARAM_BOOL(fcat)                          \
@@ -180,6 +181,7 @@ struct Tracepoint;
    OVERLAY_PARAM_CUSTOM(vram_color)                  \
    OVERLAY_PARAM_CUSTOM(ram_color)                   \
    OVERLAY_PARAM_CUSTOM(engine_color)                \
+   OVERLAY_PARAM_CUSTOM(fan_color)                   \
    OVERLAY_PARAM_CUSTOM(frametime_color)             \
    OVERLAY_PARAM_CUSTOM(background_color)            \
    OVERLAY_PARAM_CUSTOM(io_color)                    \
@@ -310,7 +312,7 @@ struct overlay_params {
    bool gl_dont_flip {false};
    int64_t log_duration, log_interval;
    unsigned cpu_color, gpu_color, vram_color, ram_color,
-            engine_color, io_color, frametime_color, background_color,
+            engine_color, fan_color, io_color, frametime_color, background_color,
             text_color, wine_color, battery_color, network_color,
             horizontal_separator_color;
    std::vector<unsigned> gpu_load_color;
@@ -341,6 +343,7 @@ struct overlay_params {
    std::string media_player_name;
    std::string cpu_text, fps_text;
    std::map<std::string, std::string> cpu_custom_temp_sensor;
+   std::vector<std::map<std::string, std::string>> fan_custom_sensor;
    std::vector<std::string> blacklist;
    unsigned autostart_log;
    std::vector<std::string> media_player_format;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -99,6 +99,7 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(device_battery_icon)           \
    OVERLAY_PARAM_BOOL(hide_fsr_sharpness)            \
    OVERLAY_PARAM_BOOL(fan)                           \
+   OVERLAY_PARAM_BOOL(cfan)                          \
    OVERLAY_PARAM_CUSTOM(fan_custom_sensor)           \
    OVERLAY_PARAM_BOOL(throttling_status)             \
    OVERLAY_PARAM_BOOL(throttling_status_graph)       \

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -101,6 +101,7 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(fan)                           \
    OVERLAY_PARAM_BOOL(cfan)                          \
    OVERLAY_PARAM_CUSTOM(fan_custom_sensor)           \
+   OVERLAY_PARAM_CUSTOM(cfan_custom_sensor)          \
    OVERLAY_PARAM_BOOL(throttling_status)             \
    OVERLAY_PARAM_BOOL(throttling_status_graph)       \
    OVERLAY_PARAM_BOOL(fcat)                          \
@@ -346,6 +347,7 @@ struct overlay_params {
    std::string cpu_text, fps_text;
    std::map<std::string, std::string> cpu_custom_temp_sensor;
    std::vector<std::map<std::string, std::string>> fan_custom_sensor;
+   std::vector<std::map<std::string, std::string>> cfan_custom_sensor;
    std::vector<std::string> blacklist;
    unsigned autostart_log;
    std::vector<std::string> media_player_format;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -183,6 +183,7 @@ struct Tracepoint;
    OVERLAY_PARAM_CUSTOM(ram_color)                   \
    OVERLAY_PARAM_CUSTOM(engine_color)                \
    OVERLAY_PARAM_CUSTOM(fan_color)                   \
+   OVERLAY_PARAM_CUSTOM(cfan_color)                  \
    OVERLAY_PARAM_CUSTOM(frametime_color)             \
    OVERLAY_PARAM_CUSTOM(background_color)            \
    OVERLAY_PARAM_CUSTOM(io_color)                    \
@@ -313,7 +314,7 @@ struct overlay_params {
    bool gl_dont_flip {false};
    int64_t log_duration, log_interval;
    unsigned cpu_color, gpu_color, vram_color, ram_color,
-            engine_color, fan_color, io_color, frametime_color, background_color,
+            engine_color, fan_color, cfan_color, io_color, frametime_color, background_color,
             text_color, wine_color, battery_color, network_color,
             horizontal_separator_color;
    std::vector<unsigned> gpu_load_color;


### PR DESCRIPTION
## Summary
- Adds a new `cfan` overlay element that auto-detects and reads chassis/CPU/system fan RPM from Super I/O chips (Nuvoton/ITE/Fintek/Winbond/SMSC) via Linux `hwmon`, independent of the existing Steam Deck-only `fan` element
- Adds `fan_custom_sensor` / `cfan_custom_sensor` config options (shared parser) to manually pick a specific `chip,input[,label]` sensor, supporting multiple labelled fans
- Adds a dedicated `cfan_color` so the new element's label isn't forced to share `fan_color`
- Fixes a pre-existing bug where `fan_color`/`cfan_color` were missing from the 0xRRGGBB→ImGui color swizzle table (red/blue channels were swapped)

## Details
See `FAN_SUPERIO.md` for the full rationale and a before/after table of touched files.

## Test plan
- [ ] Build with meson/ninja on a desktop system with a Super I/O hwmon device present
- [ ] Verify `cfan=1` auto-detects and displays a sensible RPM
- [ ] Verify `cfan_custom_sensor` selects a specific chip/input and supports multiple fans
- [ ] Verify `fan` (Steam Deck) behavior is unchanged
- [ ] Verify `fan_color`/`cfan_color` render with correct (non-swapped) RGB

---
**Disclosure:** This code and PR description were written with the help of an AI coding assistant (Claude).