### PR TITLE
control: keep the socket owner process-scoped

### DIFF
--- a/src/control.cpp
+++ b/src/control.cpp
@@ -3,12 +3,56 @@
 #include <cerrno>
 #include <cstring>
 #include <sys/socket.h>
+#include <mutex>
+#include <string>
 #include "mesa/util/os_socket.h"
 #include "overlay.h"
 #include "version.h"
 #include "app/mangoapp.h"
 
 int global_control_client;
+
+namespace {
+std::recursive_mutex control_mutex;
+int control_listener = -1;
+int control_client = -1;
+std::string control_path;
+
+struct control_lifetime {
+   ~control_lifetime() {
+      std::lock_guard<std::recursive_mutex> lock(control_mutex);
+      if (control_client >= 0)
+         os_socket_close(control_client);
+      if (control_listener >= 0)
+         os_socket_close(control_listener);
+   }
+};
+control_lifetime process_control_lifetime;
+}
+
+int control_socket_listen(const char *path)
+{
+   std::lock_guard<std::recursive_mutex> lock(control_mutex);
+   const std::string requested(path ? path : "");
+   if (requested.empty())
+      return -1;
+   if (control_listener >= 0 && control_path == requested)
+      return control_listener;
+   if (control_client >= 0) {
+      os_socket_close(control_client);
+      control_client = -1;
+   }
+   if (control_listener >= 0)
+      os_socket_close(control_listener);
+   control_listener = os_socket_listen_abstract(requested.c_str(), 1);
+   if (control_listener < 0) {
+      control_path.clear();
+      return -1;
+   }
+   os_socket_block(control_listener, false);
+   control_path = requested;
+   return control_listener;
+}
 
 using namespace std;
 static void parse_command(overlay_params &params,
@@ -152,13 +196,17 @@ static void control_send_connection_string(int control_client, const std::string
 
 void control_client_check(int control, int& control_client, const std::string& deviceName)
 {
+   std::lock_guard<std::recursive_mutex> lock(::control_mutex);
    /* Already connected, just return. */
-   if (control_client >= 0){
-      global_control_client = control_client;
+   if (::control_client >= 0){
+      control_client = ::control_client;
+      global_control_client = ::control_client;
       return;
    }
 
-   int socket = os_socket_accept(control);
+   if (::control_listener < 0)
+      return;
+   int socket = os_socket_accept(::control_listener);
    if (socket == -1) {
       if (errno != EAGAIN && errno != EWOULDBLOCK && errno != ECONNABORTED)
          fprintf(stderr, "ERROR on socket: %s\n", strerror(errno));
@@ -167,24 +215,31 @@ void control_client_check(int control, int& control_client, const std::string& d
 
    if (socket >= 0) {
       os_socket_block(socket, false);
-      control_client = socket;
-      control_send_connection_string(control_client, deviceName);
+      ::control_client = control_client = socket;
+      global_control_client = socket;
+      control_send_connection_string(socket, deviceName);
    }
 }
 
 static void control_client_disconnected(int& control_client)
 {
-   os_socket_close(control_client);
+   std::lock_guard<std::recursive_mutex> lock(::control_mutex);
+   if (control_client >= 0)
+      os_socket_close(control_client);
+   if (::control_client == control_client)
+      ::control_client = -1;
    control_client = -1;
 }
 
 void process_control_socket(int& control_client, overlay_params &params)
 {
-   if (control_client >= 0) {
+   std::lock_guard<std::recursive_mutex> lock(::control_mutex);
+   control_client = ::control_client;
+   if (::control_client >= 0) {
       char buf[BUFSIZE];
 
       while (true) {
-         ssize_t n = os_socket_recv(control_client, buf, BUFSIZE, 0);
+         ssize_t n = os_socket_recv(::control_client, buf, BUFSIZE, 0);
 
          if (n == -1) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) {

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -172,6 +172,7 @@ extern void control_client_check(int control, int& control_client, const std::st
 extern void process_control_socket(int& control_client, overlay_params &params);
 extern void control_send(int control_client, const char *cmd, unsigned cmdlen, const char *param, unsigned paramlen);
 extern int global_control_client;
+extern int control_socket_listen(const char *path);
 #ifdef HAVE_DBUS
 void render_mpris_metadata(const overlay_params& params, mutexed_metadata& meta, uint64_t frame_timing);
 #endif

--- a/src/overlay_params.cpp
+++ b/src/overlay_params.cpp
@@ -147,7 +147,7 @@ parse_control(const char *str)
       path.replace(npos, 2, std::to_string(getpid()));
    SPDLOG_DEBUG("Socket: {}", path);
 
-   int ret = os_socket_listen_abstract(path.c_str(), 1);
+   int ret = control_socket_listen(path.c_str());
    if (ret < 0) {
       SPDLOG_DEBUG("Couldn't create socket pipe at '{}'", path);
       SPDLOG_DEBUG("ERROR: '{}'", strerror(errno));

--- a/src/vulkan.cpp
+++ b/src/vulkan.cpp
@@ -285,8 +285,6 @@ static struct instance_data *new_instance_data(VkInstance instance)
 
 static void destroy_instance_data(struct instance_data *data)
 {
-   if (data->params.control >= 0)
-      os_socket_close(data->params.control);
    unmap_object(HKEY(data->instance));
    delete data;
 }


### PR DESCRIPTION
When an application creates or recreates Vulkan/API instances, MangoHud can leave
the control listener open while the presenting instance has `control == -1`.

The render loop then skips `accept()` and command processing even though the
process still owns the listening socket. Connections accumulate in the backlog
and `mangohudctl` does not receive its greeting. Destroying one instance can also
close a listener still needed by another instance.

This patch keeps the existing control protocol but moves listener/client ownership
to process scope.

Configuration parsing reuses the endpoint for the same path, instance teardown
no longer owns or closes the shared listener, and a process-lifetime owner closes
the descriptors once at exit. A path change safely replaces the old endpoint.
Accept/read/parser access is serialized.

The existing greeting, control commands and public control API signatures are
unchanged.

This addresses the generic lifetime issue for multi-instance Vulkan,
DXVK/vkd3d, OpenGL/Vulkan coexistence and configuration reinitialization without
depending on any particular game, compositor or overlay extension.

### Validation

- Applied and tested against MangoHud HEAD
  `1319124ac4f22fec75246f6ffbf3b912dc2a6865`
- Clean Meson/Ninja build succeeded
- ASan/UBSan build succeeded
- Existing project tests passed
- `git diff --check` passes