### PR TITLE
next: do not poll metrics after exceeding gpu_metrics_sample_count

### DIFF
--- a/mangohud-next/server/metrics/gpu/gpu.cpp
+++ b/mangohud-next/server/metrics/gpu/gpu.cpp
@@ -29,6 +29,9 @@ void GPU::poll() {
             if (stop_thread)
                 break;
 
+            if (samples >= gpu_metrics_sample_count)
+                continue;
+
             auto current_time = std::chrono::steady_clock::now();
             delta_time_ns = current_time - previous_time;
             previous_time = current_time;
@@ -84,9 +87,6 @@ void GPU::poll() {
             }
 
             samples++;
-
-            if (samples >= gpu_metrics_sample_count)
-                continue;
 
             auto elapsed = std::chrono::steady_clock::now() - current_time;
             if (elapsed < gpu_metrics_polling_period)


### PR DESCRIPTION
After polling 20 times in a row, while loop continued to poll gpu stats without sleep, which lead to Intel Arc gpus showing -inf or nan values for power usage, because of delta being divided by 0 ms in Intel_i915::get_power_usage() line 48