### PR TITLE
hud: add temperature-only CPU and GPU options

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Parameters that are enabled by default have to be explicitly disabled. These (cu
 | `cpu_mhz`                          | Show the CPUs current MHz                                                             |
 | `cpu_power`<br>`gpu_power`         | Display CPU/GPU draw in watts                                                         |
 | `cpu_temp`<br>`gpu_temp`<br>`gpu_junction_temp`<br>`gpu_mem_temp`           | Display current CPU/GPU temperature                                                  |
+| `cpu_temp_only`<br>`gpu_temp_only` | Display only the current CPU/GPU temperature                                          |
 | `cpu_custom_temp_sensor`           | Use custom hwmon sensor for cpu temperature. e.g `cpu_custom_temp_sensor=cpuss0_2,temp3_input`.|
 | `cpu_text`<br>`gpu_text`           | Override CPU and GPU text. `gpu_text` is a list in case of multiple GPUs              |
 | `cpu_efficiency`                   | Display CPU efficiency in frames per joule                                            |

--- a/data/MangoHud.conf
+++ b/data/MangoHud.conf
@@ -91,6 +91,7 @@
 ## Note: gpu_mem_clock and gpu_mem_temp also need "vram" to be enabled
 gpu_stats
 # gpu_temp
+# gpu_temp_only
 # gpu_junction_temp
 # gpu_core_clock
 # gpu_mem_temp
@@ -112,6 +113,7 @@ gpu_stats
 ### Display the current CPU information
 cpu_stats
 # cpu_temp
+# cpu_temp_only
 # cpu_power
 # cpu_text=
 # cpu_mhz

--- a/src/hud_elements.cpp
+++ b/src/hud_elements.cpp
@@ -281,8 +281,23 @@ void HudElements::version(){
     }
 }
 
+static void display_temp(int temp){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit])
+        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", HUDElements.convert_to_fahrenheit(temp));
+    else
+        right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", temp);
+    ImGui::SameLine(0, 1.0f);
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact])
+        HUDElements.TextColored(HUDElements.colors.text, "°");
+    else if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit])
+        HUDElements.TextColored(HUDElements.colors.text, "°F");
+    else
+        HUDElements.TextColored(HUDElements.colors.text, "°C");
+}
+
 void HudElements::gpu_stats(){
-    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] && gpus){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] &&
+        !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp_only] && gpus){
         for (auto& gpu : gpus->selected_gpus()) {
             ImguiNextColumnFirstItem();
             HUDElements.TextColored(HUDElements.colors.gpu, "%s", gpu->gpu_text().c_str());
@@ -313,18 +328,7 @@ void HudElements::gpu_stats(){
 
             if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp]){
                 ImguiNextColumnOrNewRow();
-                if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit])
-                    right_aligned_text(text_color, HUDElements.ralign_width, "%i", HUDElements.convert_to_fahrenheit(gpu->metrics.temp));
-                else
-                    right_aligned_text(text_color, HUDElements.ralign_width, "%i", gpu->metrics.temp);
-                ImGui::SameLine(0, 1.0f);
-                if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact])
-                    HUDElements.TextColored(HUDElements.colors.text, "°");
-                else
-                    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit])
-                        HUDElements.TextColored(HUDElements.colors.text, "°F");
-                    else
-                        HUDElements.TextColored(HUDElements.colors.text, "°C");
+                display_temp(gpu->metrics.temp);
             }
 
             if (gpu->metrics.junction_temp > -1 && HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_junction_temp]) {
@@ -418,8 +422,24 @@ void HudElements::gpu_stats(){
     }
 }
 
