### PR TITLE
Fix race between GPU and params teardown

### DIFF
--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -201,5 +201,3 @@ std::string GPU::vram_text() {
 std::shared_ptr<const overlay_params> GPUS::params() {
     return get_params();
 }
-
-std::unique_ptr<GPUS> gpus = nullptr;

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -50,6 +50,7 @@ std::mutex config_mtx;
 std::condition_variable config_cv;
 bool config_ready = false;
 static std::atomic<std::shared_ptr<overlay_params>> g_params;
+std::unique_ptr<GPUS> gpus = nullptr;
 std::shared_ptr<fpsLimiter> fps_limiter;
 
 #if __cplusplus >= 201703L


### PR DESCRIPTION
With LTO enabled, MangoHud reproducibly crashes during shutdown in `AMDGPU::metrics_polling_thread()` while releasing the `overlay_params` shared pointer. Without LTO, the issue does not reproduce.
I initially noticed it as repeated coredumps attributed to the wine-preloader, which made the actual MangoHud failure difficult to identify.
`g_params` and `gpus` were defined in separate translation units, leaving their destruction order unspecified.
Defining `gpus` after `g_params` in the same translation unit ensures GPU polling threads are stopped and joined before the parameters are destroyed.

That's what I had in coredumpctl list for the reference,
```
Mon 2026-08-31 17:21:29 CEST 1637950 1000 1000 SIGSEGV present  /home/me/.local/share/Steam/compatibilitytools.d/GE-Proton11-6-x86_64/files/lib/wine/x86_64-unix/wine-preloader                      21.5M
Mon 2026-08-31 17:26:09 CEST 1671953 1000 1000 SIGSEGV present  /home/me/.local/share/Steam/compatibilitytools.d/GE-Proton11-6-x86_64/files/lib/wine/x86_64-unix/wine-preloader                      21.5M
Mon 2026-08-31 17:35:34 CEST 1732651 1000 1000 SIGSEGV present  /home/me/.local/share/Steam/compatibilitytools.d/GE-Proton11-6-x86_64/files/lib/wine/x86_64-unix/wine-preloader                      21.5M
Mon 2026-08-31 17:40:42 CEST 1761004 1000 1000 SIGSEGV present  /home/me/.local/share/Steam/compatibilitytools.d/GE-Proton11-6-x86_64/files/lib/wine/x86_64-unix/wine-preloader                      21.5M
Mon 2026-08-31 17:42:07 CEST 1767771 1000 1000 SIGSEGV present  /home/me/.local/share/Steam/compatibilitytools.d/GE-Proton11-6-x86_64/files/lib/wine/x86_64-unix/wine-preloader                      21.5M
Mon 2026-08-31 17:42:44 CEST 1771741 1000 1000 SIGSEGV present  /home/me/.local/share/Steam/compatibilitytools.d/GE-Proton11-6-x86_64/files/lib/wine/x86_64-unix/wine-preloader                      21.5M
Mon 2026-08-31 19:03:29 CEST 2157012 1000 1000 SIGSEGV present  /home/me/.local/share/Steam/compatibilitytools.d/GE-Proton11-6-x86_64/files/lib/wine/x86_64-unix/wine-preloader                      21.5M
```