### PR TITLE
fix: report an absent sensor as -1 rather than 0

### DIFF
--- a/src/gpu_metrics_util.h
+++ b/src/gpu_metrics_util.h
@@ -25,7 +25,7 @@ struct gpu_metrics {
     bool fan_rpm;
 
     gpu_metrics()
-        : load(0), temp(0), junction_temp(0), memory_temp(0),
+        : load(0), temp(0), junction_temp(-1), memory_temp(-1),
           sys_vram_used(0.0f), proc_vram_used(0.0f), memoryTotal(0.0f), MemClock(0), CoreClock(0),
           powerUsage(0.0f), powerLimit(0.0f), apu_cpu_power(0.0f), apu_cpu_temp(0),
           is_power_throttled(false), is_current_throttled(false),

--- a/src/gpu_metrics_util.h
+++ b/src/gpu_metrics_util.h
@@ -2,35 +2,27 @@
 #include <atomic>
 
 struct gpu_metrics {
-    int load;
-    int temp;
+    int load {0};
+    int temp {0};
     int junction_temp {-1};
     int memory_temp {-1};
-    float sys_vram_used;
-    float proc_vram_used;
-    float memoryTotal;
-    int MemClock;
-    int CoreClock;
-    float powerUsage;
-    float powerLimit;
-    float apu_cpu_power;
-    int apu_cpu_temp;
-    bool is_power_throttled;
-    bool is_current_throttled;
-    bool is_temp_throttled;
-    bool is_other_throttled;
-    float gtt_used;
-    int fan_speed;
-    int voltage;
-    bool fan_rpm;
-
-    gpu_metrics()
-        : load(0), temp(0), junction_temp(-1), memory_temp(-1),
-          sys_vram_used(0.0f), proc_vram_used(0.0f), memoryTotal(0.0f), MemClock(0), CoreClock(0),
-          powerUsage(0.0f), powerLimit(0.0f), apu_cpu_power(0.0f), apu_cpu_temp(0),
-          is_power_throttled(false), is_current_throttled(false),
-          is_temp_throttled(false), is_other_throttled(false),
-          gtt_used(0.0f), fan_speed(0), voltage(0), fan_rpm(false) {}
+    float sys_vram_used {0.0f};
+    float proc_vram_used {0.0f};
+    float memoryTotal {0.0f};
+    int MemClock {0};
+    int CoreClock {0};
+    float powerUsage {0.0f};
+    float powerLimit {0.0f};
+    float apu_cpu_power {0.0f};
+    int apu_cpu_temp {0};
+    bool is_power_throttled {false};
+    bool is_current_throttled {false};
+    bool is_temp_throttled {false};
+    bool is_other_throttled {false};
+    float gtt_used {0.0f};
+    int fan_speed {0};
+    int voltage {0};
+    bool fan_rpm {false};
 };
 
 #define METRICS_UPDATE_PERIOD_MS 500


### PR DESCRIPTION
junction_temp and memory_temp are declared with a -1 default and the HUD only draws them when the value is greater than -1, but the constructor initialises both to 0 and so defeats both. Any GPU without those sensors therefore renders a steady "0 C" instead of hiding the row - an APU exposing only an edge sensor shows 0 C junction forever.

Initialise them to -1 so the declared default and the draw condition agree.