### PR TITLE
amdgpu: fall back to hwmon when gpu_metrics v1 is too old

### DIFF
--- a/src/amdgpu.cpp
+++ b/src/amdgpu.cpp
@@ -519,13 +519,31 @@ AMDGPU::AMDGPU(std::string pci_dev, uint32_t device_id, uint32_t vendor_id, std:
 	this->vendor_id = vendor_id;
 	const std::string device_path = "/sys/bus/pci/devices/" + pci_dev;
 	gpu_metrics_path = device_path + "/gpu_metrics";
-    // Just check that the metrics file exists and is readable
+    // Check that the metrics file exists, is readable, and uses a version we support.
+    // Some GPUs (e.g. older Vega/Instinct) expose an old gpu_metrics_v1 that is
+    // smaller than gpu_metrics_v1_3. If unreadable/unsupported we fall back to
+    // the hwmon sysfs nodes (gpu_busy_percent + power1_input).
     FILE *f = fopen(gpu_metrics_path.c_str(), "rb");
+    gpu_metrics_is_valid = false;
     if (f) {
-        gpu_metrics_is_valid = true;
+        metrics_table_header mhdr {};
+        size_t nread = fread(&mhdr, 1, sizeof(mhdr), f);
+        if (nread == sizeof(mhdr)) {
+            if (mhdr.format_revision == 1) {
+                gpu_metrics_is_valid = mhdr.structure_size >= sizeof(gpu_metrics_v1_3);
+                if (!gpu_metrics_is_valid)
+                    SPDLOG_DEBUG("amdgpu gpu_metrics v1 too small (have {}, need {}) for '{}'; using hwmon fallback",
+                                 mhdr.structure_size, sizeof(gpu_metrics_v1_3), gpu_metrics_path);
+            } else if (mhdr.format_revision == 2) {
+                gpu_metrics_is_valid = mhdr.structure_size >= sizeof(gpu_metrics_v2_1);
+            } else if (mhdr.format_revision == 3) {
+                gpu_metrics_is_valid = mhdr.structure_size >= sizeof(gpu_metrics_v3_0);
+            } else {
+                gpu_metrics_is_valid = false;
+            }
+        }
         fclose(f);
     } else {
-        gpu_metrics_is_valid = false;
         SPDLOG_DEBUG("Failed to open gpu_metrics at '{}'", gpu_metrics_path);
     }
 


### PR DESCRIPTION
## Problem

On some AMD GPUs - notably older **Vega 20 / datacenter (Instinct) cards** such as the Radeon Instinct MI50 / Radeon Pro VII (device id `0x66a1`) - MangoHud shows **GPU load at 0% and power at 0W** permanently.

## Root cause

These cards expose a `gpu_metrics` sysfs file in the **old v1 format** that is smaller than `gpu_metrics_v1_3` (the smallest version MangoHud knows how to parse). On this hardware:

- The constructor only checked that the `gpu_metrics` file *existed and was readable* to set `gpu_metrics_is_valid = true`.
- In `get_instant_metrics` (`src/amdgpu.cpp`), reading a v1 file that is too small returns early **without populating the fields**, leaving `gpu_load_percent` and `average_gfx_power_w` at 0.
- Because `gpu_metrics_is_valid` was still `true`, `metrics_polling_thread` then **overwrote** the correct hwmon values (`gpu_busy_percent` and `power1_input`) with those zeros.

## Fix

In the `AMDGPU` constructor, read the metrics **header** and validate `structure_size` against the largest version we can actually parse. If the version is not supported (e.g. old v1 smaller than v1_3), mark `gpu_metrics_is_valid = false` so MangoHud falls back to the working hwmon sysfs nodes (`gpu_busy_percent` for load and `power1_input` for power).

Verified on an Instinct MI50: GPU load and power now report real values instead of 0.

## Notes

- Only reads the first 4 bytes of the header (no behavior change for GPUs with a supported `gpu_metrics` version).
- Falls back gracefully - existing supported GPUs are unaffected.
