### PR TITLE
gl: guard against null ctx on teardown

### DIFF
--- a/src/gl/gl_hud.cpp
+++ b/src/gl/gl_hud.cpp
@@ -104,7 +104,7 @@ void imgui_init()
 void imgui_create(gl_context *ctx, const gl_wsi plat)
 {
     //SPDLOG_DEBUG("ctx {}", (void *)ctx);
-    if (!ctx)
+    if (!ctx || !ctx->ctx)
         return;
 
     if (inited)

--- a/src/gl/inject_egl.cpp
+++ b/src/gl/inject_egl.cpp
@@ -89,9 +89,10 @@ static void* get_egl_proc_address(const char* name) {
 
 static gl_context *create_gl_context(void *ctx)
 {
-    gl_context *gl_ctx;
+    if (!ctx)
+        return nullptr;
 
-    gl_ctx = (gl_context *)calloc(1, sizeof(*gl_ctx));
+    gl_context *gl_ctx = (gl_context *)calloc(1, sizeof(*gl_ctx));
     gl_ctx->ctx = ctx;
     gl_contexts[ctx] = gl_ctx;
     //SPDLOG_DEBUG("created gl_context {} for GLX context {}", (void *)gl_ctx, ctx);
@@ -164,12 +165,16 @@ EXPORT_C_(unsigned int) eglSwapBuffers(void* dpy, void* surf)
 
         if (!gl_ctx)
             gl_ctx = create_gl_context(ctx);
-        imgui_create(gl_ctx, gl_wsi::GL_WSI_EGL);
 
-        int width=0, height=0;
-        if (pfn_eglQuerySurface(dpy, surf, EGL_HEIGHT, &height) &&
-            pfn_eglQuerySurface(dpy, surf, EGL_WIDTH, &width))
-            imgui_render(gl_ctx, width, height);
+        if (gl_ctx) {
+            imgui_create(gl_ctx, gl_wsi::GL_WSI_EGL);
+
+            int width=0, height=0;
+            if (pfn_eglQuerySurface(dpy, surf, EGL_HEIGHT, &height) &&
+                pfn_eglQuerySurface(dpy, surf, EGL_WIDTH, &width))
+                imgui_render(gl_ctx, width, height);
+        } else
+            spdlog::warn("eglSwapBuffers called without an OpenGL context");
 
         if (fps_limiter)
             fps_limiter->limit(true);

--- a/src/gl/inject_glx.cpp
+++ b/src/gl/inject_glx.cpp
@@ -70,9 +70,10 @@ bool glx_mesa_queryInteger(int attrib, unsigned int *value)
 
 static gl_context *create_gl_context(void *ctx)
 {
-    gl_context *gl_ctx;
+    if (!ctx)
+        return nullptr;
 
-    gl_ctx = (gl_context *)calloc(1, sizeof(*gl_ctx));
+    gl_context *gl_ctx = (gl_context *)calloc(1, sizeof(*gl_ctx));
     gl_ctx->ctx = ctx;
     gl_contexts[ctx] = gl_ctx;
     //SPDLOG_DEBUG("created gl_context {} for GLX context {}", (void *)gl_ctx, ctx);
@@ -148,6 +149,12 @@ static void do_imgui_swap(void *dpy, void *drawable)
         //SPDLOG_TRACE("ctx {}, gl_ctx {}", ctx, (void *)gl_ctx);
         if (!gl_ctx)
             gl_ctx = create_gl_context(ctx);
+
+        if (!gl_ctx) {
+            spdlog::warn("do_imgui_swap called without an OpenGL context");
+            return;
+        }
+
         imgui_create(gl_ctx, gl_wsi::GL_WSI_GLX);
 
         unsigned int width = -1, height = -1;


### PR DESCRIPTION
Avoid spurious SIGSEGV if `imgui_create()` is called during app shutdown.

---

Just witnessed it crash after closing closing `eglgears_wayland`. Below are logs and backtrace that lead to this PR.

```log
[2026-09-07 20:59:49.516] [MANGOHUD] [info] [cpu.cpp:636] hwmon: using input: /sys/class/hwmon/hwmon0/temp1_input
[2026-09-07 20:59:50.893] [MANGOHUD] [error] Failed to initialize OpenGL context, crash incoming
```

```log
Core was generated by `eglgears_wayland'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  __strlen_evex () at ../sysdeps/x86_64/multiarch/strlen-evex-base.S:81
81		VPCMPEQ	(%rdi), %VZERO, %k0
[Current thread is 1 (Thread 0x7f94d2ffdcc0 (LWP 2278040))]
(gdb) bt
#0  __strlen_evex () at ../sysdeps/x86_64/multiarch/strlen-evex-base.S:81
#1  0x00007f94c3639b5d in std::char_traits<char>::length (__s=0x0, __s=<optimized out>) at /usr/include/c++/16.1.1/bits/basic_string.h:1868
#2  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::assign (this=0x7f94c3947ac0 <_ZN8MangoHud2GLL10deviceNameE.lto_priv.0>, __s=0x0)
    at /usr/include/c++/16.1.1/bits/basic_string.h:1871
#3  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator= (this=0x7f94c3947ac0 <_ZN8MangoHud2GLL10deviceNameE.lto_priv.0>, __s=0x0)
    at /usr/include/c++/16.1.1/bits/basic_string.h:940
#4  MangoHud::GL::imgui_create (ctx=0x56279fa82e30, plat=MangoHud::GL::GL_WSI_EGL) at ../MangoHud-v0.8.4/src/gl/gl_hud.cpp:118
#5  0x00007f94c36434a7 in eglSwapBuffers (dpy=0x56279f70a100, surf=0x56279f9d4320) at ../MangoHud-v0.8.4/src/gl/inject_egl.cpp:167
#6  0x00007f94c001791e in pointer_button (wl_pointer=<optimized out>, data=<optimized out>, serial=130676, time=90912673, button=272, state=0) at ../libdecor-0.2.5/src/plugins/gtk/libdecor-gtk.c:2269
#7  pointer_button (data=<optimized out>, wl_pointer=<optimized out>, serial=130676, time=90912673, button=272, state=0) at ../libdecor-0.2.5/src/plugins/gtk/libdecor-gtk.c:2178
#8  0x00007f94d32cedb6 in ffi_call_unix64 () at ../src/x86/unix64.S:105
#9  0x00007f94d32caa6d in ffi_call_int (cif=<optimized out>, fn=<optimized out>, rvalue=<optimized out>, avalue=<optimized out>, closure=closure@entry=0x0) at ../src/x86/ffi64.c:772
#10 0x00007f94d32cde32 in ffi_call (cif=cif@entry=0x7ffe0fe11430, fn=<optimized out>, rvalue=rvalue@entry=0x0, avalue=<optimized out>, avalue@entry=0x7ffe0fe11500) at ../src/x86/ffi64.c:1165
#11 0x00007f94d36a37cd in wl_closure_invoke (closure=closure@entry=0x5627a08ac800, target=<optimized out>, target@entry=0x56279f86bd70, opcode=opcode@entry=3, data=<optimized out>, flags=1)
    at ../wayland-1.26.0/src/connection.c:1243
#12 0x00007f94d36a46b9 in dispatch_event (display=display@entry=0x56279f6ebb80, queue=queue@entry=0x56279f6ebc78) at ../wayland-1.26.0/src/wayland-client.c:1732
#13 0x00007f94d36a4aeb in dispatch_queue (display=0x56279f6ebb80, queue=0x56279f6ebc78) at ../wayland-1.26.0/src/wayland-client.c:1878
#14 wl_display_dispatch_queue_pending (display=display@entry=0x56279f6ebb80, queue=queue@entry=0x56279f6ebc78) at ../wayland-1.26.0/src/wayland-client.c:2243
#15 0x00007f94d36a86dc in wl_display_dispatch_queue_timeout (display=0x56279f6ebb80, queue=0x56279f6ebc78, timeout=timeout@entry=0x0) at ../wayland-1.26.0/src/wayland-client.c:2156
#16 0x00007f94d36a8740 in wl_display_dispatch_queue (display=<optimized out>, queue=<optimized out>) at ../wayland-1.26.0/src/wayland-client.c:2216
#17 0x00007f94d36a88b1 in wl_display_dispatch (display=<optimized out>) at ../wayland-1.26.0/src/wayland-client.c:2314
#18 0x000056278888a89a in _eglutNativeEventLoop () at ../mesa-demos-9.0.0/src/egl/eglut/eglut_wayland.c:538
#19 _eglutNativeEventLoop () at ../mesa-demos-9.0.0/src/egl/eglut/eglut_wayland.c:477
#20 eglutMainLoop () at ../mesa-demos-9.0.0/src/egl/eglut/eglut.c:267
#21 main (argc=<optimized out>, argv=<optimized out>) at ../mesa-demos-9.0.0/src/egl/opengl/eglgears.c:318
(gdb) f 4
Downloading 7.18 K source file /usr/src/debug/mangohud/build/../MangoHud-v0.8.4/src/gl/gl_hud.cpp
#4  MangoHud::GL::imgui_create (ctx=0x56279fa82e30, plat=MangoHud::GL::GL_WSI_EGL) at ../MangoHud-v0.8.4/src/gl/gl_hud.cpp:118                                                                                       
118	   deviceName = (char*)glGetString(GL_RENDERER);
(gdb) p ctx
$1 = (MangoHud::GL::gl_context *) 0x56279fa82e30
(gdb) p ctx->ctx
$2 = (void *) 0x0
(gdb) quit
```