### PR TITLE
Read hotspot, VRAM and voltage on NVIDIA through NVAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `gpu_load_value`                   | Set the values for medium and high load e.g `gpu_load_value=50,90`                    |
 | `gpu_name`                         | Display GPU name from pci.ids                                                         |
 | `gpu_voltage`                      | Display GPU voltage                                                                   |
+| `gpu_voltage_pci_dev`              | Show GPU voltage only for the given PCI address, e.g. `0000:01:00.0`                  |
 | `gpu_list`                         | List GPUs to display `gpu_list=0,1`                                                   |
 | `gpu_efficiency`                   | Display GPU efficiency in frames per joule                                            |
 | `gpu_power_limit`                  | Display GPU power limit                                                               |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -105,6 +105,8 @@ gpu_stats
 # gpu_fan
 ## Display GPU voltage
 # gpu_voltage
+## Show the voltage only for the named GPU; unset shows it for all of them
+# gpu_voltage_pci_dev=0000:01:00.0
 ## Select list of GPUs to display
 # gpu_list=0,1
 # gpu_efficiency

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -103,7 +103,7 @@ gpu_stats
 # gpu_load_color=39F900,FDFD09,B22222
 ## GPU fan in rpm on AMD, FAN in percent on NVIDIA
 # gpu_fan
-## gpu_voltage only works on AMD GPUs
+## Display GPU voltage
 # gpu_voltage
 ## Select list of GPUs to display
 # gpu_list=0,1

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -404,7 +404,12 @@ void HudElements::gpu_stats(){
                 ImGui::PopFont();
             }
 
-            if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_voltage]) {
+            // Voltage is reported by every GPU including APUs, but on a hybrid
+            // system only one of them is usually of interest. Naming a device
+            // here restricts the readout to it; unset keeps showing them all.
+            const std::string& voltage_dev = HUDElements.params->gpu_voltage_pci_dev;
+            if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_voltage] &&
+                (voltage_dev.empty() || gpu->pci_dev == voltage_dev)) {
                 ImguiNextColumnOrNewRow();
                 right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.voltage);
                 ImGui::SameLine(0, 1.0f);

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -409,6 +409,7 @@ void HudElements::gpu_stats(){
             // here restricts the readout to it; unset keeps showing them all.
             const std::string& voltage_dev = HUDElements.params->gpu_voltage_pci_dev;
             if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_voltage] &&
+                gpu->metrics.voltage >= 0 &&
                 (voltage_dev.empty() || gpu->pci_dev == voltage_dev)) {
                 ImguiNextColumnOrNewRow();
                 right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.voltage);

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,6 +53,7 @@ vklayer_files = files(
   'blacklist.cpp',
   'file_utils.cpp',
   'nvidia.cpp',
+  'nvapi_sensors.cpp',
   'gpu_fdinfo.cpp',
   'amdgpu.cpp'
 )