+void HudElements::gpu_temp_only(){
+    if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp_only] && gpus){
+        for (auto& gpu : gpus->selected_gpus()) {
+            ImguiNextColumnFirstItem();
+            HUDElements.TextColored(HUDElements.colors.gpu, "%s", gpu->gpu_text().c_str());
+
+            ImguiNextColumnOrNewRow();
+            display_temp(gpu->metrics.temp);
+
+            if (!HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_horizontal])
+                ImGui::TableNextRow();
+        }
+    }
+}
+
 void HudElements::cpu_stats(){
-    if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats]){
+    if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] &&
+       !HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only]){
         ImguiNextColumnFirstItem();
         const char* cpu_text;
         if (HUDElements.params->cpu_text.empty())
@@ -453,18 +473,7 @@ void HudElements::cpu_stats(){
 
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp]){
             ImguiNextColumnOrNewRow();
-            if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit])
-                right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", HUDElements.convert_to_fahrenheit(cpuStats.GetCPUDataTotal().temp));
-            else
-                right_aligned_text(HUDElements.colors.text, HUDElements.ralign_width, "%i", cpuStats.GetCPUDataTotal().temp);
-            ImGui::SameLine(0, 1.0f);
-            if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_hud_compact])
-                HUDElements.TextColored(HUDElements.colors.text, "°");
-            else
-                if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_temp_fahrenheit])
-                    HUDElements.TextColored(HUDElements.colors.text, "°F");
-                else
-                    HUDElements.TextColored(HUDElements.colors.text, "°C");
+            display_temp(cpuStats.GetCPUDataTotal().temp);
         }
 
         if (HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_mhz]){
@@ -507,6 +516,21 @@ void HudElements::cpu_stats(){
             HUDElements.TextColored(HUDElements.colors.text, efficiency_unit);
             ImGui::PopFont();
         }
+    }
+}
+
+void HudElements::cpu_temp_only(){
+    if(HUDElements.params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only]){
+        ImguiNextColumnFirstItem();
+        const char* cpu_text;
+        if (HUDElements.params->cpu_text.empty())
+            cpu_text = "CPU";
+        else
+            cpu_text = HUDElements.params->cpu_text.c_str();
+
+        HUDElements.TextColored(HUDElements.colors.cpu, "%s", cpu_text);
+        ImguiNextColumnOrNewRow();
+        display_temp(cpuStats.GetCPUDataTotal().temp);
     }
 }
 
@@ -1953,12 +1977,18 @@ void HudElements::sort_elements(const std::pair<std::string, std::string>& optio
     const auto& param = option.first;
     const auto& value = option.second;
 
+    if ((param == "gpu_stats" && get_params()->enabled[OVERLAY_PARAM_ENABLED_gpu_temp_only]) ||
+        (param == "cpu_stats" && get_params()->enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only]))
+        return;
+
     // Initialize a map of display parameters and their corresponding functions.
     const std::map<std::string, Function> display_params = {
         {"version", {version}},
         {"time", {time}},
         {"gpu_stats", {gpu_stats}},
+        {"gpu_temp_only", {gpu_temp_only}},
         {"cpu_stats", {cpu_stats}},
+        {"cpu_temp_only", {cpu_temp_only}},
         {"core_load", {core_load}},
         {"io_read", {io_stats}},
         {"io_write", {io_stats}},
@@ -2046,10 +2076,16 @@ void HudElements::legacy_elements(const overlay_params* temp_params){
         ordered_functions.push_back({time, "time", value});
     if (temp_params->enabled[OVERLAY_PARAM_ENABLED_version])
         ordered_functions.push_back({version, "version", value});
-    if (temp_params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats])
+    if (temp_params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] &&
+        !temp_params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp_only])
         ordered_functions.push_back({gpu_stats, "gpu_stats", value});
-    if (temp_params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats])
+    if (temp_params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp_only])
+        ordered_functions.push_back({gpu_temp_only, "gpu_temp_only", value});
+    if (temp_params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] &&
+        !temp_params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only])
         ordered_functions.push_back({cpu_stats, "cpu_stats", value});
+    if (temp_params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only])
+        ordered_functions.push_back({cpu_temp_only, "cpu_temp_only", value});
     if (temp_params->enabled[OVERLAY_PARAM_ENABLED_core_load])
         ordered_functions.push_back({core_load, "core_load", value});
     if (temp_params->enabled[OVERLAY_PARAM_ENABLED_io_read] || temp_params->enabled[OVERLAY_PARAM_ENABLED_io_write])

