### PR TITLE
data: add Russian translation to the metainfo file

### DIFF
--- a/data/io.github.flightlessmango.mangohud.metainfo.xml
+++ b/data/io.github.flightlessmango.mangohud.metainfo.xml
@@ -4,6 +4,7 @@
 
   <name>MangoHud</name>
   <summary>Vulkan/OpenGL overlay for monitoring FPS, temperatures, CPU/GPU load and more</summary>
+  <summary xml:lang="ru">Оверлей для Vulkan и OpenGL: FPS, температуры, загрузка CPU/GPU и не только</summary>
   <developer_name>FlightlessMango</developer_name>
   <icon type="stock">io.github.flightlessmango.mangohud</icon>
 
@@ -12,15 +13,18 @@
 
   <description>
     <p>A modification of the Mesa Vulkan overlay, including GUI improvements with HUD configuration, temperature reporting, and logging capabilities. Includes a script (mangohud) to start it on any OpenGL or Vulkan application.</p>
+    <p xml:lang="ru">MangoHud вырос из оверлея Mesa Vulkan: к нему добавились настройка состава HUD, показ температур и ведение журнала. В комплекте идёт скрипт mangohud — он включает оверлей в любом приложении OpenGL или Vulkan.</p>
   </description>
 
   <screenshots>
     <screenshot type="default">
       <caption>Example</caption>
+      <caption xml:lang="ru">Пример</caption>
       <image>https://raw.githubusercontent.com/flightlessmango/MangoHud/master/assets/overlay_example.gif</image>
     </screenshot>
     <screenshot>
       <caption>Log uploading walkthrough</caption>
+      <caption xml:lang="ru">Как выгрузить журнал</caption>
       <image>https://raw.githubusercontent.com/flightlessmango/MangoHud/master/assets/log_upload_example.gif</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
The metainfo file carries no translations at all, so GNOME Software, KDE
Discover and Flathub show MangoHud in English to everyone. This adds Russian
next to the English, in the same file — there is no translation machinery in
the tree and this one file does not need any.

Four strings: the summary, the description paragraph, and both screenshot
captions.

The description is written to read as Russian rather than word-for-word off the
English — a store page is the first thing a user sees. Everything with a name of
its own stays in Latin: Vulkan, OpenGL, FPS, CPU, GPU, HUD, Mesa, MangoHud, and
the `mangohud` script.

No English string is changed, nothing is added to the build, and no dependency
is involved — the file is still the same one `data/meson.build` installs and
tests.

Checked with `appstreamcli validate --no-net --pedantic`, which is the exact
command the meson test runs: it passes with the same two informational messages
as before my change (`developer-name-tag-deprecated`, `developer-info-missing`),
so nothing new appears. `xmllint --noout` is clean and the file is still UTF-8.
I also ran `appstreamcli convert` on it and read the DEP-11 output to be sure a
consumer actually picks the Russian up: all four strings land under `ru:` with
the English kept as `C:`.

Happy to keep it current as the text changes, if you would rather not carry a
translation that goes stale.