--- a/src/nvapi_sensors.cpp
+++ b/src/nvapi_sensors.cpp
@@ -1,0 +1,187 @@
+#include "nvapi_sensors.h"
+#include <spdlog/spdlog.h>
+
+#include <cstdio>
+#include <cstring>
+#include <dlfcn.h>
+
+namespace {
+
+const char* NVAPI_LIBRARY = "libnvidia-api.so.1";
+
+// NVAPI has no exported symbols beyond nvapi_QueryInterface; every entry point
+// is looked up by a numeric id.
+const uint32_t QUERY_INITIALIZE = 0x0150e828;
+const uint32_t QUERY_UNLOAD = 0xd22bdd7e;
+const uint32_t QUERY_ENUM_PHYSICAL_GPUS = 0xe5ac921f;
+const uint32_t QUERY_GET_BUS_ID = 0x1be0b8e5;
+const uint32_t QUERY_THERMALS = 0x65fe3aad;
+const uint32_t QUERY_VOLTAGE = 0x465f9bcf;
+
+const int MAX_PHYSICAL_GPUS = 64;
+
+// Thermal values are fixed point with 8 fractional bits.
+const int FIXED_POINT_SCALE = 256;
+
+const int MICROVOLTS_PER_MILLIVOLT = 1000;
+const int MAX_PLAUSIBLE_MILLIVOLTS = 2000;
+
+} // namespace
+
+NvApiSensors::~NvApiSensors() {
+    if (library_) {
+        if (query_interface_) {
+            typedef int32_t (*unload_fn)(void);
+            unload_fn unload = (unload_fn)query_interface_(QUERY_UNLOAD);
+            if (unload)
+                unload();
+        }
+        dlclose(library_);
+    }
+}
+
+bool NvApiSensors::find_gpu(unsigned bus) {
+    typedef int32_t (*enum_fn)(void**, uint32_t*);
+    typedef int32_t (*bus_fn)(void*, uint32_t*);
+
+    enum_fn enum_gpus = (enum_fn)query_interface_(QUERY_ENUM_PHYSICAL_GPUS);
+    bus_fn get_bus = (bus_fn)query_interface_(QUERY_GET_BUS_ID);
+    if (!enum_gpus || !get_bus)
+        return false;
+
+    void* handles[MAX_PHYSICAL_GPUS];
+    memset(handles, 0, sizeof(handles));
+    uint32_t count = 0;
+
+    if (enum_gpus(handles, &count) != 0)
+        return false;
+
+    for (uint32_t i = 0; i < count && i < MAX_PHYSICAL_GPUS; i++) {
+        uint32_t id = 0;
+        if (get_bus(handles[i], &id) == 0 && id == bus) {
+            gpu_ = handles[i];
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool NvApiSensors::calculate_mask() {
+    // The sensor mask this GPU accepts is not reported anywhere, so widen it one
+    // bit at a time until the call is rejected and keep the last accepted value.
+    for (int bit = 0; bit < 32; bit++) {
+        Thermals probe;
+        memset(&probe, 0, sizeof(probe));
+        probe.version = (uint32_t)(sizeof(Thermals) | (2 << 16));
+        probe.mask = 1 << bit;
+
+        if (get_thermals_(gpu_, &probe) != 0) {
+            mask_ = (1 << bit) - 1;
+            return mask_ != 0;
+        }
+    }
+
+    return false;
+}
+
+bool NvApiSensors::init(const char* pci_bus_id) {
+    unsigned domain, bus, device, function;
+
+    if (!pci_bus_id ||
+        sscanf(pci_bus_id, "%x:%x:%x.%x", &domain, &bus, &device, &function) != 4) {
+        SPDLOG_DEBUG("NvAPI: could not parse PCI bus id");
+        return false;
+    }
+
+    library_ = dlopen(NVAPI_LIBRARY, RTLD_NOW);
+    if (!library_) {
+        SPDLOG_DEBUG("NvAPI: {} not available, extra sensors disabled", NVAPI_LIBRARY);
+        return false;
+    }
+
+    query_interface_ = (void* (*)(uint32_t))dlsym(library_, "nvapi_QueryInterface");
+    if (!query_interface_) {
+        SPDLOG_DEBUG("NvAPI: nvapi_QueryInterface missing");
+        return false;
+    }
+
+    typedef int32_t (*init_fn)(void);
+    init_fn initialize = (init_fn)query_interface_(QUERY_INITIALIZE);
+    if (!initialize || initialize() != 0) {
+        SPDLOG_DEBUG("NvAPI: initialization failed");
+        return false;
+    }
+
+    get_thermals_ = (int32_t (*)(void*, Thermals*))query_interface_(QUERY_THERMALS);
+    if (!get_thermals_) {
+        SPDLOG_DEBUG("NvAPI: thermals interface missing");
+        return false;
+    }
+
+    // Optional: absent voltage support must not disable the temperatures.
+    get_voltage_ = (int32_t (*)(void*, Voltage*))query_interface_(QUERY_VOLTAGE);
+
+    if (!find_gpu(bus)) {
+        SPDLOG_DEBUG("NvAPI: no GPU matching bus {:#x}", bus);
+        return false;
+    }
+
+    if (!calculate_mask()) {
+        SPDLOG_DEBUG("NvAPI: could not determine sensor mask");
+        return false;
+    }
+
+    available_ = true;
+    SPDLOG_DEBUG("NvAPI: sensors available (mask {:#x}, voltage {})",
+                 mask_, get_voltage_ ? "yes" : "no");
+    return true;
+}
+
+int NvApiSensors::read_sensor(int index) {
+    if (!available_)
+        return -1;
+
+    Thermals thermals;
+    memset(&thermals, 0, sizeof(thermals));
+    thermals.version = (uint32_t)(sizeof(Thermals) | (2 << 16));
+    thermals.mask = mask_;
+
+    if (get_thermals_(gpu_, &thermals) != 0)
+        return -1;
+
+    int value = thermals.values[index] / FIXED_POINT_SCALE;
+
+    // An absent sensor reads back as zero; a plausible die never does.
+    if (value <= 0 || value >= 255)
+        return -1;
+
+    return value;
+}
+
+int NvApiSensors::hotspot() {
+    return read_sensor(HOTSPOT_INDEX);
+}
+
+int NvApiSensors::vram() {
+    return read_sensor(VRAM_INDEX);
+}
+
+int NvApiSensors::voltage() {
+    if (!available_ || !get_voltage_)
+        return -1;
+
+    Voltage voltage;
+    memset(&voltage, 0, sizeof(voltage));
+    voltage.version = (uint32_t)(sizeof(Voltage) | (1 << 16));
+
+    if (get_voltage_(gpu_, &voltage) != 0)
+        return -1;
+
+    int millivolts = (int)(voltage.rails[0].current_voltage_uv / MICROVOLTS_PER_MILLIVOLT);
+
+    if (millivolts <= 0 || millivolts >= MAX_PLAUSIBLE_MILLIVOLTS)
+        return -1;
+
+    return millivolts;
+}

--- a/src/nvapi_sensors.cpp
+++ b/src/nvapi_sensors.cpp
@@ -74,10 +74,11 @@ bool NvApiSensors::calculate_mask() {
         Thermals probe;
         memset(&probe, 0, sizeof(probe));
         probe.version = (uint32_t)(sizeof(Thermals) | (2 << 16));
-        probe.mask = 1 << bit;
+        const uint32_t probe_mask = 1u << bit;
+        probe.mask = (int32_t)probe_mask;
 
         if (get_thermals_(gpu_, &probe) != 0) {
-            mask_ = (1 << bit) - 1;
+            mask_ = (int32_t)(probe_mask - 1u);
             return mask_ != 0;
         }
     }

--- a/src/nvapi_sensors.h
+++ b/src/nvapi_sensors.h
@@ -1,0 +1,64 @@
+#pragma once
+#include <cstdint>
+
+// Reads sensors that NVML does not expose on GeForce cards by going through
+// NVIDIA's own NVAPI library (libnvidia-api.so.1). No elevated privileges and
+// no direct BAR0 access are needed: the driver performs the read for us.
+//
+// Blackwell reports the hotspot through a different path and is deliberately not
+// handled - hotspot() simply reports nothing there rather than a wrong number.
+class NvApiSensors {
+    public:
+        ~NvApiSensors();
+
+        // pci_bus_id is the usual "0000:01:00.0" form.
+        bool init(const char* pci_bus_id);
+        bool available() const { return available_; }
+
+        // Rounded degrees celsius, or -1 when unavailable.
+        int hotspot();
+        int vram();
+
+        // Millivolts, or -1 when unavailable.
+        int voltage();
+
+    private:
+        struct Thermals {
+            uint32_t version;
+            int32_t mask;
+            int32_t values[40];
+        };
+
+        struct VoltageRail {
+            uint32_t rail_id;
+            uint32_t current_voltage_uv;
+            uint8_t reserved[32];
+        };
+
+        struct Voltage {
+            uint32_t version;
+            uint8_t reserved[32];
+            VoltageRail rails[1];
+        };
+
+        static const int HOTSPOT_INDEX = 9;
+
+        // Verified on GA107 (Ampere, GDDR6) by comparing a shader-bound load with
+        // a memory-bound one at matched core temperature: every die sensor stayed
+        // within 0.16 C of the core across both, while this one rose 1.24 C once
+        // the memory bus was saturated. It also reports whole degrees only, unlike
+        // the 1/256 C die taps. Other parts may well place memory elsewhere.
+        static const int VRAM_INDEX = 16;
+
+        void* library_ = nullptr;
+        void* (*query_interface_)(uint32_t) = nullptr;
+        int32_t (*get_thermals_)(void*, Thermals*) = nullptr;
+        int32_t (*get_voltage_)(void*, Voltage*) = nullptr;
+        void* gpu_ = nullptr;
+        int32_t mask_ = 0;
+        bool available_ = false;
+
+        bool find_gpu(unsigned bus);
+        bool calculate_mask();
+        int read_sensor(int index);
+};

--- a/src/nvapi_sensors.h
+++ b/src/nvapi_sensors.h
@@ -15,7 +15,7 @@ class NvApiSensors {
         bool init(const char* pci_bus_id);
         bool available() const { return available_; }
 
-        // Rounded degrees celsius, or -1 when unavailable.
+        // Integer degrees celsius, truncated, or -1 when unavailable.
         int hotspot();
         int vram();
 

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -46,6 +46,16 @@ NVIDIA::NVIDIA(const char* pciBusId) {
     }
 #endif
 
+    // NVML has no hotspot sensor on GeForce; NVAPI does.
+    if (nvapi.init(pciBusId)) {
+        // Seed before the sampling thread starts. Whether the sensor exists is
+        // known now, so the first frame can already show it - otherwise the row
+        // only appears one update later and shifts the layout under it.
+        metrics.junction_temp = nvapi.hotspot();
+        metrics.memory_temp = nvapi.vram();
+        metrics.voltage = nvapi.voltage();
+    }
+
 #if defined(HAVE_XNVCTRL) && defined(HAVE_X11)
     if (!get_libx11()->IsLoaded())
         SPDLOG_DEBUG("XNVCtrl: X11 not loaded");
@@ -97,6 +107,15 @@ void NVIDIA::get_instant_metrics_nvml(struct gpu_metrics *metrics, struct overla
             nvml->nvmlDeviceGetTemperature(device, NVML_TEMPERATURE_GPU, &temp);
             metrics->temp = temp;
         }
+
+        if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_junction_temp] || (logger && logger->is_active()))
+            metrics->junction_temp = nvapi.hotspot();
+
+        if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_mem_temp] || (logger && logger->is_active()))
+            metrics->memory_temp = nvapi.vram();
+
+        if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_voltage] || (logger && logger->is_active()))
+            metrics->voltage = nvapi.voltage();
 
         if (params->enabled[OVERLAY_PARAM_ENABLED_vram] || (logger && logger->is_active())) {
             struct nvmlMemory_st nvml_memory;
@@ -257,6 +276,9 @@ void NVIDIA::get_samples_and_copy() {
         GPU_UPDATE_METRIC_AVERAGE(MemClock);
 
         GPU_UPDATE_METRIC_AVERAGE(temp);
+        GPU_UPDATE_METRIC_AVERAGE(junction_temp);
+        GPU_UPDATE_METRIC_AVERAGE(memory_temp);
+        GPU_UPDATE_METRIC_AVERAGE(voltage);
 
         GPU_UPDATE_METRIC_AVERAGE_FLOAT(memoryTotal);
         GPU_UPDATE_METRIC_AVERAGE_FLOAT(sys_vram_used);

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -85,6 +85,23 @@ NVIDIA::NVIDIA(const char* pciBusId) {
 }
 
 #ifdef HAVE_NVML
+// NVAPI is independent of NVML, so this is sampled on its own rather than from
+// inside the NVML path: with only XNVCtrl available the values would otherwise
+// never be refreshed after the constructor seeded them.
+void NVIDIA::get_instant_metrics_nvapi(struct gpu_metrics *metrics, struct overlay_params *params) {
+    if (!nvapi.available())
+        return;
+
+    if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_junction_temp] || (logger && logger->is_active()))
+        metrics->junction_temp = nvapi.hotspot();
+
+    if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_mem_temp] || (logger && logger->is_active()))
+        metrics->memory_temp = nvapi.vram();
+
+    if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_voltage] || (logger && logger->is_active()))
+        metrics->voltage = nvapi.voltage();
+}
+
 void NVIDIA::get_instant_metrics_nvml(struct gpu_metrics *metrics, struct overlay_params *params) {
     nvmlReturn_t response;
 
@@ -107,15 +124,6 @@ void NVIDIA::get_instant_metrics_nvml(struct gpu_metrics *metrics, struct overla
             nvml->nvmlDeviceGetTemperature(device, NVML_TEMPERATURE_GPU, &temp);
             metrics->temp = temp;
         }
-
-        if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_junction_temp] || (logger && logger->is_active()))
-            metrics->junction_temp = nvapi.hotspot();
-
-        if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_mem_temp] || (logger && logger->is_active()))
-            metrics->memory_temp = nvapi.vram();
-
-        if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_voltage] || (logger && logger->is_active()))
-            metrics->voltage = nvapi.voltage();
 
         if (params->enabled[OVERLAY_PARAM_ENABLED_vram] || (logger && logger->is_active())) {
             struct nvmlMemory_st nvml_memory;
@@ -254,6 +262,7 @@ void NVIDIA::get_samples_and_copy() {
 #endif
 
         for (size_t cur_sample_id=0; cur_sample_id < METRICS_SAMPLE_COUNT; cur_sample_id++) {
+            NVIDIA::get_instant_metrics_nvapi(&metrics_buffer[cur_sample_id], params_p);
 #ifdef HAVE_NVML
         if (nvml_available)
             NVIDIA::get_instant_metrics_nvml(&metrics_buffer[cur_sample_id], params_p);

--- a/src/nvidia.h
+++ b/src/nvidia.h
@@ -85,6 +85,7 @@ class NVIDIA {
 
     private:
         NvApiSensors nvapi;
+        void get_instant_metrics_nvapi(struct gpu_metrics *metrics, struct overlay_params *params);
 
         pid_t pid = getpid();
         std::mutex metrics_mutex;

--- a/src/nvidia.h
+++ b/src/nvidia.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "gpu.h"
+#include "nvapi_sensors.h"
 #ifdef HAVE_NVML
 #include "loaders/loader_nvml.h"
 #endif
@@ -83,6 +84,8 @@ class NVIDIA {
         }
 
     private:
+        NvApiSensors nvapi;
+
         pid_t pid = getpid();
         std::mutex metrics_mutex;
         gpu_metrics metrics;

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -591,6 +591,7 @@ parse_ftrace(const char *str) {
 #define parse_io_read(s) parse_unsigned(s)
 #define parse_io_write(s) parse_unsigned(s)
 #define parse_pci_dev(s) parse_str(s)
+#define parse_gpu_voltage_pci_dev(s) parse_str(s)
 #define parse_media_player_name(s) parse_str(s)
 #define parse_font_scale_media_player(s) parse_float(s)
 #define parse_cpu_text(s) parse_str(s)
@@ -1199,6 +1200,9 @@ parse_overlay_config(struct overlay_params *params,
 
    if (!params->pci_dev.empty())
       params->pci_dev = verify_pci_dev(params->pci_dev);
+
+   if (!params->gpu_voltage_pci_dev.empty())
+      params->gpu_voltage_pci_dev = verify_pci_dev(params->gpu_voltage_pci_dev);
 
    if (!params->vulkan_present_mode.empty()) {
       VkPresentModeKHR present_mode;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -191,6 +191,7 @@ struct Tracepoint;
    OVERLAY_PARAM_CUSTOM(alpha)                       \
    OVERLAY_PARAM_CUSTOM(log_duration)                \
    OVERLAY_PARAM_CUSTOM(pci_dev)                     \
+   OVERLAY_PARAM_CUSTOM(gpu_voltage_pci_dev)         \
    OVERLAY_PARAM_CUSTOM(media_player_name)           \
    OVERLAY_PARAM_CUSTOM(media_player_color)          \
    OVERLAY_PARAM_CUSTOM(media_player_format)         \
@@ -338,6 +339,7 @@ struct overlay_params {
    std::vector<KeySym> reset_fps_metrics;
    std::string time_format, output_folder, output_file;
    std::string pci_dev;
+   std::string gpu_voltage_pci_dev;
    std::string media_player_name;
    std::string cpu_text, fps_text;
    std::map<std::string, std::string> cpu_custom_temp_sensor;


### PR DESCRIPTION
`gpu_junction_temp` and `gpu_mem_temp` have always read 0 on GeForce cards and `gpu_voltage` was never populated for NVIDIA at all, because the backend reads temperatures through NVML and NVML exposes a single sensor there. The sensors exist; NVIDIA's own `libnvidia-api.so.1` returns them. This reads them from there.

Closes the NVIDIA half of #760 and #1159.

## Tested on

| GPU | Architecture | Driver | hotspot | VRAM | voltage |
|---|---|---|---|---|---|
| RTX 3050 Laptop (GA107) | Ampere | 595.71.05 | yes | yes | yes |

Linux 6.18, KDE Wayland, hybrid laptop alongside a Radeon 680M.

The hotspot reading was also confirmed working on a GTX 1060 by another user. I have no details of that system, so I am reporting it only as a second data point on much older hardware, not as something I measured.

## Why NVML cannot do it

Probed directly on the 3050:

```
nvmlDeviceGetTemperature(dev, sensorType=0)    ->  OK, 38 C   (core)
nvmlDeviceGetTemperature(dev, sensorType=1..3) ->  error
nvmlDeviceGetThermalSettings(dev, 0..3)        ->  one sensor: GPU_INTERNAL, target=GPU
nvmlDeviceGetFieldValues(dev, fields 150..240) ->  nothing thermal beyond the core
```

Nothing else on the system reads them either: `nvidia-smi` reports only the core, and `nvtop` exposes a single `temp` field, both for the same reason.

## Implementation

`src/nvapi_sensors.{h,cpp}` dlopens the library, resolves entry points by id through `nvapi_QueryInterface`, matches the GPU by PCI bus, and reads thermal sensor 9 (hotspot) and 16 (VRAM) as fixed point with 8 fractional bits, plus voltage rail 0 in microvolts. No elevated privileges, no BAR0 mapping - the driver performs the reads. If the library is missing the module disables itself and nothing else changes. Blackwell reads its hotspot through a different interface, so it is left to report nothing there rather than a wrong number.

Two things in the wiring are load-bearing. Values are seeded in the constructor before the sampling thread starts, or the rows appear one period late and shift the layout. And `get_samples_and_copy()` reduces metrics by an explicit list of fields, which did not include these three - without adding them the sampled values never reach the HUD at all.

## New option

`gpu_voltage_pci_dev=0000:01:00.0` restricts the voltage readout to one card. Every GPU reports a voltage, an APU's SoC rail included, and on a hybrid system the second is noise. Unset keeps current behaviour. Uses the same `verify_pci_dev()` normalisation as `pci_dev`. The example config line claiming `gpu_voltage` is AMD-only is removed, since it stops being true here.

## Verification

**Hotspot** was cross-checked against a BAR0 MMIO reader built from the register offsets `gddr6-core-junction-vram-temps` uses, sampled alongside NVAPI:

```
NVAPI 49.78   MMIO 49   core (NVML) 43
NVAPI 49.69   MMIO 49   core (NVML) 43
NVAPI 49.66   MMIO 49   core (NVML) 43
```

Two independent paths agree, both differ from the core, and the MMIO value being the truncated integer part also confirms the fixed-point encoding. Under load the junction sits 12-14 C above the core and tracks it.

**VRAM** took more work. The thermals call returns 40 unlabelled slots, nine non-zero here, so the memory sensor has to be identified rather than assumed - LACT maps slot 15, which turns out to track the die on this part. Comparing a shader-bound load against a memory-bound one at matched core temperature (70-74 C):

```
sensor 8    +0.16 C        sensor 14   +0.15 C
sensor 9    -0.07 C        sensor 15   -0.07 C
sensor 13   +0.15 C        sensor 16   +1.24 C
```

Every die sensor is locked to the core whatever the GPU is doing. Only 16 has an independent heat source, and it reports whole degrees where the die sensors report 1/256 C.

**Voltage**: 631 mV idle, 1081 mV loaded.