### PR TITLE
Search for batteries by checking directories under /sys/class/power_supply/

### DIFF
--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -7,19 +7,32 @@ using namespace std;
 
 void BatteryStats::numBattery() {
     int batteryCount = 0;
-    if (!fs::exists("/sys/class/power_supply/")) {
-         batteryCount = 0;
+    
+    if (fs::exists("/sys/class/power_supply/")) {
+    	fs::path path("/sys/class/power_supply/");
+    	for (auto& p : fs::directory_iterator(path)) {
+    	    if ( ( fs::exists(p.path().string() + "/charge_now") && fs::exists(p.path().string() + "/charge_full") ) || ( fs::exists(p.path().string() + "/energy_now") && fs::exists(p.path().string() + "/energy_full")) ) {
+    	    	//Test if path contains the stuff we use if it is a battery
+    	        battPath[batteryCount] = p.path();
+    	        
+    	        std::istringstream iss((std::stringstream{} << std::ifstream((p.path().string() + "/charge_now")).rdbuf()).str());
+    	        if (int a; iss >> a) {
+    	        	battType[batteryCount] = "/charge";
+    	        } else {
+    	        	std::istringstream iss2((std::stringstream{} << std::ifstream((p.path().string() + "/energy_now")).rdbuf()).str());
+    	        	if (int b; iss2 >> b) {
+    	        		battType[batteryCount] = "/energy";
+    	        	} else {
+    	        		battType[batteryCount] = "/none";
+    	        	}
+    	        }
+    	 
+    	        batteryCount += 1;
+    	    }
+    	}
+    	batt_count = batteryCount;
+    	batt_check = true;
     }
-    fs::path path("/sys/class/power_supply/");
-    for (auto& p : fs::directory_iterator(path)) {
-        string fileName = p.path().filename();
-        if (fileName.find("BAT") != std::string::npos) {
-            battPath[batteryCount] = p.path();
-            batteryCount += 1;
-        }
-    }
-    batt_count = batteryCount;
-    batt_check = true;
 }
 
 void BatteryStats::update() {
@@ -37,46 +50,27 @@ void BatteryStats::update() {
     }
 }
 
-float BatteryStats::getPercent()
-{
+float BatteryStats::getPercent() {
     float charge_n = 0;
     float charge_f = 0;
     for(int i = 0; i < batt_count; i++) {
         string syspath = battPath[i];
-        string charge_now = syspath + "/charge_now";
-        string charge_full = syspath + "/charge_full";
-        string energy_now = syspath + "/energy_now";
-        string energy_full = syspath + "/energy_full";
-        string capacity = syspath + "/capacity";
-
-        if (fs::exists(charge_now)) {
-            std::ifstream input(charge_now);
-            std::string line;
-            if(std::getline(input, line)) {
-                charge_n += (stof(line) / 1000000);
-            }
-            std::ifstream input2(charge_full);
-            if(std::getline(input2, line)) {
-                charge_f += (stof(line) / 1000000);
-            }
-        }
-
-        else if (fs::exists(energy_now)) {
-            std::ifstream input(energy_now);
-            std::string line;
-            if(std::getline(input, line)) {
-                charge_n += (stof(line) / 1000000);
-            }
-            std::ifstream input2(energy_full);
-            if(std::getline(input2, line)) {
-                charge_f += (stof(line) / 1000000);
-            }
-        }
-
-        else {
+        
+		if ((battType[i] == "/charge") | (battType[i] == "/energy")) {
+			std::ifstream input(syspath + battType[i] + "_now");
+		    std::string line;
+			if(std::getline(input, line)) {
+				charge_n += (stof(line) / 1000000);
+			}
+			
+			std::ifstream input2(syspath + battType[i] + "_full");
+			if(std::getline(input2, line)) {
+			    charge_f += (stof(line) / 1000000);
+			}
+		} else {
             // using /sys/class/power_supply/BAT*/capacity
             // No way to get an accurate reading just average the percents if mutiple batteries
-            std::ifstream input(capacity);
+            std::ifstream input(syspath + "/capacity");
             std::string line;
             if(std::getline(input, line)) {
                 charge_n += stof(line) / 100;
@@ -147,18 +141,22 @@ float BatteryStats::getPower() {
     return power_w;
 }
 
+
+//TODO: This shares similar issues with pre-rewrite getPercents and doesn't work OoB on A16 either.
 float BatteryStats::getTimeRemaining() {
     float current = 0.0f;
     float charge = 0.0f;
 
     for (int i = 0; i < batt_count; i++) {
         string syspath = battPath[i];
+ 
         string current_now = syspath + "/current_now";
         string charge_now = syspath + "/charge_now";
         string energy_now = syspath + "/energy_now";
         string voltage_now = syspath + "/voltage_now";
         string power_now = syspath + "/power_now";
-
+       
+        
         if (fs::exists(current_now)) {
             std::ifstream input(current_now);
             std::string line;
@@ -183,17 +181,19 @@ float BatteryStats::getTimeRemaining() {
                     power = stof(line);
                 }
             }
-
             if (voltage > 0.0f) {
                 // (µW / µV) = µA
                 current_now_vec.push_back(std::fabs(power) / voltage);
             }
         }
 
-        if (fs::exists(charge_now)) {
+    	std::istringstream iss((std::stringstream{} << std::ifstream(charge_now).rdbuf()).str());
+        if (int a; fs::exists(charge_now) && iss >> a) {
+   
             std::ifstream input(charge_now);
             std::string line;
             if (std::getline(input, line)) {
+            
                 charge += stof(line);
             }
         } else if (fs::exists(energy_now) && fs::exists(voltage_now)) {

--- a/src/battery.h
+++ b/src/battery.h
@@ -8,7 +8,8 @@ class BatteryStats{
         float getPower();
         float getPercent();
         float getTimeRemaining();
-        std::string battPath[2];
+        std::string battPath[2]; // I guess this is why it triggered a segfault earlier when working on this?
+        std::string battType[2];
         float current_watt = 0;
         float current_percent = 0;
         float remaining_time = 0;


### PR DESCRIPTION
Additionally, check if the sysfs attribute actually returns a number which there is maybe a better way of doing it, but it is necessary because on my system, the charge_now and charge_full attributes return "No data available", in which case just ends up returning battery %NaN. 

Do the same when checking the remaining battery life as well