### PR TITLE
build: pass `Wl,--undefined-version` to linker to fix linker errors  on clang

### DIFF
--- a/mangohud-next/client/meson.build
+++ b/mangohud-next/client/meson.build
@@ -41,6 +41,7 @@ vulkan_layer = shared_library(
     link_args: [
       '-static-libstdc++',
       '-Wl,--version-script,@0@'.format(join_paths(meson.current_source_dir(), 'mangohud.version')),
+      '-Wl,--undefined-version',
     ],
 )
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -171,6 +171,8 @@ endif
 link_args = cc.get_supported_link_arguments(['-Wl,-Bsymbolic-functions', '-Wl,-z,relro', '-Wl,--exclude-libs,ALL', '-lGL', '-static-libstdc++'])
 # meson fails to check version-script so just force add
 link_args += '-Wl,--version-script,@0@'.format(join_paths(meson.current_source_dir(), 'mangohud.version'))
+# lld errors on version-script symbols that are not defined in this library
+link_args += '-Wl,--undefined-version'
 
 mangohud_static_lib = static_library(
   'MangoHud',


### PR DESCRIPTION
curretly, using ldd and clang, compile failes with:

<details>

```

[4/6] Linking target mangohud-next/client/libMangoHud-next.so
FAILED: [code=1] mangohud-next/client/libMangoHud-next.so 
clang++  -o mangohud-next/client/libMangoHud-next.so mangohud-next/client/libMangoHud-next.so.p/meson-generated_.._.._wayland_linux-dmabuf-v1-protocol.c.o mangohud-next/client/libMangoHud-next.so.p/meson-generated_.._.._wayland_fractional-scale-v1-protocol.c.o mangohud-next/client/libMangoHud-next.so.p/meson-generated_.._.._wayland_viewporter-protocol.c.o mangohud-next/client/libMangoHud-next.so.p/meson-generated_.._.._wayland_presentation-time-protocol.c.o mangohud-next/client/libMangoHud-next.so.p/layer.cpp.o mangohud-next/client/libMangoHud-next.so.p/vulkan.cpp.o mangohud-next/client/libMangoHud-next.so.p/wayland.cpp.o mangohud-next/client/libMangoHud-next.so.p/gl.cpp.o mangohud-next/client/libMangoHud-next.so.p/gl_hooks.cpp.o mangohud-next/client/libMangoHud-next.so.p/real_dlsym.c.o mangohud-next/client/libMangoHud-next.so.p/elfhacks.c.o mangohud-next/client/libMangoHud-next.so.p/.._wayland_wayland_ctx.cpp.o -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -shared -fPIC -Wl,-soname,libMangoHud-next.so -fuse-ld=lld -flto=auto -Wl,--start-group subprojects/spdlog-1.14.1/src/libspdlog.a mangohud-next/ipc/libipc.a subprojects/imgui-1.91.6/libimgui.a subprojects/implot-0.16/libimplot.a subprojects/vk-bootstrap/libvk-bootstrap.a mangohud-next/utils/libutils.a -static-libstdc++ -Wl,--version-script,/home/solomoncyj/Downloads/Mangohud/mangohud-next/client/mangohud.version -lvulkan /usr/lib64/libxkbcommon.so /usr/lib64/libwayland-client.so -lm -pthread /usr/lib64/libsystemd.so /usr/lib64/libEGL.so /usr/lib64/libwayland-egl.so /usr/lib64/libGL.so -lvulkan -ldl -lvulkan -lvulkan -Wl,--end-group
ld.lld: error: version script assignment of 'global' to symbol 'overlay_GetInstanceProcAddr' failed: symbol not defined
ld.lld: error: version script assignment of 'global' to symbol 'overlay_GetDeviceProcAddr' failed: symbol not defined
ld.lld: error: version script assignment of 'global' to symbol 'mangohud_find_glx_ptr' failed: symbol not defined
ld.lld: error: version script assignment of 'global' to symbol 'mangohud_find_egl_ptr' failed: symbol not defined
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[5/6] Linking target src/libMangoHud.so
FAILED: [code=1] src/libMangoHud.so 
clang++  -o src/libMangoHud.so src/libMangoHud.a.p/vulkan.cpp.o src/libMangoHud.a.p/mesa_util_os_socket.c.o src/libMangoHud.a.p/mesa_util_os_time.c.o src/libMangoHud.a.p/hud_elements.cpp.o src/libMangoHud.a.p/overlay.cpp.o src/libMangoHud.a.p/overlay_params.cpp.o src/libMangoHud.a.p/font.cpp.o src/libMangoHud.a.p/keybinds.cpp.o src/libMangoHud.a.p/font_unispace.c.o src/libMangoHud.a.p/logging.cpp.o src/libMangoHud.a.p/config.cpp.o src/libMangoHud.a.p/gpu.cpp.o src/libMangoHud.a.p/blacklist.cpp.o src/libMangoHud.a.p/file_utils.cpp.o src/libMangoHud.a.p/nvidia.cpp.o src/libMangoHud.a.p/gpu_fdinfo.cpp.o src/libMangoHud.a.p/amdgpu.cpp.o src/libMangoHud.a.p/cpu.cpp.o src/libMangoHud.a.p/memory.cpp.o src/libMangoHud.a.p/iostats.cpp.o src/libMangoHud.a.p/notify.cpp.o src/libMangoHud.a.p/elfhacks.c.o src/libMangoHud.a.p/real_dlsym.c.o src/libMangoHud.a.p/pci_ids.cpp.o src/libMangoHud.a.p/battery.cpp.o src/libMangoHud.a.p/control.cpp.o src/libMangoHud.a.p/device.cpp.o src/libMangoHud.a.p/net.cpp.o src/libMangoHud.a.p/shell.cpp.o src/libMangoHud.a.p/ftrace.cpp.o src/libMangoHud.a.p/loaders_loader_nvml.cpp.o src/libMangoHud.a.p/loaders_loader_x11.cpp.o src/libMangoHud.a.p/shared_x11.cpp.o src/libMangoHud.a.p/wayland_keybinds.cpp.o src/libMangoHud.a.p/dbus.cpp.o src/libMangoHud.a.p/loaders_loader_dbus.cpp.o src/libMangoHud.a.p/meson-generated_.._.._vk_enum_to_str.c.o src/libMangoHud.a.p/meson-generated_.._.._vk_dispatch_table.c.o src/libMangoHud.a.p/meson-generated_.._.._vk_extensions.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -shared -fPIC -Wl,-soname,libMangoHud.so -fuse-ld=lld -flto=auto -Wl,--start-group src/libMangoHud.a mangohud-next/legacy_gpu_wrapper/libMangoHud_LegacyGPUWrapper.a subprojects/spdlog-1.14.1/src/libspdlog.a subprojects/imgui-1.91.6/libimgui.a subprojects/implot-0.16/libimplot.a -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,--exclude-libs,ALL -lGL -static-libstdc++ -Wl,--version-script,/home/solomoncyj/Downloads/Mangohud/src/mangohud.version /usr/lib64/libxkbcommon.so /usr/lib64/libwayland-client.so -lm -pthread /usr/lib64/libcap.so /usr/lib64/libdrm.so /usr/lib64/libGL.so -ldl -lvulkan -Wl,--end-group
ld.lld: error: version script assignment of 'global' to symbol 'dlsym' failed: symbol not defined
ld.lld: error: version script assignment of 'global' to symbol 'mangohud_find_glx_ptr' failed: symbol not defined
ld.lld: error: version script assignment of 'global' to symbol 'mangohud_find_egl_ptr' failed: symbol not defined
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[6/6] Linking target src/libMangoHud_opengl.so
FAILED: [code=1] src/libMangoHud_opengl.so 
clang++  -o src/libMangoHud_opengl.so src/libMangoHud_opengl.so.p/gl_glad.c.o src/libMangoHud_opengl.so.p/gl_gl_renderer.cpp.o src/libMangoHud_opengl.so.p/gl_gl_hud.cpp.o src/libMangoHud_opengl.so.p/gl_inject_egl.cpp.o src/libMangoHud_opengl.so.p/loaders_loader_glx.cpp.o src/libMangoHud_opengl.so.p/gl_inject_glx.cpp.o src/libMangoHud_opengl.so.p/hud_elements.cpp.o src/libMangoHud_opengl.so.p/overlay.cpp.o src/libMangoHud_opengl.so.p/overlay_params.cpp.o src/libMangoHud_opengl.so.p/font.cpp.o src/libMangoHud_opengl.so.p/keybinds.cpp.o src/libMangoHud_opengl.so.p/font_unispace.c.o src/libMangoHud_opengl.so.p/logging.cpp.o src/libMangoHud_opengl.so.p/config.cpp.o src/libMangoHud_opengl.so.p/gpu.cpp.o src/libMangoHud_opengl.so.p/blacklist.cpp.o src/libMangoHud_opengl.so.p/file_utils.cpp.o src/libMangoHud_opengl.so.p/nvidia.cpp.o src/libMangoHud_opengl.so.p/gpu_fdinfo.cpp.o src/libMangoHud_opengl.so.p/amdgpu.cpp.o src/libMangoHud_opengl.so.p/cpu.cpp.o src/libMangoHud_opengl.so.p/memory.cpp.o src/libMangoHud_opengl.so.p/iostats.cpp.o src/libMangoHud_opengl.so.p/notify.cpp.o src/libMangoHud_opengl.so.p/elfhacks.c.o src/libMangoHud_opengl.so.p/real_dlsym.c.o src/libMangoHud_opengl.so.p/pci_ids.cpp.o src/libMangoHud_opengl.so.p/battery.cpp.o src/libMangoHud_opengl.so.p/control.cpp.o src/libMangoHud_opengl.so.p/device.cpp.o src/libMangoHud_opengl.so.p/net.cpp.o src/libMangoHud_opengl.so.p/shell.cpp.o src/libMangoHud_opengl.so.p/ftrace.cpp.o src/libMangoHud_opengl.so.p/loaders_loader_nvml.cpp.o src/libMangoHud_opengl.so.p/loaders_loader_x11.cpp.o src/libMangoHud_opengl.so.p/shared_x11.cpp.o src/libMangoHud_opengl.so.p/wayland_keybinds.cpp.o src/libMangoHud_opengl.so.p/dbus.cpp.o src/libMangoHud_opengl.so.p/loaders_loader_dbus.cpp.o src/libMangoHud_opengl.so.p/mesa_util_os_socket.c.o src/libMangoHud_opengl.so.p/mesa_util_os_time.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -shared -fPIC -Wl,-soname,libMangoHud_opengl.so -fuse-ld=lld -flto=auto -Wl,--start-group src/libMangoHud.a mangohud-next/legacy_gpu_wrapper/libMangoHud_LegacyGPUWrapper.a subprojects/spdlog-1.14.1/src/libspdlog.a subprojects/imgui-1.91.6/libimgui.a subprojects/implot-0.16/libimplot.a -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,--exclude-libs,ALL -lGL -static-libstdc++ -Wl,--version-script,/home/solomoncyj/Downloads/Mangohud/src/mangohud.version /usr/lib64/libxkbcommon.so /usr/lib64/libwayland-client.so -lm -pthread /usr/lib64/libcap.so /usr/lib64/libdrm.so /usr/lib64/libGL.so -ldl -lvulkan -Wl,--end-group
ld.lld: error: version script assignment of 'global' to symbol 'dlsym' failed: symbol not defined
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.

```

</details>