### PR TITLE
feat: Add no_engine_name_label option to FPS overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `fps_metrics`                      | Takes a list of decimal values or the value avg, e.g `avg,0.001`                      |
 | `reset_fps_metrics`                | Reset fps metrics keybind, default is `Shift_R+F9`                                    |
 | `fps_text`                         | Display custom text for engine name in front of FPS                                   |
+| `no_engine_name_label`              | Hide the engine or process name shown before the FPS value (e.g. `gamescope`)         |
 | `frame_count`                      | Display frame count                                                                   |
 | `frametime`                        | Display frametime next to FPS text                                                    |
 | `frame_timing_detailed`            | Display frame timing in a more detailed chart                                         |

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -835,7 +835,10 @@ void HudElements::procmem()
 void HudElements::fps(){
     if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fps] && !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fps_only]){
         ImguiNextColumnFirstItem();
-        HUDElements.TextColored(HUDElements.colors.engine, "%s", engine_name(*HUDElements.sw_stats));
+        // Skip engine/process label when requested.
+        if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_no_engine_name_label]) {
+            HUDElements.TextColored(HUDElements.colors.engine, "%s", engine_name(*HUDElements.sw_stats));
+        }
 
         ImguiNextColumnOrNewRow();
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_fps_color_change]){

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -118,6 +118,7 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(engine_short_names)            \
    OVERLAY_PARAM_BOOL(hide_engine_names)             \
    OVERLAY_PARAM_BOOL(hide_fps_superscript)          \
+   OVERLAY_PARAM_BOOL(no_engine_name_label)          \
    OVERLAY_PARAM_BOOL(text_outline)                  \
    OVERLAY_PARAM_BOOL(temp_fahrenheit)               \
    OVERLAY_PARAM_BOOL(dynamic_frame_timing)          \


### PR DESCRIPTION
## Summary

Adds an opt-in `no_engine_name_label` configuration option that suppresses the engine or process name displayed before the FPS counter.

This is especially useful with gamescope, where `fps=1` otherwise displays a `gamescope` label.

The option is disabled by default, so existing configurations and behavior remain unchanged. The FPS value, `FPS` suffix, alignment, and other overlay settings are preserved.

## Example

```ini
fps=1
no_engine_name_label=1
```

## Result

The overlay displays the FPS counter without the engine or process name, while retaining the small superscript suffix:

144 <sup>FPS</sup>