--- a/src/hud_elements.h
+++ b/src/hud_elements.h
@@ -76,7 +76,9 @@ class HudElements{
         static void version();
         static void time();
         static void gpu_stats();
+        static void gpu_temp_only();
         static void cpu_stats();
+        static void cpu_temp_only();
         static void core_load();
         static void io_stats();
         static void vram();

--- a/src/nvidia.cpp
+++ b/src/nvidia.cpp
@@ -92,7 +92,7 @@ void NVIDIA::get_instant_metrics_nvml(struct gpu_metrics *metrics, struct overla
 
         metrics->load = nvml_utilization.gpu;
 
-        if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp] || (logger && logger->is_active())) {
+        if (params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp] || params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp_only] || (logger && logger->is_active())) {
             unsigned int temp;
             nvml->nvmlDeviceGetTemperature(device, NVML_TEMPERATURE_GPU, &temp);
             metrics->temp = temp;

--- a/src/overlay.cpp
+++ b/src/overlay.cpp
@@ -104,19 +104,19 @@ void update_hw_info(const struct overlay_params& params, uint32_t vendorID)
    auto real_params = get_params();
    if (real_params->enabled[OVERLAY_PARAM_ENABLED_fan])
       update_fan();
-   if (real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] || logger->is_active()) {
+   if (real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] || real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only] || logger->is_active()) {
       cpuStats.UpdateCPUData();
 
 #ifdef __linux__
       if (real_params->enabled[OVERLAY_PARAM_ENABLED_core_load] || real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_mhz] || logger->is_active())
          cpuStats.UpdateCoreMhz();
-      if (real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp] || logger->is_active() || real_params->enabled[OVERLAY_PARAM_ENABLED_graphs])
+      if (real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp] || real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only] || logger->is_active() || real_params->enabled[OVERLAY_PARAM_ENABLED_graphs])
          cpuStats.UpdateCpuTemp();
       if (real_params->enabled[OVERLAY_PARAM_ENABLED_cpu_power] || logger->is_active())
          cpuStats.UpdateCpuPower();
 #endif
    }
-   if (real_params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] || logger->is_active()) {
+   if (real_params->enabled[OVERLAY_PARAM_ENABLED_gpu_stats] || real_params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp_only] || logger->is_active()) {
       if (gpus)
          gpus->get_metrics();
    }
@@ -752,6 +752,8 @@ void init_cpu_stats(overlay_params& params)
                            && enabled[OVERLAY_PARAM_ENABLED_cpu_stats];
    enabled[OVERLAY_PARAM_ENABLED_cpu_temp] = cpuStats.GetCpuFile()
                            && enabled[OVERLAY_PARAM_ENABLED_cpu_temp];
+   enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only] = cpuStats.GetCpuFile()
+                           && enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only];
 #endif
 }
 

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -849,8 +849,10 @@ static void set_param_defaults(struct overlay_params *params){
    params->enabled[OVERLAY_PARAM_ENABLED_core_load] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_core_bars] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_cpu_temp_only] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_power] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp] = false;
+   params->enabled[OVERLAY_PARAM_ENABLED_gpu_temp_only] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_junction_temp] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_gpu_mem_temp] = false;
    params->enabled[OVERLAY_PARAM_ENABLED_cpu_stats] = true;

--- a/src/overlay_params.h
+++ b/src/overlay_params.h
@@ -43,9 +43,11 @@ struct Tracepoint;
    OVERLAY_PARAM_BOOL(core_bars)                     \
    OVERLAY_PARAM_BOOL(core_type)                     \
    OVERLAY_PARAM_BOOL(cpu_temp)                      \
+   OVERLAY_PARAM_BOOL(cpu_temp_only)                 \
    OVERLAY_PARAM_CUSTOM(cpu_custom_temp_sensor)      \
    OVERLAY_PARAM_BOOL(cpu_power)                     \
    OVERLAY_PARAM_BOOL(gpu_temp)                      \
+   OVERLAY_PARAM_BOOL(gpu_temp_only)                 \
    OVERLAY_PARAM_BOOL(gpu_junction_temp)             \
    OVERLAY_PARAM_BOOL(gpu_mem_temp)                  \
    OVERLAY_PARAM_BOOL(cpu_stats)                     \


### PR DESCRIPTION
## Summary

Add `cpu_temp_only` and `gpu_temp_only` configuration options.

This was submitted as an issue on jan 2026: https://github.com/flightlessmango/MangoHud/issues/1950

I added these in a backwards-compatible way (they are new options):

```ini
cpu_temp_only
gpu_temp_only
```

However, I think at some point it may make sense to look into having `gpu_temp` and `cpu_temp` be "temp only". The current implementation is confusing. I'd suggest something like `cpu_temp_full` to show the % load as well. Just a suggestion.

I've refactored the shared behavior into a helper.

These options display the corresponding CPU or GPU label and temperature
without displaying load percentage. Existing `cpu_temp`, `gpu_temp`,
`cpu_stats`, and `gpu_stats` behavior remains unchanged unless one of the
new options is enabled.

The new options support existing temperature presentation settings,
including Fahrenheit and compact mode. GPU temperature-only display also
supports the existing multi-GPU selection.
